### PR TITLE
Feature/datetime format

### DIFF
--- a/src/Wordpress/MetaBox/Field.php
+++ b/src/Wordpress/MetaBox/Field.php
@@ -53,6 +53,11 @@ class Field
             $params['show_option_none'] = true;
         }
 
+        if($this->getType() == 'text_datetime_timestamp' OR 'text_time') {
+            $params['time_format'] = get_option('time_format');
+            $params['date_format'] = get_option('date_format');
+        }
+
         if(count($this->getOptions())) {
             foreach ($this->getOptions() as $key => $item) {
 


### PR DESCRIPTION
hi @markus-mw hab mal testweise die datumsformatierung für die cmb2 custom fields angepasst. Funktioniert soweit in der Darstellung im timeframe-Editor. Buchungskalender wird auch korrekt ausgegeben.
Das Datum (start-date / end-date) wir nun allerdings in der Datenbank entsprechend der eingestellten Formatierung gespeichert. 
Kann das irgendwo zum Problem werden?
Falls ja, erstmal ignorieren. Wenn soweit ok, könnten wir es evtl. direkt für MVP übernehmen.
Danke. 