### PR TITLE
added admin message class

### DIFF
--- a/src/Messages/AdminMessage.php
+++ b/src/Messages/AdminMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CommonsBooking\Messages;
+
+Class AdminMessage 
+{
+    
+    /**
+     * __construct
+     *
+     * @param  mixed $message message text
+     * @param  mixed $notice_type admin_notice type (can be: info, warning, success, error)
+     * @return void
+     */
+    public function __construct( $message, $notice_type = 'info') 
+    {
+        $this->message = $message;
+        $this->notice_type = $notice_type;
+
+        add_action( 'admin_notices', array ($this, 'render') );
+    }
+
+    
+    /**
+     * renders an admin message
+     *
+     * @return void
+     */
+    public function render() {
+
+        echo '<div class="notice notice-'. $this->notice_type . ' is-dismissible">';
+        echo '<p>';
+        echo $this->message;
+        echo '</p>';
+        echo '</div>';
+    }
+
+}

--- a/src/Wordpress/Options/AdminOptions.php
+++ b/src/Wordpress/Options/AdminOptions.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace CommonsBooking\Wordpress\Options;
+
+use CommonsBooking\Messages\AdminMessage;
 use CommonsBooking\Settings\Settings;
 
 /**
@@ -47,25 +49,10 @@ class AdminOptions
         }
 
         // maybe show admin notice if fields are restored to hreir default value
-        self::setDefaultsAdminNotice($restored_fields);
-    }
-    
-    /**
-     * Display admin notice if option fields are set to their default values
-     *
-     * @param  mixed $fields
-     * @return void
-     */
-    public static function setDefaultsAdminNotice($fields = false) {
-
-        if ($fields && is_array($fields)) {   
-
-            ?>
-                    <div class="notice notice-info is-dismissible">
-                        <p><?php echo commonsbooking_sanitizeHTML( __('<strong>Default values for following fields automatically set or restored, because they were empty:</strong><br> ', 'commonsbooking' ) ); 
-                        echo implode("<br> ", $fields); ?></p>
-                    </div>
-            <?php 
-        }   
+        if ($restored_fields) {
+            $message = commonsbooking_sanitizeHTML( __('<strong>Default values for following fields automatically set or restored, because they were empty:</strong><br> ', 'commonsbooking' ) ); 
+            $message .= implode("<br> ", $restored_fields);
+            new AdminMessage($message);
+        }
     }
 }


### PR DESCRIPTION
@markus-mw Hab eine AdminMessage-Klasse hinzugefügt, die das erzeugen von Admin-Notices vereinfacht.
Schau mal drauf und wenn das so passt, dann bitte mergen und gerne die Klasse generell für alle Admin-Notices verwenden. 

Merci.