### PR TITLE
Fix date conversion issue

### DIFF
--- a/commonsbooking.php
+++ b/commonsbooking.php
@@ -330,12 +330,6 @@ add_filter('cron_schedules', 'commonsbooking_cron_interval');
 // Removes all uncofirmed bookings older than 10 minutes
 function commonsbooking_cleanupBookings()
 {
-    // Get timezone from wordpress, to build right date query.
-    $wpTimezone = get_option('timezone_string');
-    if($wpTimezone) {
-        date_default_timezone_set ( $wpTimezone ) ;
-    }
-
     $args = array(
         'post_type'   => Timeframe::$postType,
         'post_status' => 'unconfirmed',

--- a/commonsbooking.php
+++ b/commonsbooking.php
@@ -336,7 +336,7 @@ function commonsbooking_cleanupBookings()
         'meta_key'    => 'type',
         'meta_value'  => Timeframe::BOOKING_ID,
         'date_query'  => array(
-            'before' => date('Y-m-d H:i:s', strtotime('-10 minutes')),
+            'before' => '-10 minutes',
         ),
         'nopaging'    => true,
     );


### PR DESCRIPTION
Let Wordpress interpet the strtotime()-compatible string which avoids time-zone related conversion issues. See also #532.