### PR TITLE
Feature/cb admin filter

### DIFF
--- a/includes/Users.php
+++ b/includes/Users.php
@@ -18,9 +18,10 @@ function commonsbooking_isCurrentUserAllowedToEdit($post): bool
     $current_user = wp_get_current_user();
     $isAuthor     = intval($current_user->ID) == intval($post->post_author);
     $isAdmin      = commonsbooking_isCurrentUserAdmin();
+    $isAllowed    = $isAdmin || $isAuthor;
 
     // Check if it is the main query and one of our custom post types
-    if ( ! $isAdmin && ! $isAuthor) {
+    if ( ! $isAllowed ) {
         $admins = [];
 
         // Get allowed admins for timeframe listing
@@ -67,11 +68,11 @@ function commonsbooking_isCurrentUserAllowedToEdit($post): bool
             $admins = get_post_meta($post->ID, '_'.$post->post_type.'_admins', true);
         }
 
-        return (is_string($admins) && $current_user->ID === $admins) ||
+        $isAllowed = (is_string($admins) && $current_user->ID === $admins) ||
             (is_array($admins) && in_array($current_user->ID.'', $admins, true));
     }
 
-    return true;
+    return $isAllowed;
 }
 
 /**
@@ -123,5 +124,5 @@ add_filter(
 // Check if current user has admin role
 function commonsbooking_isCurrentUserAdmin() {
     $user = wp_get_current_user();
-    return in_array('administrator', $user->roles);
+    return apply_filters('commonsbooking_isCurrentUserAdmin', in_array('administrator', $user->roles), $user);
 }

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -17,10 +17,7 @@ function commonsbooking_isCurrentUserAllowedToEdit($post): bool
 {
     $current_user = wp_get_current_user();
     $isAuthor     = intval($current_user->ID) == intval($post->post_author);
-    $isAdmin      = false;
-    if (in_array('administrator', (array)$current_user->roles)) {
-        $isAdmin = true;
-    }
+    $isAdmin      = commonsbooking_isCurrentUserAdmin();
 
     // Check if it is the main query and one of our custom post types
     if ( ! $isAdmin && ! $isAuthor) {
@@ -58,27 +55,20 @@ function commonsbooking_isCurrentUserAllowedToEdit($post): bool
             ) {
                 $admins = array_merge($locationAdminIds, $itemAdminIds);
             }
-        }
-
-        // Get allowed admins for Location / Item Listing
-        if (in_array(
+        } elseif (in_array(
             $post->post_type,
             [
                 Location::$postType,
                 Item::$postType,
             ]
-        )
-        ) {
+        )) {
+            // Get allowed admins for Location / Item Listing
             // post-related admins (returns string if single result and array if multiple results)
             $admins = get_post_meta($post->ID, '_'.$post->post_type.'_admins', true);
         }
 
-        if (
-            (is_string($admins) && $current_user->ID != $admins) ||
-            (is_array($admins) && ! in_array($current_user->ID.'', $admins, true))
-        ) {
-            return false;
-        }
+        return (is_string($admins) && $current_user->ID === $admins) ||
+            (is_array($admins) && in_array($current_user->ID.'', $admins, true));
     }
 
     return true;
@@ -112,12 +102,7 @@ add_filter(
         if (is_admin() && array_key_exists('post_type', $query->query)) {
             // Post type of current list
             $postType = $query->query['post_type'];
-
-            $current_user = wp_get_current_user();
-            $isAdmin      = false;
-            if (in_array('administrator', (array)$current_user->roles)) {
-                $isAdmin = true;
-            }
+            $isAdmin = commonsbooking_isCurrentUserAdmin();
 
             // Check if it is the main query and one of our custom post types
             if ( ! $isAdmin && $query->is_main_query() && in_array($postType, Plugin::getCustomPostTypesLabels())) {

--- a/src/Repository/BookablePost.php
+++ b/src/Repository/BookablePost.php
@@ -42,34 +42,33 @@ abstract class BookablePost extends PostRepository
                 $items = array_merge($items, $query->get_posts());
             }
 
-            // get all items where current user is assigned as admin
-            $args = array(
-                'post_type'  => static::getPostType(),
-                'meta_query' => array(
-                    'relation' => 'AND',
-                    array(
-                        'key' => '_'.static::getPostType().'_admins',
-                        'compare' => 'EXISTS',
-                    ),
-                    array(
-                        'key'     => '_'.static::getPostType().'_admins',
-                        'value'   => '"'.$current_user->ID.'"',
-                        'compare' => 'like',
-                    )
-                ),
-                'nopaging'   => true,
-                'orderby'    => 'post_title',
-                'order'      => 'asc',
-            );
-
-            // workaround: if user has admin-role get all available items
-            if (in_array('administrator', $current_user->roles)) {
-                unset($args);
+            if (commonsbooking_isCurrentUserAdmin()) {
+                // if user has admin-role get all available items
                 $args = array(
                     'post_type' => static::getPostType(),
                     'nopaging'  => true,
                     'orderby'   => 'post_title',
                     'order'     => 'asc',
+                );
+            } else {
+                // get all items where current user is assigned as admin
+                $args = array(
+                    'post_type'  => static::getPostType(),
+                    'meta_query' => array(
+                        'relation' => 'AND',
+                        array(
+                            'key' => '_'.static::getPostType().'_admins',
+                            'compare' => 'EXISTS',
+                        ),
+                        array(
+                            'key'     => '_'.static::getPostType().'_admins',
+                            'value'   => '"'.$current_user->ID.'"',
+                            'compare' => 'like',
+                        )
+                    ),
+                    'nopaging'   => true,
+                    'orderby'    => 'post_title',
+                    'order'      => 'asc',
                 );
             }
 

--- a/src/Wordpress/CustomPostType/Item.php
+++ b/src/Wordpress/CustomPostType/Item.php
@@ -44,14 +44,8 @@ class Item extends CustomPostType
             isset($_GET['post_type']) && self::$postType == $_GET['post_type'] &&
             $pagenow == 'edit.php'
         ) {
-            $current_user = wp_get_current_user();
-            $isAdmin      = false;
-            if (in_array('administrator', (array)$current_user->roles)) {
-                $isAdmin = true;
-            }
-
             // Check if current user is allowed to see posts
-            if ( ! $isAdmin) {
+            if ( ! commonsbooking_isCurrentUserAdmin() ) {
                 $items = \CommonsBooking\Repository\Item::getByCurrentUser();
                 array_walk(
                     $items,

--- a/src/Wordpress/CustomPostType/Location.php
+++ b/src/Wordpress/CustomPostType/Location.php
@@ -60,14 +60,8 @@ class Location extends CustomPostType
             isset($_GET['post_type']) && self::$postType == $_GET['post_type'] &&
             $pagenow == 'edit.php'
         ) {
-            $current_user = wp_get_current_user();
-            $isAdmin      = false;
-            if (in_array('administrator', (array)$current_user->roles)) {
-                $isAdmin = true;
-            }
-
             // Check if current user is allowed to see posts
-            if ( ! $isAdmin) {
+            if ( ! commonsbooking_isCurrentUserAdmin()) {
                 $locations = \CommonsBooking\Repository\Location::getByCurrentUser();
                 array_walk(
                     $locations,

--- a/src/Wordpress/CustomPostType/Timeframe.php
+++ b/src/Wordpress/CustomPostType/Timeframe.php
@@ -598,15 +598,8 @@ class Timeframe extends CustomPostType
                 }
             }
 
-            $current_user = wp_get_current_user();
-            $isAdmin      = false;
-            if (in_array('administrator', (array)$current_user->roles)) {
-                $isAdmin = true;
-            }
-
             // Check if current user is allowed to see posts
-            if ( ! $isAdmin) {
-
+            if ( ! commonsbooking_isCurrentUserAdmin() ) {
                 $locations = \CommonsBooking\Repository\Location::getByCurrentUser();
                 array_walk($locations, function(&$item, $key) {
                     $item = $item->ID;


### PR DESCRIPTION
Adds the Wordpress filter **commonsbooking_isCurrentUserAdmin**, which allows more precise control over who is considered an administrator by CommonsBooking. This allows users to have full control over CommonsBooking without having to be a Wordpress administrator themselves.

At the same time, this request unifies and simplifies the administrator check in relevant places.

Closes #599.