### PR TITLE
Add GBFS discovery and system information API

### DIFF
--- a/src/API/GBFS/Discovery.php
+++ b/src/API/GBFS/Discovery.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace CommonsBooking\API\GBFS;
+
+use Exception;
+use stdClass;
+use WP_REST_Response;
+
+class Discovery extends \CommonsBooking\API\BaseRoute {
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'gbfs.json';
+
+	/**
+	 * Commons-API schema definition.
+	 * @var string
+	 */
+	protected $schemaUrl = "https://raw.githubusercontent.com/MobilityData/gbfs-json-schema/master/gbfs.json";
+
+	public function get_items( $request ): WP_REST_Response {
+		$feeds = [];
+		$feeds[] = $this->get_feed('system_information');
+		$feeds[] = $this->get_feed('station_information');
+		$feeds[] = $this->get_feed('station_status');
+
+		$data                 = new stdClass();
+		$data->data           = new stdClass();
+		$data->data->feeds    = $feeds;
+		$data->last_updated   = time();
+		$data->ttl            = 86400;
+		$data->version        = "2.2";
+
+		if ( WP_DEBUG ) {
+			$this->validateData( $data );
+		}
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	private function get_feed( $name ): stdClass {
+		$feed = new stdClass();
+		$feed->name = $name;
+		$feed->url = site_url() . '/wp-json/commonsbooking/v1/' . $name . '.json';
+		return $feed;
+	}
+}

--- a/src/API/GBFS/SystemInformation.php
+++ b/src/API/GBFS/SystemInformation.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace CommonsBooking\API\GBFS;
+
+use Exception;
+use stdClass;
+use WP_REST_Response;
+
+class SystemInformation extends \CommonsBooking\API\BaseRoute {
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'system_information.json';
+
+	/**
+	 * Commons-API schema definition.
+	 * @var string
+	 */
+	protected $schemaUrl = "https://raw.githubusercontent.com/MobilityData/gbfs-json-schema/master/system_information.json";
+
+        public function get_items( $request ): WP_REST_Response {
+		$data                 = new stdClass();
+		$data->data           = new stdClass();
+		$data->data->name     = get_bloginfo('name');
+		$data->data->system_id = sha1(site_url());
+		$data->data->language = get_bloginfo('language');
+		$data->data->timezone = get_option('timezone_string');
+		$data->last_updated   = time();
+		$data->ttl            = 86400;
+		$data->version        = "2.2";
+
+		if ( WP_DEBUG ) {
+			$this->validateData( $data );
+		}
+
+		return new WP_REST_Response( $data, 200 );
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,8 +4,10 @@
 namespace CommonsBooking;
 
 use CommonsBooking\API\AvailabilityRoute;
+use CommonsBooking\API\GBFS\Discovery;
 use CommonsBooking\API\GBFS\StationInformation;
 use CommonsBooking\API\GBFS\StationStatus;
+use CommonsBooking\API\GBFS\SystemInformation;
 use CommonsBooking\API\ItemsRoute;
 use CommonsBooking\API\LocationsRoute;
 use CommonsBooking\API\ProjectsRoute;
@@ -605,8 +607,10 @@ class Plugin {
 						new LocationsRoute(),
 //                    new \CommonsBooking\API\OwnersRoute(),
 						new ProjectsRoute(),
+						new Discovery(),
 						new StationInformation(),
 						new StationStatus(),
+						new SystemInformation(),
 
 					];
 					foreach ( $routes as $route ) {


### PR DESCRIPTION
This completes the existing GBFS API to the bare minimum to be GBFS
compliant and thus consumable by GBFS clients.

See also issue #627.