### PR TITLE
Add filter hook for shortcode cb_bookings

### DIFF
--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -172,7 +172,7 @@ class Booking extends View {
 				// If search term was submitted, filter for it.
 				if ( ! $search || count( preg_grep( '/.*' . $search . '.*/i', $rowData ) ) > 0 ) {
 					$rowData['actions']         = $actions;
-					$bookingDataArray['data'][] = $rowData;
+					$bookingDataArray['data'][] = apply_filters('cb_booking_filter', $rowData, $booking);
 				}
 			}
 


### PR DESCRIPTION
Über den Filter kann man anpassen, welche Informationen für jede Buchung ausgegeben werden. Zum Beispiel könnte man dem [content-Objekt](https://github.com/wielebenwir/commonsbooking/blob/df32ec744b76a3473fec05de706c44e28a447c47/src/View/Booking.php#L127) weitere Item-Felder hinzufügen, die dann automatisch im Frontend mit ausgegeben werden.

Dies erscheint einfacher zu sein, als das Shortcode-Template im Theme zu überschreiben, da die Buchungen über JS ausgegeben werden.

Resolves #936 
