### PR TITLE
Feature/issue 1128

### DIFF
--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -26,7 +26,7 @@ class BookingMessage extends Message {
 
 		// get location email adresses to send them bcc copies
 		$location = get_post($booking->getMeta('location-id'));
-		$location_emails = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email', $location ) ; /*  email adresses, comma-seperated  */
+		$location_emails = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email', $location ) ; /*  email addresses, comma-seperated  */
 		$bcc_adresses = str_replace(' ','',$location_emails); 
 
 		// get templates from Admin Options

--- a/src/Messages/RestrictionMessage.php
+++ b/src/Messages/RestrictionMessage.php
@@ -2,9 +2,11 @@
 
 namespace CommonsBooking\Messages;
 
+use CommonsBooking\CB\CB;
 use CommonsBooking\Model\Booking;
 use CommonsBooking\Model\Restriction;
 use CommonsBooking\Settings\Settings;
+use CommonsBooking\Wordpress\CustomPostType\Item;
 
 class RestrictionMessage extends Message {
 
@@ -104,18 +106,23 @@ class RestrictionMessage extends Message {
 	 *
 	 * @param $body
 	 * @param $subject
+	 *
+	 * @throws \Exception
 	 */
 	protected function prepareRestrictionMail( $body, $subject ) {
 		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name' ) .
 		              ' <' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-email' ) . '>';
 		$restriction = $this->getRestriction();
 
+		$item_maintainer_email = CB::get( Item::$postType, COMMONSBOOKING_METABOX_PREFIX . 'item_maintainer_email', $this->booking->getItem() ) ; /*  email addresses, comma-seperated  */
+		$bcc_addresses = str_replace(' ','',$item_maintainer_email);
+
 		$this->prepareMail(
 			$this->getUser(),
 			$body,
 			$subject,
 			$fromHeader,
-			null,
+			$bcc_addresses,
 			[
 				'restriction' => $restriction,
 				'item'        => $this->booking->getItem(),

--- a/src/Messages/RestrictionMessage.php
+++ b/src/Messages/RestrictionMessage.php
@@ -18,6 +18,8 @@ class RestrictionMessage extends Message {
 
 	protected $booking;
 
+	protected bool $firstMessage;
+
 	protected $validActions = [
 		Restriction::TYPE_REPAIR,
 		Restriction::TYPE_HINT
@@ -29,11 +31,12 @@ class RestrictionMessage extends Message {
 	 * @param $booking Booking
 	 * @param $action
 	 */
-	public function __construct( $restriction, $user, Booking $booking, $action ) {
+	public function __construct( $restriction, $user, Booking $booking, $action, bool $firstMessage = false ) {
 		$this->restriction = $restriction;
 		$this->user        = $user;
 		$this->booking    = $booking;
 		$this->action      = $action;
+		$this->firstMessage = $firstMessage;
 	}
 
 	/**
@@ -114,8 +117,11 @@ class RestrictionMessage extends Message {
 		              ' <' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-email' ) . '>';
 		$restriction = $this->getRestriction();
 
-		$item_maintainer_email = CB::get( Item::$postType, COMMONSBOOKING_METABOX_PREFIX . 'item_maintainer_email', $this->booking->getItem() ) ; /*  email addresses, comma-seperated  */
-		$bcc_addresses = str_replace(' ','',$item_maintainer_email);
+		$bcc_addresses = "";
+		if ($this->firstMessage){ //Notify the maintainer about the damage by putting them in the BCC for the first notice. Avoids the maintainer getting flooded with restriction messages.
+			$item_maintainer_email = CB::get( Item::$postType, COMMONSBOOKING_METABOX_PREFIX . 'item_maintainer_email', $this->booking->getItem() ) ; /*  email addresses, comma-seperated  */
+			$bcc_addresses = str_replace(' ','',$item_maintainer_email);
+		}
 
 		$this->prepareMail(
 			$this->getUser(),

--- a/src/Model/Restriction.php
+++ b/src/Model/Restriction.php
@@ -289,13 +289,15 @@ class Restriction extends CustomPost {
 	 * @param Booking[] $bookings booking post objects.
 	 */
 	protected function sendRestrictionMails( $bookings ) {
-
-		foreach ( $bookings as $booking ) {
+		foreach ( $bookings as $key => $booking ) {
 			// get User ID from booking
 			$userId = $booking->getUserData()->ID;
 
+			//checks if this is the first booking that is processed
+			$firstMessage = ( $key === array_key_first( $bookings ) );
+
             // send restriction message for each booking 
-            $hintMail = new RestrictionMessage( $this, get_userdata( $userId ), $booking, $this->getType() );
+            $hintMail = new RestrictionMessage( $this, get_userdata( $userId ), $booking, $this->getType(),$firstMessage);
             $hintMail->triggerMail();
         }
     }

--- a/src/Wordpress/CustomPostType/Item.php
+++ b/src/Wordpress/CustomPostType/Item.php
@@ -225,6 +225,16 @@ class Item extends CustomPostType {
 					'placeholder' => esc_html__( 'Select item admins.', 'commonsbooking' )
 				),
 			) );
+
+			// item maintainer(s) emails
+			$cmb->add_field( array(
+				'name'       => esc_html__( 'Item maintainer email', 'commonsbooking' ),
+				'desc'       => esc_html__( 'Email addresses to which notifications about a change of item status (restriction, breakdown) shall be sent. You can enter multiple addresses separated by commas.',
+					'commonsbooking' ),
+				'id'         => COMMONSBOOKING_METABOX_PREFIX . 'item_maintainer_email',
+				'type'       => 'text',
+				'show_on_cb' => 'cmb2_hide_if_no_cats', // function should return a bool value
+			) );
 		}
 
 		// Check if custom meta fields are set in CB Options and generate MetaData-Box and fields

--- a/src/Wordpress/CustomPostType/Item.php
+++ b/src/Wordpress/CustomPostType/Item.php
@@ -213,6 +213,8 @@ class Item extends CustomPostType {
 			foreach ( $users as $user ) {
 				$userOptions[ $user->ID ] = $user->get( 'user_nicename' ) . " (" . $user->first_name . " " . $user->last_name . ")";
 			}
+
+			//Item Administrators
 			$cmb->add_field( array(
 				'name'       => esc_html__( 'Item Admin(s)', 'commonsbooking' ),
 				'desc'       => esc_html__( 'choose one or more users to give them the permisssion to edit and manage this specific item. Only users with the role cb_manager can be selected here', 'commonsbooking' ),

--- a/src/Wordpress/CustomPostType/Location.php
+++ b/src/Wordpress/CustomPostType/Location.php
@@ -145,11 +145,11 @@ class Location extends CustomPostType {
 			// Post Type in der oberen Admin-Bar anzeigen?
 			'show_in_admin_bar' => true,
 
-			// in den Navigations Menüs sichtbar machen?
+			// in den Navigationsmenüs sichtbar machen?
 			'show_in_nav_menus' => true,
 
 			// Hier können Berechtigungen in einem Array gesetzt werden
-			// oder die standart Werte post und page in form eines Strings gesetzt werden
+			// oder die standard Werte post und page in Form eines Strings gesetzt werden
 			'capability_type'   => array( self::$postType, self::$postType . 's' ),
 
 			'map_meta_cap'        => true,
@@ -195,7 +195,7 @@ class Location extends CustomPostType {
 	 * @return void
 	 */
 	public function registerMetabox() {
-		// Initiate the metabox Adress
+		// Initiate the metabox address
 		$cmb = new_cmb2_box( array(
 			'id'           => COMMONSBOOKING_METABOX_PREFIX . 'location_adress',
 			'title'        => esc_html__( 'Address', 'commonsbooking' ),
@@ -304,7 +304,7 @@ class Location extends CustomPostType {
 			'show_names'   => true, // Show field names on the left
 		) );
 
-		// short description
+		// location email
 		$cmb->add_field( array(
 			'name'       => esc_html__( 'Location email', 'commonsbooking' ),
 			'desc'       => esc_html__( 'Email addresses to which a copy of the booking confirmation / cancellation should be sent. You can enter multiple addresses separated by commas.',


### PR DESCRIPTION
Aktuelles Problem ist noch, dass jede Ausfallmeldung gerade weitergeleitet wird. Also wenn für einen Artikel eine Ausfallmeldung an mehrere Leute rausgeht, kriegt der/die maintainer*in auch genau so viele Warnungen.

Closing #1128 