### PR TITLE
Add a docker test image

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,0 +1,4 @@
+FROM wordpress:php7.4
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,0 +1,27 @@
+1. First build a custom wordpress image with composer included
+
+```bash
+docker build -t cbdev -f Dockerfile .
+```
+
+2. Use docker compose to start up network with database and wordpress webserver
+
+```bash
+docker-compose -f stack.yml up
+```
+
+3. Deploy plugin sources to wp plugin folder with docker cp
+
+`wordpress_wordpress_1` is the name of container. 
+You can call it also via script at `sh ./wordpress/deploy-plugin.sh`.
+
+```bash
+docker cp . wordpress_wordpress_1:/var/www/html/wp-content/plugins/commonsbooking
+```
+
+For an initial `composer install` in the plugin directory, login into the container with e.g. `docker exec -it $CONTAINERNAME /bin/bash`.
+
+# Alternatively
+
+Skip the custom image from step one and start the compose script using `wordpress:php7.4` image, instead of `cbdev`.
+And install composer by yourself, e.g. via login into the container.

--- a/wordpress/deploy-plugin.sh
+++ b/wordpress/deploy-plugin.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker cp . wordpress_wordpress_1:/var/www/html/wp-content/plugins/commonsbooking
+

--- a/wordpress/stack.yml
+++ b/wordpress/stack.yml
@@ -1,0 +1,31 @@
+version: '3.1'
+
+services:
+
+  wordpress:
+    image: cbdev # was wordpress:php7.4
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: exampleuser
+      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_NAME: exampledb
+    volumes:
+      - wordpress:/var/www/html
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: exampledb
+      MYSQL_USER: exampleuser
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:


### PR DESCRIPTION
I have no local webserver/php/mariadb on my machine to test my changes in #1154  , so I used docker to setup a wordpress instance.

What do you think about including it in the repo/in an own repo?

Maybe this can be used as an starting point for some automated browser tests?