### PR TITLE
CB_MAP: Allows no-clustering with max_cluster_radius == 0px

### DIFF
--- a/assets/map/js/cb-map-shortcode.js
+++ b/assets/map/js/cb-map-shortcode.js
@@ -294,9 +294,8 @@ function CB_Map() {
         if ((!init && this.settings.marker_map_bounds_filter) || (init && this.settings.marker_map_bounds_initial)) {
             if (Object.keys(data).length > 0) {
 
-                // TODO If max_cluster_radius == 0, markers is a layerGroup and doesn't define getBounds
-                //  Addionally center_position happens to be undefined (but I don't know why at the moment)
-                //  So this is rather a hack and should be placed elsewhere
+                // If max_cluster_radius == 0, markers is a layerGroup and doesn't define getBounds, 
+                //  so the next if statement will fail, when center_position happens to be undefined
                 if (markers.getBounds === undefined && center_position === undefined) {
                     center_position = {
                         lat: data.map( location => location.lat ).reduce( (a, b) => a+b) / data.length,

--- a/assets/map/js/cb-map-shortcode.js
+++ b/assets/map/js/cb-map-shortcode.js
@@ -296,6 +296,7 @@ function CB_Map() {
 
                 // If max_cluster_radius == 0, markers is a layerGroup and doesn't define getBounds, 
                 //  so the next if statement will fail, when center_position happens to be undefined
+                // TODO why center_position can be undefined
                 if (markers.getBounds === undefined && center_position === undefined) {
                     center_position = {
                         lat: data.map( location => location.lat ).reduce( (a, b) => a+b) / data.length,

--- a/assets/map/js/cb-map-shortcode.js
+++ b/assets/map/js/cb-map-shortcode.js
@@ -117,12 +117,13 @@ function CB_Map() {
 
         var markers;
 
-        console.log('max_cluster_radius - Was ' + this.settings.max_cluster_radius)
-        if(this.settings.max_cluster_radius == undefined || (this.settings.max_cluster_radius < 10 && this.settings.max_cluster_radius != 0)) {
+        // As the documentation states, a valid cluster radius is:
+        //   => 10px to enable  clustering
+        //   == 0px  to disable clustering 
+        //   1px-9px are ignored and 10px is assumed
+        if(this.settings.max_cluster_radius == undefined || (0 < this.settings.max_cluster_radius < 10)) {
             this.settings.max_cluster_radius = 10;
-            
         }
-        console.log('max_cluster_radius - Set to ' + this.settings.max_cluster_radius)
 
         if (this.settings.max_cluster_radius > 0) {
             var marker_cluster_options = {
@@ -152,10 +153,10 @@ function CB_Map() {
             }
 
             markers = L.markerClusterGroup(marker_cluster_options);
-            console.log('Markers is cluster group')
         } else {
+            // No clustering
+            // NOTE layergroup uses another api
             markers = L.layerGroup();
-            console.log('Markers is layer group')
         }
 
         var custom_marker_icon;
@@ -294,11 +295,9 @@ function CB_Map() {
             if (Object.keys(data).length > 0) {
 
                 // TODO If max_cluster_radius == 0, markers is a layerGroup and doesn't define getBounds
-                //  Addionally center_position can be undefined (don't know why)
+                //  Addionally center_position happens to be undefined (but I don't know why at the moment)
                 //  So this is rather a hack and should be placed elsewhere
                 if (markers.getBounds === undefined && center_position === undefined) {
-                    console.log('No clustering, getbounds === undefined')
-                    console.log(data)
                     center_position = {
                         lat: data.map( location => location.lat ).reduce( (a, b) => a+b) / data.length,
                         lon: data.map( location => location.lon ).reduce( (a, b) => a+b) / data.length

--- a/assets/map/js/cb-map-shortcode.js
+++ b/assets/map/js/cb-map-shortcode.js
@@ -117,10 +117,12 @@ function CB_Map() {
 
         var markers;
 
-        // @TODO: Check real problem with markers.getBounds() error.
-        if(!this.settings.max_cluster_radius || this.settings.max_cluster_radius <= 0) {
+        console.log('max_cluster_radius - Was ' + this.settings.max_cluster_radius)
+        if(this.settings.max_cluster_radius == undefined || (this.settings.max_cluster_radius < 10 && this.settings.max_cluster_radius != 0)) {
             this.settings.max_cluster_radius = 10;
+            
         }
+        console.log('max_cluster_radius - Set to ' + this.settings.max_cluster_radius)
 
         if (this.settings.max_cluster_radius > 0) {
             var marker_cluster_options = {
@@ -150,9 +152,10 @@ function CB_Map() {
             }
 
             markers = L.markerClusterGroup(marker_cluster_options);
-
+            console.log('Markers is cluster group')
         } else {
             markers = L.layerGroup();
+            console.log('Markers is layer group')
         }
 
         var custom_marker_icon;
@@ -289,6 +292,18 @@ function CB_Map() {
         //adjust map section to marker bounds based on settings
         if ((!init && this.settings.marker_map_bounds_filter) || (init && this.settings.marker_map_bounds_initial)) {
             if (Object.keys(data).length > 0) {
+
+                // TODO If max_cluster_radius == 0, markers is a layerGroup and doesn't define getBounds
+                //  Addionally center_position can be undefined (don't know why)
+                //  So this is rather a hack and should be placed elsewhere
+                if (markers.getBounds === undefined && center_position === undefined) {
+                    console.log('No clustering, getbounds === undefined')
+                    console.log(data)
+                    center_position = {
+                        lat: data.map( location => location.lat ).reduce( (a, b) => a+b) / data.length,
+                        lon: data.map( location => location.lon ).reduce( (a, b) => a+b) / data.length
+                    }
+                }
 
                 //keep center position & set bounds based on markers to show around
                 if (center_position) {


### PR DESCRIPTION
This fixes getBounds error when max_cluster_radius is set to 0px, by computing `center_position` from the average lat/lon of all markers.

This will resolve #733 

I tested it with my local setup, with 3 locations there is no problem (See issue discussion).

I don't know about performance issue when there are many more markers to display.

When you accept it I will remove the debug logs.