### PR TITLE
added path option for cache #1166

### DIFF
--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1093,10 +1093,23 @@ Return date: {{booking:returnDatetime}}
 			),
 			'experimental' => array(
 				'title'  => commonsbooking_sanitizeHTML( __( 'Advanced caching settings', 'commonsbooking' ) ),
-				'id'     => 'redis_group',
+				'id'     => 'caching_group',
 				'desc'   =>
 					commonsbooking_sanitizeHTML( __( 'Allows you to change options regarding the caching system', 'commonsbooking' ) ),
 				'fields' => array(
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Filesystem cache path', 'commonsbooking' ) ),
+						'desc'          => commonsbooking_sanitizeHTML( __('Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/','commonsbooking' ) ),
+						'id'            => 'cache_path',
+						'type'          => 'text',
+						'default'       => '',
+					),
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Current connection status', 'commonsbooking' ) ),
+						'id'            => 'filesystem-status',
+						'type'          => 'text',
+						'render_row_cb' => array( Cache::class, 'renderFilesystemStatus' ),
+					),
 					array(
 						'name' => commonsbooking_sanitizeHTML( __( 'Enable REDIS Caching (experimental)', 'commonsbooking' ) ),
 						'id'   => 'redis_enabled',
@@ -1107,13 +1120,6 @@ Return date: {{booking:returnDatetime}}
 						'id'   => 'redis_dsn',
 						'type' => 'text',
 						'default' => 'redis://localhost:6379'
-					),
-					array(
-						'name'          => commonsbooking_sanitizeHTML( __( 'Filesystem cache path', 'commonsbooking' ) ),
-						'desc'          => commonsbooking_sanitizeHTML( __('Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/','commonsbooking' ) ),
-						'id'            => 'cache_path',
-						'type'          => 'text',
-						'default'       => '',
 					),
 					array(
 						'name'          => commonsbooking_sanitizeHTML( __( 'Current connection status', 'commonsbooking' ) ),

--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1092,13 +1092,13 @@ Return date: {{booking:returnDatetime}}
 				]
 			),
 			'experimental' => array(
-				'title'  => commonsbooking_sanitizeHTML( __( 'Connect to REDIS database.', 'commonsbooking' ) ),
+				'title'  => commonsbooking_sanitizeHTML( __( 'Advanced caching settings', 'commonsbooking' ) ),
 				'id'     => 'redis_group',
 				'desc'   =>
-					commonsbooking_sanitizeHTML( __( 'Allows you to connect the cache to a REDIS database. This feature is experimental.', 'commonsbooking' ) ),
+					commonsbooking_sanitizeHTML( __( 'Allows you to change options regarding the caching system', 'commonsbooking' ) ),
 				'fields' => array(
 					array(
-						'name' => commonsbooking_sanitizeHTML( __( 'Enable REDIS Caching', 'commonsbooking' ) ),
+						'name' => commonsbooking_sanitizeHTML( __( 'Enable REDIS Caching (experimental)', 'commonsbooking' ) ),
 						'id'   => 'redis_enabled',
 						'type' => 'checkbox',
 					),
@@ -1109,7 +1109,14 @@ Return date: {{booking:returnDatetime}}
 						'default' => 'redis://localhost:6379'
 					),
 					array(
-						'name'          => commonsbooking_sanitizeHTML( __( 'Current connections status', 'commonsbooking' ) ),
+						'name'          => commonsbooking_sanitizeHTML( __( 'Filesystem cache path', 'commonsbooking' ) ),
+						'desc'          => commonsbooking_sanitizeHTML( __('Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/','commonsbooking' ) ),
+						'id'            => 'cache_path',
+						'type'          => 'text',
+						'default'       => '',
+					),
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Current connection status', 'commonsbooking' ) ),
 						'id'            => 'redis_connection-status',
 						'type'          => 'text',
 						'render_row_cb' => array( Cache::class, 'renderREDISConnectionStatus' ),

--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1099,7 +1099,7 @@ Return date: {{booking:returnDatetime}}
 				'fields' => array(
 					array(
 						'name'          => commonsbooking_sanitizeHTML( __( 'Filesystem cache path', 'commonsbooking' ) ),
-						'desc'          => commonsbooking_sanitizeHTML( __( 'Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/','commonsbooking' ) ),
+						'desc'          => commonsbooking_sanitizeHTML( __( 'Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/', 'commonsbooking' ) ),
 						'id'            => 'cache_path',
 						'type'          => 'text',
 						'default'       => '',

--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1099,7 +1099,7 @@ Return date: {{booking:returnDatetime}}
 				'fields' => array(
 					array(
 						'name'          => commonsbooking_sanitizeHTML( __( 'Filesystem cache path', 'commonsbooking' ) ),
-						'desc'          => commonsbooking_sanitizeHTML( __('Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/','commonsbooking' ) ),
+						'desc'          => commonsbooking_sanitizeHTML( __( 'Where the filesystem cache should be created. Only change when filesystem caching is not working. Default when empty: /tmp/symfony-cache/','commonsbooking' ) ),
 						'id'            => 'cache_path',
 						'type'          => 'text',
 						'default'       => '',

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -308,12 +308,12 @@ trait Cache {
 				}
 				if (is_writable($cachePath)){
 					echo '<div style="color:green">';
-					echo sprintf( commonsbooking_sanitizeHTML(__('Directory %s is writeable.', 'commonsbooking'), 'commonsbooking' ), $cachePath);
+					echo sprintf( commonsbooking_sanitizeHTML(__('Directory %s is writeable.', 'commonsbooking') ), $cachePath);
 					echo '</div>';
 				}
 				else {
 					echo '<div style="color:red">';
-					echo sprintf( commonsbooking_sanitizeHTML(__('Directory %s could not be written to.', 'commonsbooking'), 'commonsbooking' ), $cachePath);
+					echo sprintf( commonsbooking_sanitizeHTML(__('Directory %s could not be written to.', 'commonsbooking') ), $cachePath);
 					echo '</div>';
 				}
 				?>

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -99,6 +99,13 @@ trait Cache {
 	 * @return TagAwareAdapterInterface
 	 */
 	public static function getCache( string $namespace = '', int $defaultLifetime = 0, string $directory = null ): TagAwareAdapterInterface {
+		if ($directory == null){
+			$customCachePath = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' );
+			if ($customCachePath ){
+				$directory = $customCachePath;
+			}
+		}
+
 		if (Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'redis_enabled') =='on'){
 			try {
 				$adapter = new RedisTagAwareAdapter(

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -92,6 +92,10 @@ trait Cache {
 	}
 
 	/**
+	 * Creates cache based on user settings or defaults.
+	 * 
+	 * At the moment filesystem and redis cache are supported.
+	 *
 	 * @param string $namespace
 	 * @param int $defaultLifetime
 	 * @param string|null $directory
@@ -99,25 +103,25 @@ trait Cache {
 	 * @return TagAwareAdapterInterface
 	 */
 	public static function getCache( string $namespace = '', int $defaultLifetime = 0, string $directory = null ): TagAwareAdapterInterface {
-		if ($directory == null){
-			$customCachePath = commonsbooking_sanitizeArrayorString(Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' ));
-			if ($customCachePath ){
+		if ( $directory === null ){
+			$customCachePath = commonsbooking_sanitizeArrayorString( Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' ) );
+			if ( $customCachePath ){
 				$directory = $customCachePath;
 			}
 		}
 
-		if (Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'redis_enabled') =='on'){
+		if (Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'redis_enabled' ) === 'on'){
 			try {
 				$adapter = new RedisTagAwareAdapter(
-					RedisAdapter::createConnection(Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'redis_dsn')),
+					RedisAdapter::createConnection( Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'redis_dsn' ) ),
 					$namespace,
 					$defaultLifetime
 				);
 				return $adapter;
 			}
 			catch (Exception $e) {
-				commonsbooking_write_log($e . 'Falling back to Filesystem adapter');
-				set_transient( COMMONSBOOKING_PLUGIN_SLUG . '_adapter-error',$e->getMessage());
+				commonsbooking_write_log( $e . 'Falling back to Filesystem adapter' );
+				set_transient( COMMONSBOOKING_PLUGIN_SLUG . '_adapter-error', $e->getMessage() );
 			}
 		}
 		$adapter = new TagAwareAdapter(

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -100,7 +100,7 @@ trait Cache {
 	 */
 	public static function getCache( string $namespace = '', int $defaultLifetime = 0, string $directory = null ): TagAwareAdapterInterface {
 		if ($directory == null){
-			$customCachePath = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' );
+			$customCachePath = commonsbooking_sanitizeArrayorString(Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' ));
 			if ($customCachePath ){
 				$directory = $customCachePath;
 			}
@@ -283,6 +283,37 @@ trait Cache {
 				else {
 					echo '<div style="color:orange">';
 						echo __('REDIS database not enabled','commonsbooking');
+					echo '</div>';
+				}
+				?>
+			</div>
+		</div>
+		<?php
+	}
+
+	public static function renderFilesystemStatus( array $field_ars, CMB2_Field $field){
+		?>
+		<div class="cmb-row cmb-type-text table-layout">
+			<div class="cmb-th">
+				Directory status:
+			</div>
+			<div class="cmb-th">
+				<?php
+				$cachePath = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' );
+				if (empty($cachePath)){
+					$cachePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'symfony-cache';
+				}
+				else {
+					$cachePath = realpath($cachePath) ?: $cachePath;
+				}
+				if (is_writable($cachePath)){
+					echo '<div style="color:green">';
+					echo sprintf( commonsbooking_sanitizeHTML(__('Directory %s is writeable.', 'commonsbooking'), 'commonsbooking' ), $cachePath);
+					echo '</div>';
+				}
+				else {
+					echo '<div style="color:red">';
+					echo sprintf( commonsbooking_sanitizeHTML(__('Directory %s could not be written to.', 'commonsbooking'), 'commonsbooking' ), $cachePath);
 					echo '</div>';
 				}
 				?>


### PR DESCRIPTION
Closing #1166 
Gibt bei Hostern, die keinen Zugriff auf den /tmp/ Ordner gewähren, die Möglichkeit den Cache in einem anderen Ordner zu speichern (zum Beispiel in wp-content/cache)