### PR TITLE
TimeFrame Helper: Merge display of overlapping timeframes

### DIFF
--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -18,7 +18,7 @@ use CommonsBooking\Model\Timeframe;
  *
  * @return object|null
  */
-function unset_if_either_key_null_else_set_func( string $key, array $arr1, array $arr2, callable $func ) : void {
+function unset_if_either_key_null_else_set_func( string $key, array &$arr1, array &$arr2, callable $func ) : void {
 	if ( !array_key_exists($key, $arr1)) {
 		// Do nothing, interval1 is open
 	} else if ( !array_key_exists($key, $arr2)) {

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -149,8 +149,7 @@ class Helper {
 		$last     = 0;
 
 		// For each range, compare with last (or first) merged range.
-		$n = count( $array_of_ranges );
-		for ( $i = 1; $i < $n; $i++ ) {
+		for ( $i = 1; $i < count( $array_of_ranges ); $i++ ) {
 			$last_interval = &$result[ $last ];
 			$next_interval = &$array_of_ranges[ $i ];
 

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -7,6 +7,14 @@ use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Model\Timeframe;
 
+function if_either_null_else_func( callable $func, object $end_date, object $end_date1 ): ?object {
+	if ($end_date == null || $end_date1 == null) {
+		return null;
+	}
+
+	return $func($end_date1, $end_date1);
+}
+
 class Helper {
 
 	/**
@@ -128,14 +136,6 @@ class Helper {
 	 */
 	public static function mergeRangesToBookableDate( $arrayOfRanges ): array {
 
-		function if_either_null_else_func( callable $func, object $end_date, object $end_date1 ): ?object {
-			if ($end_date == null || $end_date1 == null) {
-				return null;
-			}
-
-			return $func($end_date1, $end_date1);
-		}
-
 		if ( count($arrayOfRanges) == 1) {
 			return $arrayOfRanges;
 		}
@@ -168,5 +168,4 @@ class Helper {
 		return $result;
 
 	}
-
 }

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -7,6 +7,10 @@ use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Model\Timeframe;
 
+function interval_open( $interval_value ) {
+	return $interval_value === false;
+}
+
 /**
  * Set <code>arr1[key]</code> to false, if either key of arr1 or key of arr2 is false.
  * <p>If not false, use func (which takes two args) to compute a result
@@ -20,9 +24,9 @@ use CommonsBooking\Model\Timeframe;
  * @return object|null
  */
 function set_false_if_either_key_null_else_set_func( string $key, array &$arr1, array &$arr2, callable $func ) : void {
-	if ( $arr1[ $key ] === false) {
+	if ( interval_open($arr1[ $key ]) ) {
 		// Do nothing, interval1 is open
-	} else if ( $arr2[ $key ] === false) {
+	} else if ( interval_open($arr2[ $key ]) ) {
 		// Set interval_1 false because interval 2 is open
 		$arr1[$key] = false;
 	} else {
@@ -173,7 +177,7 @@ class Helper {
 			//  If first/last interval is open => overlaps next
 			//  Or first/last interval end is greater than next interval begin
 			if (
-				$result[ $last ]['end_date'] === false
+				interval_open($result[ $last ]['end_date'])
 			    || $result[ $last ]['end_date'] >= $arrayOfRanges[$i]['start_date'])
 			{
 				// => Overlap, merge both

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -12,13 +12,13 @@ use CommonsBooking\Model\Timeframe;
  * If not, use func which is a binary operator to compute a result
  *
  * @param string $key
- * @param callable $func
  * @param object $arr1
  * @param object $arr2
+ * @param callable $func
  *
  * @return object|null
  */
-function null_if_either_key_null_else_func( string $key, callable $func, object $arr1, object $arr2 ): ?object {
+function null_if_either_key_null_else_func( string $key, array $arr1, array $arr2, callable $func ): ?object {
 	if ( !array_key_exists($key, $arr1) || !array_key_exists($key, $arr2)) {
 		return null;
 	}

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -126,8 +126,8 @@ class Helper {
 	 *
 	 * @return array():TimeFrame
 	 */
-	public static function merge_ranges_to_bookable_dates( $array_of_ranges ): array {
-		function interval_open( $interval_value ): bool {
+	public static function merge_ranges_to_bookable_dates( array $array_of_ranges ): array {
+		$interval_open = function ( $interval_value ): bool {
 			return false === $interval_value;
 		};
 
@@ -151,20 +151,22 @@ class Helper {
 		// For each range, compare with last (or first) merged range.
 		$n = count( $array_of_ranges );
 		for ( $i = 1; $i < $n; $i++ ) {
-			$last_interval = $result[ $last ];
-			$next_interval = $array_of_ranges[ $i ];
+			$last_interval = &$result[ $last ];
+			$next_interval = &$array_of_ranges[ $i ];
 
 			// Either
 			// If first/last interval is open => overlaps next
 			// Or first/last interval end is greater than next interval begin.
 			if (
-				interval_open( $last_interval['end_date'] )
+				$interval_open( $last_interval['end_date'] )
 				|| $last_interval['end_date'] >= $next_interval['start_date'] ) {
 				// TimeFrame overlap?
 				// => Overlap, merge interval start and end.
-				$last_interval = min( $last_interval['start_date'], $next_interval['start_date'] );
+				$last_interval['start_date'] = min( $last_interval['start_date'], $next_interval['start_date'] );
 
-				if ( interval_open( $next_interval['end_date'] ) ) {
+				if ( $interval_open( $last_interval['end_date'] ) ) {
+					// Do nothing.
+				} elseif ( $interval_open( $next_interval['end_date'] ) ) {
 					$last_interval['end_date'] = false;
 				} else {
 					// Both intervals are closed.
@@ -179,4 +181,6 @@ class Helper {
 
 		return $result;
 	}
+
+
 }

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -7,12 +7,23 @@ use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Model\Timeframe;
 
-function if_either_null_else_func( callable $func, object $end_date, object $end_date1 ): ?object {
-	if ($end_date == null || $end_date1 == null) {
+/**
+ * If key of arr1 and arr2 is null, return null
+ * If not, use func which is a binary operator to compute a result
+ *
+ * @param string $key
+ * @param callable $func
+ * @param object $arr1
+ * @param object $arr2
+ *
+ * @return object|null
+ */
+function null_if_either_key_null_else_func( string $key, callable $func, object $arr1, object $arr2 ): ?object {
+	if ( !array_key_exists($key, $arr1) || !array_key_exists($key, $arr2)) {
 		return null;
 	}
 
-	return $func($end_date1, $end_date1);
+	return $func($arr2[$key], $arr2[$key]);
 }
 
 class Helper {
@@ -155,8 +166,10 @@ class Helper {
 
 			if ($result[$last]['end_date'] >= $arrayOfRanges[$i]['start_date']) {
 				// Overlap => do the merge
-				$result[$last]["start_date"] = if_either_null_else_func(min, $result[ $last ]['start_date'], $arrayOfRanges[ $i ]['start_date'] );
-				$result[$last]["end_date"]   = if_either_null_else_func(max, $result[ $last ]['end_date'],   $arrayOfRanges[ $i ]['end_date'] );
+				$result[$last]["start_date"] = null_if_either_key_null_else_func( 'start_date', $result[ $last ],
+					$arrayOfRanges[ $i ], function($a,$b) {return min($a, $b);} );
+				$result[$last]["end_date"]   = null_if_either_key_null_else_func( 'end_date',   $result[ $last ],
+					$arrayOfRanges[ $i ], function($a,$b) {return max($a, $b);} );
 			} else {
 				// No overlap => Add new interval to result
 				// And use this as new last interval

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -23,7 +23,7 @@ function null_if_either_key_null_else_func( string $key, array $arr1, array $arr
 		return null;
 	}
 
-	return $func($arr2[$key], $arr2[$key]);
+	return $func($arr1[$key], $arr2[$key]);
 }
 
 class Helper {

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -5,7 +5,6 @@ namespace CommonsBooking\Helper;
 use CommonsBooking\Model\Booking;
 use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Location;
-use CommonsBooking\Model\Timeframe;
 
 class Helper {
 
@@ -124,7 +123,7 @@ class Helper {
 	 *
 	 * @param array $array_of_ranges Array of one or more ranges.
 	 *
-	 * @return array():TimeFrame
+	 * @return array - Array of overlapping ranges.
 	 */
 	public static function merge_ranges_to_bookable_dates( array $array_of_ranges ): array {
 		$interval_open = function ( $interval_value ): bool {

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -164,12 +164,14 @@ class Helper {
 		// For each element
 		for ($i = 1; $i < count($arrayOfRanges); $i++) {
 
-			if ($result[$last]['end_date'] >= $arrayOfRanges[$i]['start_date']) {
-				// Overlap => do the merge
-				$result[$last]["start_date"] = null_if_either_key_null_else_func( 'start_date', $result[ $last ],
-					$arrayOfRanges[ $i ], function($a,$b) {return min($a, $b);} );
-				$result[$last]["end_date"]   = null_if_either_key_null_else_func( 'end_date',   $result[ $last ],
-					$arrayOfRanges[ $i ], function($a,$b) {return max($a, $b);} );
+			// Either interval_0 is open
+			//  or interval_0 is not open and intersects interval_1
+			// => Overlap, merge both
+			if (!array_key_exists('end_date', $result[$last])
+			    || $result[$last]['end_date'] >= $arrayOfRanges[$i]['start_date'])
+			{
+				$result[$last]["start_date"] = null_if_either_key_null_else_func( 'start_date', $result[ $last ], $arrayOfRanges[ $i ], function($a,$b) {return min($a, $b);} );
+				$result[$last]["end_date"]   = null_if_either_key_null_else_func( 'end_date',   $result[ $last ], $arrayOfRanges[ $i ], function($a,$b) {return max($a, $b);} );
 			} else {
 				// No overlap => Add new interval to result
 				// And use this as new last interval

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -18,12 +18,16 @@ use CommonsBooking\Model\Timeframe;
  *
  * @return object|null
  */
-function null_if_either_key_null_else_func( string $key, array $arr1, array $arr2, callable $func ): ?object {
-	if ( !array_key_exists($key, $arr1) || !array_key_exists($key, $arr2)) {
-		return null;
+function unset_if_either_key_null_else_set_func( string $key, array $arr1, array $arr2, callable $func ) : void {
+	if ( !array_key_exists($key, $arr1)) {
+		// Do nothing, interval1 is open
+	} else if ( !array_key_exists($key, $arr2)) {
+		// Unset interval_1 because interval 2 is open
+		unset($arr1[$key]);
+	} else {
+		// Both intervals are closed
+		$arr1[$key] = $func($arr1[$key], $arr2[$key]);
 	}
-
-	return $func($arr1[$key], $arr2[$key]);
 }
 
 class Helper {
@@ -170,8 +174,8 @@ class Helper {
 			if (!array_key_exists('end_date', $result[$last])
 			    || $result[$last]['end_date'] >= $arrayOfRanges[$i]['start_date'])
 			{
-				$result[$last]["start_date"] = null_if_either_key_null_else_func( 'start_date', $result[ $last ], $arrayOfRanges[ $i ], function($a,$b) {return min($a, $b);} );
-				$result[$last]["end_date"]   = null_if_either_key_null_else_func( 'end_date',   $result[ $last ], $arrayOfRanges[ $i ], function($a,$b) {return max($a, $b);} );
+				unset_if_either_key_null_else_set_func( 'start_date', $result[ $last ], $arrayOfRanges[ $i ], function($a,$b) {return min($a, $b);} );
+				unset_if_either_key_null_else_set_func( 'end_date',   $result[ $last ], $arrayOfRanges[ $i ], function($a,$b) {return max($a, $b);} );
 			} else {
 				// No overlap => Add new interval to result
 				// And use this as new last interval

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -128,6 +128,14 @@ class Helper {
 	 */
 	public static function mergeRangesToBookableDate( $arrayOfRanges ): array {
 
+		function if_either_null_else_func( callable $func, object $end_date, object $end_date1 ): ?object {
+			if ($end_date == null || $end_date1 == null) {
+				return null;
+			}
+
+			return $func($end_date1, $end_date1);
+		}
+
 		if ( count($arrayOfRanges) == 1) {
 			return $arrayOfRanges;
 		}
@@ -136,13 +144,7 @@ class Helper {
 
 		// Sort by start date
 		usort($arrayOfRanges, function( $a, $b ) {
-			if ($a['start_date'] > $b['start_date']) {
-				return 1;
-			} if ($a['start_date'] < $b['start_date']) {
-				return -1;
-			} if ($a['start_date'] == $b['start_date']) {
-				return 0;
-			}
+			return $a['start_date'] <=> $b['start_date'];
 		});
 
 		$result[] = $arrayOfRanges[0];
@@ -153,8 +155,8 @@ class Helper {
 
 			if ($result[$last]['end_date'] >= $arrayOfRanges[$i]['start_date']) {
 				// Overlap => do the merge
-				$result[$last]["start_date"] = min($result[$last]['start_date'], $arrayOfRanges[$i]['start_date']);
-				$result[$last]["end_date"]   = max($result[$last]['end_date'],   $arrayOfRanges[$i]['end_date']);
+				$result[$last]["start_date"] = if_either_null_else_func(min, $result[ $last ]['start_date'], $arrayOfRanges[ $i ]['start_date'] );
+				$result[$last]["end_date"]   = if_either_null_else_func(max, $result[ $last ]['end_date'],   $arrayOfRanges[ $i ]['end_date'] );
 			} else {
 				// No overlap => Add new interval to result
 				// And use this as new last interval

--- a/templates/timeframe-withitem.php
+++ b/templates/timeframe-withitem.php
@@ -18,7 +18,8 @@ $permalink    = add_query_arg ( 'cb-location', $location->ID, get_the_permalink(
                 array_key_exists('ranges', $data) &&
                 count($data['ranges'])
             ) {
-                foreach ($data['ranges'] as $range) {
+	            $ranges = \CommonsBooking\Helper\Helper::mergeRangesToBookableDate($data['ranges']);
+                foreach ($ranges as $range) {
                     echo commonsbooking_sanitizeHTML( \CommonsBooking\Model\Timeframe::formatBookableDate($range['start_date'], $range['end_date']) ) . '<br>';
                 }
             }

--- a/templates/timeframe-withitem.php
+++ b/templates/timeframe-withitem.php
@@ -18,7 +18,7 @@ $permalink    = add_query_arg ( 'cb-location', $location->ID, get_the_permalink(
                 array_key_exists('ranges', $data) &&
                 count($data['ranges'])
             ) {
-	            $ranges = \CommonsBooking\Helper\Helper::mergeRangesToBookableDate($data['ranges']);
+	            $ranges = \CommonsBooking\Helper\Helper::merge_ranges_to_bookable_dates($data['ranges']);
                 foreach ($ranges as $range) {
                     echo commonsbooking_sanitizeHTML( \CommonsBooking\Model\Timeframe::formatBookableDate($range['start_date'], $range['end_date']) ) . '<br>';
                 }

--- a/templates/timeframe-withlocation.php
+++ b/templates/timeframe-withlocation.php
@@ -33,7 +33,7 @@ $permalink    = add_query_arg ( 'cb-location', $location->ID, get_the_permalink(
             ) {
 
                 // Merge overlapping timeframes
-				$ranges = \CommonsBooking\Helper\Helper::mergeRangesToBookableDate($data['ranges']);
+				$ranges = \CommonsBooking\Helper\Helper::merge_ranges_to_bookable_dates($data['ranges']);
 
 	            foreach ($ranges as $range) {
 		            echo commonsbooking_sanitizeHTML( \CommonsBooking\Model\Timeframe::formatBookableDate($range['start_date'], $range['end_date']) ) . '<br>';

--- a/templates/timeframe-withlocation.php
+++ b/templates/timeframe-withlocation.php
@@ -32,9 +32,12 @@ $permalink    = add_query_arg ( 'cb-location', $location->ID, get_the_permalink(
                 count($data['ranges'])
             ) {
 
-                foreach ($data['ranges'] as $range) {
-                    echo commonsbooking_sanitizeHTML( \CommonsBooking\Model\Timeframe::formatBookableDate($range['start_date'], $range['end_date']) ) . '<br>';
-                }
+                // Merge overlapping timeframes
+				$ranges = \CommonsBooking\Helper\Helper::mergeRangesToBookableDate($data['ranges']);
+
+	            foreach ($ranges as $range) {
+		            echo commonsbooking_sanitizeHTML( \CommonsBooking\Model\Timeframe::formatBookableDate($range['start_date'], $range['end_date']) ) . '<br>';
+	            }
             }
         ?>
     </div>

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -136,4 +136,24 @@ class HelperTest extends TestCase {
 		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
 		$this->assertArrayNotHasKey( 'end_date', $merged );
 	}
+
+	public function test_whenTimeFrameHasOpenInterval2_returnOneTimeFrame() {
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start_date" => to_ts("2020-01-01"),
+					"end_date"   => to_ts("2020-03-01")
+				),
+				array(
+					"start_date" => to_ts("2020-04-01")
+				)
+			)
+		);
+
+		$this->assertCount(1, $arrayOfBookableDates);
+		$merged = $arrayOfBookableDates[0];
+
+		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
+		$this->assertArrayNotHasKey( 'end_date', $merged );
+	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -121,7 +121,8 @@ class HelperTest extends TestCase {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01")
+					"start_date" => to_ts("2020-01-01"),
+					false
 				),
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -133,8 +134,8 @@ class HelperTest extends TestCase {
 		$this->assertCount(1, $arrayOfBookableDates);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
-		$this->assertArrayNotHasKey( 'end_date', $merged );
+		$this->assertEquals(to_ts("2020-01-01"), $merged['start_date']);
+		$this->assertEquals(false, $merged['end_date']);
 	}
 
 	public function test_whenTimeFrameHasOpenInterval2_returnOneTimeFrame() {
@@ -145,7 +146,8 @@ class HelperTest extends TestCase {
 					"end_date"   => to_ts("2020-04-01")
 				),
 				array(
-					"start_date" => to_ts("2020-03-01")
+					"start_date" => to_ts("2020-03-01"),
+					false
 				)
 			)
 		);
@@ -153,7 +155,28 @@ class HelperTest extends TestCase {
 		$this->assertCount(1, $arrayOfBookableDates);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
-		$this->assertArrayNotHasKey( 'end_date', $merged );
+		$this->assertEquals(to_ts("2020-01-01"), $merged['start_date']);
+		$this->assertEquals(false, $merged['end_date']);
+	}
+
+	public function test_whenTimeFrameHasOpenInterval3_HasSameStart_butOneOpen_returnOneOpenInterval() {
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start_date" => 1673136000,
+					"end_date"   => false
+				),
+				array(
+					"start_date" => 1673136000,
+					"end_date"  => 1681430399
+				)
+			)
+		);
+
+		$this->assertCount(1, $arrayOfBookableDates);
+		$merged = $arrayOfBookableDates[0];
+
+		$this->assertEquals(1673136000, $merged['start_date']);
+		$this->assertEquals(false,      $merged['end_date']);
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -2,10 +2,10 @@
 
 namespace CommonsBooking\Tests\Helper;
 
-use CommonsBooking\Helper\Helper;
-use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use DateTime;
 use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use CommonsBooking\Helper\Helper;
 
 function dt_to_ts( $time_str ): DateTime {
 	return DateTime::createFromFormat(DateTimeInterface::ATOM, $time_str);
@@ -22,7 +22,7 @@ function to_ts( string $time_str ): DateTime {
 	return DateTime::createFromFormat('Y-m-d', $time_str);
 }
 
-class HelperTest extends CustomPostTypeTest {
+class HelperTest extends TestCase {
 
 	public function test_whenAllTimeFramesOverlap_returnOneTimeframe() {
 

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -69,7 +69,7 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue($merged['end_date']   == to_ts("2020-01-04"));
 	}
 
-	/*
+
 	public function test_whenTwoTimeframesDontOverlap_returnTwoTimeframes() {
 
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
@@ -87,8 +87,8 @@ class HelperTest extends CustomPostTypeTest {
 
 		$this->assertTrue(count($arrayOfBookableDates) == 2);
 
-		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == "2020-01-01");
-		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == "2020-01-04");
+		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == to_ts('2020-01-01T12:00:00+00:00'));
+		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == to_ts('2020-01-04T12:00:00+00:00'));
 	}
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {
@@ -96,16 +96,16 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-01-05")
+					"start_date" => dt_to_ts("2020-01-01"),
+					"end_date"   => dt_to_ts("2020-01-05")
 				),
 				array(
-					"start_date" => to_ts("2020-01-02"),
-					"end_date"   => to_ts("2020-01-04")
+					"start_date" => dt_to_ts("2020-01-02"),
+					"end_date"   => dt_to_ts("2020-01-04")
 				),
 				array(
-					"start_date" => to_ts("2020-01-05"),
-					"end_date"   => to_ts("2020-01-06")
+					"start_date" => dt_to_ts("2020-01-05"),
+					"end_date"   => dt_to_ts("2020-01-06")
 				)
 			)
 		);
@@ -113,7 +113,7 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start_date'] == "2020-01-01");
-		$this->assertTrue($merged['end_date']   == "2020-01-06");
-	}*/
+		$this->assertTrue($merged['start_date'] == dt_to_ts("2020-01-01"));
+		$this->assertTrue($merged['end_date']   == dt_to_ts("2020-01-06"));
+	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -7,7 +7,7 @@ use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use DateTime;
 use DateTimeInterface;
 
-function dt_to_ts( $time_str ): int {
+function dt_to_ts( $time_str ): DateTime {
 	return DateTime::createFromFormat(DateTimeInterface::ATOM, $time_str);
 }
 
@@ -18,7 +18,7 @@ function dt_to_ts( $time_str ): int {
  *
  * @return int
  */
-function to_ts( $time_str ): int {
+function to_ts( string $time_str ): DateTime {
 	return DateTime::createFromFormat('Y-m-d', $time_str);
 }
 

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -116,4 +116,24 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
 		$this->assertTrue($merged['end_date']   == to_ts("2020-01-06"));
 	}
+
+	public function test_whenTimeFrameHasOpenInterval_returnOneTimeFrame() {
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start_date" => to_ts("2020-01-01")
+				),
+				array(
+					"start_date" => to_ts("2020-01-01"),
+					"end_date"   => to_ts("2020-01-04")
+				)
+			)
+		);
+
+		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$merged = $arrayOfBookableDates[0];
+
+		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
+		$this->assertTrue($merged['end_date']   == null);
+	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -2,19 +2,22 @@
 
 namespace CommonsBooking\Tests\Helper;
 
+use CommonsBooking\Helper\Helper;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use DateTime;
+use DateTimeInterface;
+
+function dt_to_ts( $time_str ): int {
+	return DateTime::createFromFormat(DateTimeInterface::ATOM, $time_str);
+}
 
 /**
  * Returns date time int
  *
- * @param $time_str like '2020-01-01T12:00:00+00:00'
+ * @param $time_str string like '2020-01-01T12:00:00+00:00'
  *
  * @return int
  */
-function dt_to_ts( $time_str ): int {
-	return DateTime::createFromFormat(DateTimeInterface::ISO8601, $time_str);
-}
-
 function to_ts( $time_str ): int {
 	return DateTime::createFromFormat('Y-m-d', $time_str);
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -29,12 +29,12 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start-date" => to_ts("2020-01-01"),
-					"end-date"   => to_ts("2020-01-03")
+					"start_date" => to_ts("2020-01-01"),
+					"end_date"   => to_ts("2020-01-03")
 				),
 				array(
-					"start-date" => to_ts("2020-01-02"),
-					"end-date"   => to_ts("2020-01-04")
+					"start_date" => to_ts("2020-01-02"),
+					"end_date"   => to_ts("2020-01-04")
 				)
 			)
 		);
@@ -42,8 +42,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start-date'] == to_ts("2020-01-01"));
-		$this->assertTrue($merged['end-date']   == to_ts("2020-01-04"));
+		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
+		$this->assertTrue($merged['end_date']   == to_ts("2020-01-04"));
 	}
 
 
@@ -52,12 +52,12 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start-date" => to_ts("2020-01-01"),
-					"end-date"   => to_ts("2020-01-02")
+					"start_date" => to_ts("2020-01-01"),
+					"end_date"   => to_ts("2020-01-02")
 				),
 				array(
-					"start-date" => to_ts("2020-01-02"),
-					"end-date"   => to_ts("2020-01-04")
+					"start_date" => to_ts("2020-01-02"),
+					"end_date"   => to_ts("2020-01-04")
 				)
 			)
 		);
@@ -65,8 +65,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start-date'] == to_ts("2020-01-01"));
-		$this->assertTrue($merged['end-date']   == to_ts("2020-01-04"));
+		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
+		$this->assertTrue($merged['end_date']   == to_ts("2020-01-04"));
 	}
 
 	/*
@@ -75,20 +75,20 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start-date" => to_ts('2020-01-01T12:00:00+00:00'),
-					"end-date"   => to_ts('2020-01-02T12:00:00+00:00'),
+					"start_date" => to_ts('2020-01-01T12:00:00+00:00'),
+					"end_date"   => to_ts('2020-01-02T12:00:00+00:00'),
 				),
 				array(
-					"start-date" => to_ts('2020-01-03T12:00:00+00:00'),
-					"end-date"   => to_ts('2020-01-04T12:00:00+00:00'),
+					"start_date" => to_ts('2020-01-03T12:00:00+00:00'),
+					"end_date"   => to_ts('2020-01-04T12:00:00+00:00'),
 				)
 			)
 		);
 
 		$this->assertTrue(count($arrayOfBookableDates) == 2);
 
-		$this->assertTrue($arrayOfBookableDates[0]['start-date'] == "2020-01-01");
-		$this->assertTrue($arrayOfBookableDates[1]['end-date']   == "2020-01-04");
+		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == "2020-01-01");
+		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == "2020-01-04");
 	}
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {
@@ -96,16 +96,16 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start-date" => to_ts("2020-01-01"),
-					"end-date"   => to_ts("2020-01-05")
+					"start_date" => to_ts("2020-01-01"),
+					"end_date"   => to_ts("2020-01-05")
 				),
 				array(
-					"start-date" => to_ts("2020-01-02"),
-					"end-date"   => to_ts("2020-01-04")
+					"start_date" => to_ts("2020-01-02"),
+					"end_date"   => to_ts("2020-01-04")
 				),
 				array(
-					"start-date" => to_ts("2020-01-05"),
-					"end-date"   => to_ts("2020-01-06")
+					"start_date" => to_ts("2020-01-05"),
+					"end_date"   => to_ts("2020-01-06")
 				)
 			)
 		);
@@ -113,7 +113,7 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start-date'] == "2020-01-01");
-		$this->assertTrue($merged['end-date']   == "2020-01-06");
+		$this->assertTrue($merged['start_date'] == "2020-01-01");
+		$this->assertTrue($merged['end_date']   == "2020-01-06");
 	}*/
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use CommonsBooking\Helper\Helper;
 
 function dt_to_ts( $time_str ): DateTime {
-	return DateTime::createFromFormat(DateTimeInterface::ATOM, $time_str);
+	return DateTime::createFromFormat( DateTimeInterface::ATOM, $time_str );
 }
 
 /**
@@ -19,164 +19,160 @@ function dt_to_ts( $time_str ): DateTime {
  * @return int
  */
 function to_ts( string $time_str ): DateTime {
-	return DateTime::createFromFormat('Y-m-d', $time_str);
+	return DateTime::createFromFormat( 'Y-m-d', $time_str );
 }
 
 class HelperTest extends TestCase {
 
 	public function test_whenAllTimeFramesOverlap_returnOneTimeframe() {
-
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-01-03")
+					'start_date' => to_ts( '2020-01-01' ),
+					'end_date'   => to_ts( '2020-01-03' ),
 				),
 				array(
-					"start_date" => to_ts("2020-01-02"),
-					"end_date"   => to_ts("2020-01-04")
-				)
+					'start_date' => to_ts( '2020-01-02' ),
+					'end_date'   => to_ts( '2020-01-04' ),
+				),
 			)
 		);
 
-		$this->assertCount(1, $arrayOfBookableDates);
+		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
-		$this->assertEquals($merged['end_date'],   to_ts("2020-01-04"));
+		$this->assertEquals( $merged['start_date'], to_ts( '2020-01-01' ) );
+		$this->assertEquals( $merged['end_date'], to_ts( '2020-01-04' ) );
 	}
 
 
 	public function test_whenTimeframesOverlapOnDay_returnOneTimeframe() {
-
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-01-02")
+					'start_date' => to_ts( '2020-01-01' ),
+					'end_date'   => to_ts( '2020-01-02' ),
 				),
 				array(
-					"start_date" => to_ts("2020-01-02"),
-					"end_date"   => to_ts("2020-01-04")
-				)
+					'start_date' => to_ts( '2020-01-02' ),
+					'end_date'   => to_ts( '2020-01-04' ),
+				),
 			)
 		);
 
-		$this->assertCount(1 , $arrayOfBookableDates);
+		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
-		$this->assertEquals($merged['end_date'],   to_ts("2020-01-04"));
+		$this->assertEquals( $merged['start_date'], to_ts( '2020-01-01' ) );
+		$this->assertEquals( $merged['end_date'], to_ts( '2020-01-04' ) );
 	}
 
 
 	public function test_whenTwoTimeframesDontOverlap_returnTwoTimeframes() {
-
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => dt_to_ts('2020-01-01T12:00:00+00:00'),
-					"end_date"   => dt_to_ts('2020-01-02T12:00:00+00:00'),
+					'start_date' => dt_to_ts( '2020-01-01T12:00:00+00:00' ),
+					'end_date'   => dt_to_ts( '2020-01-02T12:00:00+00:00' ),
 				),
 				array(
-					"start_date" => dt_to_ts('2020-01-03T12:00:00+00:00'),
-					"end_date"   => dt_to_ts('2020-01-04T12:00:00+00:00'),
-				)
+					'start_date' => dt_to_ts( '2020-01-03T12:00:00+00:00' ),
+					'end_date'   => dt_to_ts( '2020-01-04T12:00:00+00:00' ),
+				),
 			)
 		);
 
-		$this->assertCount(2, $arrayOfBookableDates);
+		$this->assertCount( 2, $arrayOfBookableDates );
 
-		$this->assertEquals($arrayOfBookableDates[0]['start_date'], dt_to_ts('2020-01-01T12:00:00+00:00'));
-		$this->assertEquals($arrayOfBookableDates[1]['end_date'],   dt_to_ts('2020-01-04T12:00:00+00:00'));
+		$this->assertEquals( $arrayOfBookableDates[0]['start_date'], dt_to_ts( '2020-01-01T12:00:00+00:00' ) );
+		$this->assertEquals( $arrayOfBookableDates[1]['end_date'],   dt_to_ts( '2020-01-04T12:00:00+00:00' ) );
 	}
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {
-
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-01-05")
+					'start_date' => to_ts( '2020-01-01' ),
+					'end_date'   => to_ts( '2020-01-05' ),
 				),
 				array(
-					"start_date" => to_ts("2020-01-02"),
-					"end_date"   => to_ts("2020-01-04")
+					'start_date' => to_ts( '2020-01-02' ),
+					'end_date'   => to_ts( '2020-01-04' ),
 				),
 				array(
-					"start_date" => to_ts("2020-01-05"),
-					"end_date"   => to_ts("2020-01-06")
-				)
+					'start_date' => to_ts( '2020-01-05' ),
+					'end_date'   => to_ts( '2020-01-06' ),
+				),
 			)
 		);
 
-		$this->assertCount(1, $arrayOfBookableDates);
+		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
-		$this->assertEquals($merged['end_date'],   to_ts("2020-01-06"));
+		$this->assertEquals( $merged['start_date'], to_ts( '2020-01-01' ) );
+		$this->assertEquals( $merged['end_date'], to_ts( '2020-01-06' ) );
 	}
 
 	public function test_whenTimeFrameHasOpenInterval_returnOneTimeFrame() {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => false
+					'start_date' => to_ts( '2020-01-01' ),
+					'end_date'   => false,
 				),
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-01-04")
-				)
+					'start_date' => to_ts( '2020-01-01' ),
+					'end_date'   => to_ts( '2020-01-04' ),
+				),
 			)
 		);
 
-		$this->assertCount(1, $arrayOfBookableDates);
+		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals(to_ts("2020-01-01"), $merged['start_date']);
-		$this->assertEquals(false, $merged['end_date']);
+		$this->assertEquals( to_ts( '2020-01-01' ), $merged['start_date'] );
+		$this->assertEquals( false, $merged['end_date'] );
 	}
 
 	public function test_whenTimeFrameHasOpenInterval2_returnOneTimeFrame() {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-04-01")
+					'start_date' => to_ts( '2020-01-01' ),
+					'end_date'   => to_ts( '2020-04-01' ),
 				),
 				array(
-					"start_date" => to_ts("2020-03-01"),
-					"end_date"   => false
-				)
+					'start_date' => to_ts( '2020-03-01' ),
+					'end_date'   => false,
+				),
 			)
 		);
 
-		$this->assertCount(1, $arrayOfBookableDates);
+		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals(to_ts("2020-01-01"), $merged['start_date']);
-		$this->assertEquals(false, $merged['end_date']);
+		$this->assertEquals( to_ts( '2020-01-01' ), $merged['start_date'] );
+		$this->assertEquals( false, $merged['end_date'] );
 	}
 
 	public function test_whenTimeFrameHasOpenInterval3_HasSameStart_butOneOpen_returnOneOpenInterval() {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					"start_date" => 1673136000,
-					"end_date"   => false
+					'start_date' => 1673136000,
+					'end_date'   => false,
 				),
 				array(
-					"start_date" => 1673136000,
-					"end_date"  => 1681430399
-				)
+					'start_date' => 1673136000,
+					'end_date'   => 1681430399,
+				),
 			)
 		);
 
-		$this->assertCount(1, $arrayOfBookableDates);
+		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals(1673136000, $merged['start_date']);
-		$this->assertEquals(false,      $merged['end_date']);
+		$this->assertEquals( 1673136000, $merged['start_date'] );
+		$this->assertEquals( false, $merged['end_date'] );
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -42,8 +42,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
-		assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
+		$this->assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
+		$this->assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
 	}
 
 
@@ -65,8 +65,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
-		assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
+		$this->assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
+		$this->assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
 	}
 
 

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -122,7 +122,7 @@ class HelperTest extends TestCase {
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
-					false
+					"end_date"   => false
 				),
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -147,7 +147,7 @@ class HelperTest extends TestCase {
 				),
 				array(
 					"start_date" => to_ts("2020-03-01"),
-					false
+					"end_date"   => false
 				)
 			)
 		);

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -39,7 +39,7 @@ class HelperTest extends CustomPostTypeTest {
 			)
 		);
 
-		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$this->assertCount(1, $arrayOfBookableDates);
 		$merged = $arrayOfBookableDates[0];
 
 		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
@@ -62,7 +62,7 @@ class HelperTest extends CustomPostTypeTest {
 			)
 		);
 
-		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$this->assertCount(1 , $arrayOfBookableDates);
 		$merged = $arrayOfBookableDates[0];
 
 		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
@@ -85,7 +85,7 @@ class HelperTest extends CustomPostTypeTest {
 			)
 		);
 
-		$this->assertTrue(count($arrayOfBookableDates) == 2);
+		$this->assertCount(2, $arrayOfBookableDates);
 
 		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == dt_to_ts('2020-01-01T12:00:00+00:00'));
 		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == dt_to_ts('2020-01-04T12:00:00+00:00'));
@@ -110,11 +110,11 @@ class HelperTest extends CustomPostTypeTest {
 			)
 		);
 
-		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$this->assertCount(1, $arrayOfBookableDates);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
-		$this->assertTrue($merged['end_date']   == to_ts("2020-01-06"));
+		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
+		$this->assertEquals($merged['end_date'],   to_ts("2020-01-06"));
 	}
 
 	public function test_whenTimeFrameHasOpenInterval_returnOneTimeFrame() {
@@ -130,10 +130,10 @@ class HelperTest extends CustomPostTypeTest {
 			)
 		);
 
-		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$this->assertCount(1, $arrayOfBookableDates);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
+		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
 		$this->assertArrayNotHasKey( 'end_date', $merged );
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -134,6 +134,6 @@ class HelperTest extends CustomPostTypeTest {
 		$merged = $arrayOfBookableDates[0];
 
 		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
-		$this->assertTrue($merged['end_date']   == null);
+		$this->assertFalse(array_key_exists('end_date', $merged));
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -26,7 +26,7 @@ class HelperTest extends TestCase {
 
 	public function test_whenAllTimeFramesOverlap_returnOneTimeframe() {
 
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -49,7 +49,7 @@ class HelperTest extends TestCase {
 
 	public function test_whenTimeframesOverlapOnDay_returnOneTimeframe() {
 
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -72,7 +72,7 @@ class HelperTest extends TestCase {
 
 	public function test_whenTwoTimeframesDontOverlap_returnTwoTimeframes() {
 
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => dt_to_ts('2020-01-01T12:00:00+00:00'),
@@ -93,7 +93,7 @@ class HelperTest extends TestCase {
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {
 
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -118,7 +118,7 @@ class HelperTest extends TestCase {
 	}
 
 	public function test_whenTimeFrameHasOpenInterval_returnOneTimeFrame() {
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -139,7 +139,7 @@ class HelperTest extends TestCase {
 	}
 
 	public function test_whenTimeFrameHasOpenInterval2_returnOneTimeFrame() {
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
@@ -160,7 +160,7 @@ class HelperTest extends TestCase {
 	}
 
 	public function test_whenTimeFrameHasOpenInterval3_HasSameStart_butOneOpen_returnOneOpenInterval() {
-		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
 					"start_date" => 1673136000,

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -42,8 +42,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
-		$this->assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
+		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
+		$this->assertEquals($merged['end_date'],   to_ts("2020-01-04"));
 	}
 
 
@@ -65,8 +65,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
-		$this->assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
+		$this->assertEquals($merged['start_date'], to_ts("2020-01-01"));
+		$this->assertEquals($merged['end_date'],   to_ts("2020-01-04"));
 	}
 
 

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace CommonsBooking\Tests\Helper;
+
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+
+/**
+ * Returns date time int
+ *
+ * @param $time_str like '2020-01-01T12:00:00+00:00'
+ *
+ * @return int
+ */
+function dt_to_ts( $time_str ): int {
+	return DateTime::createFromFormat(DateTimeInterface::ISO8601, $time_str);
+}
+
+function to_ts( $time_str ): int {
+	return DateTime::createFromFormat('Y-m-d', $time_str);
+}
+
+class HelperTest extends CustomPostTypeTest {
+
+	public function test_whenAllTimeFramesOverlap_returnOneTimeframe() {
+
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start-date" => to_ts("2020-01-01"),
+					"end-date"   => to_ts("2020-01-03")
+				),
+				array(
+					"start-date" => to_ts("2020-01-02"),
+					"end-date"   => to_ts("2020-01-04")
+				)
+			)
+		);
+
+		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$merged = $arrayOfBookableDates[0];
+
+		$this->assertTrue($merged['start-date'] == to_ts("2020-01-01"));
+		$this->assertTrue($merged['end-date']   == to_ts("2020-01-04"));
+	}
+
+
+	public function test_whenTimeframesOverlapOnDay_returnOneTimeframe() {
+
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start-date" => to_ts("2020-01-01"),
+					"end-date"   => to_ts("2020-01-02")
+				),
+				array(
+					"start-date" => to_ts("2020-01-02"),
+					"end-date"   => to_ts("2020-01-04")
+				)
+			)
+		);
+
+		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$merged = $arrayOfBookableDates[0];
+
+		$this->assertTrue($merged['start-date'] == to_ts("2020-01-01"));
+		$this->assertTrue($merged['end-date']   == to_ts("2020-01-04"));
+	}
+
+	/*
+	public function test_whenTwoTimeframesDontOverlap_returnTwoTimeframes() {
+
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start-date" => to_ts('2020-01-01T12:00:00+00:00'),
+					"end-date"   => to_ts('2020-01-02T12:00:00+00:00'),
+				),
+				array(
+					"start-date" => to_ts('2020-01-03T12:00:00+00:00'),
+					"end-date"   => to_ts('2020-01-04T12:00:00+00:00'),
+				)
+			)
+		);
+
+		$this->assertTrue(count($arrayOfBookableDates) == 2);
+
+		$this->assertTrue($arrayOfBookableDates[0]['start-date'] == "2020-01-01");
+		$this->assertTrue($arrayOfBookableDates[1]['end-date']   == "2020-01-04");
+	}
+
+	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {
+
+		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
+			array(
+				array(
+					"start-date" => to_ts("2020-01-01"),
+					"end-date"   => to_ts("2020-01-05")
+				),
+				array(
+					"start-date" => to_ts("2020-01-02"),
+					"end-date"   => to_ts("2020-01-04")
+				),
+				array(
+					"start-date" => to_ts("2020-01-05"),
+					"end-date"   => to_ts("2020-01-06")
+				)
+			)
+		);
+
+		$this->assertTrue(count($arrayOfBookableDates) == 1);
+		$merged = $arrayOfBookableDates[0];
+
+		$this->assertTrue($merged['start-date'] == "2020-01-01");
+		$this->assertTrue($merged['end-date']   == "2020-01-06");
+	}*/
+}

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -87,8 +87,8 @@ class HelperTest extends CustomPostTypeTest {
 
 		$this->assertCount(2, $arrayOfBookableDates);
 
-		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == dt_to_ts('2020-01-01T12:00:00+00:00'));
-		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == dt_to_ts('2020-01-04T12:00:00+00:00'));
+		$this->assertEquals($arrayOfBookableDates[0]['start_date'], dt_to_ts('2020-01-01T12:00:00+00:00'));
+		$this->assertEquals($arrayOfBookableDates[1]['end_date'],   dt_to_ts('2020-01-04T12:00:00+00:00'));
 	}
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -142,10 +142,10 @@ class HelperTest extends TestCase {
 			array(
 				array(
 					"start_date" => to_ts("2020-01-01"),
-					"end_date"   => to_ts("2020-03-01")
+					"end_date"   => to_ts("2020-04-01")
 				),
 				array(
-					"start_date" => to_ts("2020-04-01")
+					"start_date" => to_ts("2020-03-01")
 				)
 			)
 		);

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -96,16 +96,16 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start_date" => dt_to_ts("2020-01-01"),
-					"end_date"   => dt_to_ts("2020-01-05")
+					"start_date" => to_ts("2020-01-01"),
+					"end_date"   => to_ts("2020-01-05")
 				),
 				array(
-					"start_date" => dt_to_ts("2020-01-02"),
-					"end_date"   => dt_to_ts("2020-01-04")
+					"start_date" => to_ts("2020-01-02"),
+					"end_date"   => to_ts("2020-01-04")
 				),
 				array(
-					"start_date" => dt_to_ts("2020-01-05"),
-					"end_date"   => dt_to_ts("2020-01-06")
+					"start_date" => to_ts("2020-01-05"),
+					"end_date"   => to_ts("2020-01-06")
 				)
 			)
 		);
@@ -113,7 +113,7 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start_date'] == dt_to_ts("2020-01-01"));
-		$this->assertTrue($merged['end_date']   == dt_to_ts("2020-01-06"));
+		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
+		$this->assertTrue($merged['end_date']   == to_ts("2020-01-06"));
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -7,33 +7,18 @@ use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use CommonsBooking\Helper\Helper;
 
-function dt_to_ts( $time_str ): DateTime {
-	return DateTime::createFromFormat( DateTimeInterface::ATOM, $time_str );
-}
-
-/**
- * Returns date time int
- *
- * @param $time_str string like '2020-01-01T12:00:00+00:00'
- *
- * @return int
- */
-function to_ts( string $time_str ): DateTime {
-	return DateTime::createFromFormat( 'Y-m-d', $time_str );
-}
-
 class HelperTest extends TestCase {
 
 	public function test_whenAllTimeFramesOverlap_returnOneTimeframe() {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					'start_date' => to_ts( '2020-01-01' ),
-					'end_date'   => to_ts( '2020-01-03' ),
+					'start_date' => self::to_ts( '2020-01-01' ),
+					'end_date'   => self::to_ts( '2020-01-03' ),
 				),
 				array(
-					'start_date' => to_ts( '2020-01-02' ),
-					'end_date'   => to_ts( '2020-01-04' ),
+					'start_date' => self::to_ts( '2020-01-02' ),
+					'end_date'   => self::to_ts( '2020-01-04' ),
 				),
 			)
 		);
@@ -41,8 +26,8 @@ class HelperTest extends TestCase {
 		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals( $merged['start_date'], to_ts( '2020-01-01' ) );
-		$this->assertEquals( $merged['end_date'], to_ts( '2020-01-04' ) );
+		$this->assertEquals( $merged['start_date'], self::to_ts( '2020-01-01' ) );
+		$this->assertEquals( $merged['end_date'], self::to_ts( '2020-01-04' ) );
 	}
 
 
@@ -50,12 +35,12 @@ class HelperTest extends TestCase {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					'start_date' => to_ts( '2020-01-01' ),
-					'end_date'   => to_ts( '2020-01-02' ),
+					'start_date' => self::to_ts( '2020-01-01' ),
+					'end_date'   => self::to_ts( '2020-01-02' ),
 				),
 				array(
-					'start_date' => to_ts( '2020-01-02' ),
-					'end_date'   => to_ts( '2020-01-04' ),
+					'start_date' => self::to_ts( '2020-01-02' ),
+					'end_date'   => self::to_ts( '2020-01-04' ),
 				),
 			)
 		);
@@ -63,8 +48,8 @@ class HelperTest extends TestCase {
 		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals( $merged['start_date'], to_ts( '2020-01-01' ) );
-		$this->assertEquals( $merged['end_date'], to_ts( '2020-01-04' ) );
+		$this->assertEquals( $merged['start_date'], self::to_ts( '2020-01-01' ) );
+		$this->assertEquals( $merged['end_date'], self::to_ts( '2020-01-04' ) );
 	}
 
 
@@ -72,36 +57,36 @@ class HelperTest extends TestCase {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					'start_date' => dt_to_ts( '2020-01-01T12:00:00+00:00' ),
-					'end_date'   => dt_to_ts( '2020-01-02T12:00:00+00:00' ),
+					'start_date' => self::dt_to_ts( '2020-01-01T12:00:00+00:00' ),
+					'end_date'   => self::dt_to_ts( '2020-01-02T12:00:00+00:00' ),
 				),
 				array(
-					'start_date' => dt_to_ts( '2020-01-03T12:00:00+00:00' ),
-					'end_date'   => dt_to_ts( '2020-01-04T12:00:00+00:00' ),
+					'start_date' => self::dt_to_ts( '2020-01-03T12:00:00+00:00' ),
+					'end_date'   => self::dt_to_ts( '2020-01-04T12:00:00+00:00' ),
 				),
 			)
 		);
 
 		$this->assertCount( 2, $arrayOfBookableDates );
 
-		$this->assertEquals( $arrayOfBookableDates[0]['start_date'], dt_to_ts( '2020-01-01T12:00:00+00:00' ) );
-		$this->assertEquals( $arrayOfBookableDates[1]['end_date'],   dt_to_ts( '2020-01-04T12:00:00+00:00' ) );
+		$this->assertEquals( $arrayOfBookableDates[0]['start_date'], self::dt_to_ts( '2020-01-01T12:00:00+00:00' ) );
+		$this->assertEquals( $arrayOfBookableDates[1]['end_date'],   self::dt_to_ts( '2020-01-04T12:00:00+00:00' ) );
 	}
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					'start_date' => to_ts( '2020-01-01' ),
-					'end_date'   => to_ts( '2020-01-05' ),
+					'start_date' => self::to_ts( '2020-01-01' ),
+					'end_date'   => self::to_ts( '2020-01-05' ),
 				),
 				array(
-					'start_date' => to_ts( '2020-01-02' ),
-					'end_date'   => to_ts( '2020-01-04' ),
+					'start_date' => self::to_ts( '2020-01-02' ),
+					'end_date'   => self::to_ts( '2020-01-04' ),
 				),
 				array(
-					'start_date' => to_ts( '2020-01-05' ),
-					'end_date'   => to_ts( '2020-01-06' ),
+					'start_date' => self::to_ts( '2020-01-05' ),
+					'end_date'   => self::to_ts( '2020-01-06' ),
 				),
 			)
 		);
@@ -109,20 +94,20 @@ class HelperTest extends TestCase {
 		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals( $merged['start_date'], to_ts( '2020-01-01' ) );
-		$this->assertEquals( $merged['end_date'], to_ts( '2020-01-06' ) );
+		$this->assertEquals( $merged['start_date'], self::to_ts( '2020-01-01' ) );
+		$this->assertEquals( $merged['end_date'], self::to_ts( '2020-01-06' ) );
 	}
 
 	public function test_whenTimeFrameHasOpenInterval_returnOneTimeFrame() {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					'start_date' => to_ts( '2020-01-01' ),
+					'start_date' => self::to_ts( '2020-01-01' ),
 					'end_date'   => false,
 				),
 				array(
-					'start_date' => to_ts( '2020-01-01' ),
-					'end_date'   => to_ts( '2020-01-04' ),
+					'start_date' => self::to_ts( '2020-01-01' ),
+					'end_date'   => self::to_ts( '2020-01-04' ),
 				),
 			)
 		);
@@ -130,7 +115,7 @@ class HelperTest extends TestCase {
 		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals( to_ts( '2020-01-01' ), $merged['start_date'] );
+		$this->assertEquals( self::to_ts( '2020-01-01' ), $merged['start_date'] );
 		$this->assertEquals( false, $merged['end_date'] );
 	}
 
@@ -138,11 +123,11 @@ class HelperTest extends TestCase {
 		$arrayOfBookableDates = Helper::merge_ranges_to_bookable_dates(
 			array(
 				array(
-					'start_date' => to_ts( '2020-01-01' ),
-					'end_date'   => to_ts( '2020-04-01' ),
+					'start_date' => self::to_ts( '2020-01-01' ),
+					'end_date'   => self::to_ts( '2020-04-01' ),
 				),
 				array(
-					'start_date' => to_ts( '2020-03-01' ),
+					'start_date' => self::to_ts( '2020-03-01' ),
 					'end_date'   => false,
 				),
 			)
@@ -151,7 +136,7 @@ class HelperTest extends TestCase {
 		$this->assertCount( 1, $arrayOfBookableDates );
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertEquals( to_ts( '2020-01-01' ), $merged['start_date'] );
+		$this->assertEquals( self::to_ts( '2020-01-01' ), $merged['start_date'] );
 		$this->assertEquals( false, $merged['end_date'] );
 	}
 
@@ -174,5 +159,20 @@ class HelperTest extends TestCase {
 
 		$this->assertEquals( 1673136000, $merged['start_date'] );
 		$this->assertEquals( false, $merged['end_date'] );
+	}
+
+	private function dt_to_ts( $time_str ): DateTime {
+		return DateTime::createFromFormat( DateTimeInterface::ATOM, $time_str );
+	}
+
+	/**
+	 * Returns date time object from string
+	 *
+	 * @param $time_str string like '2020-01-01T12:00:00+00:00'
+	 *
+	 * @return \DateTime
+	 */
+	private function to_ts( string $time_str ): DateTime {
+		return DateTime::createFromFormat( 'Y-m-d', $time_str );
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -42,8 +42,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
-		$this->assertTrue($merged['end_date']   == to_ts("2020-01-04"));
+		assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
+		assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
 	}
 
 
@@ -65,8 +65,8 @@ class HelperTest extends CustomPostTypeTest {
 		$this->assertTrue(count($arrayOfBookableDates) == 1);
 		$merged = $arrayOfBookableDates[0];
 
-		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
-		$this->assertTrue($merged['end_date']   == to_ts("2020-01-04"));
+		assertThat($merged['start_date'], is(equalTo(to_ts("2020-01-01"))));
+		assertThat($merged['end_date'],   is(equalTo(to_ts("2020-01-04"))));
 	}
 
 
@@ -134,6 +134,6 @@ class HelperTest extends CustomPostTypeTest {
 		$merged = $arrayOfBookableDates[0];
 
 		$this->assertTrue($merged['start_date'] == to_ts("2020-01-01"));
-		$this->assertFalse(array_key_exists('end_date', $merged));
+		$this->assertArrayNotHasKey( 'end_date', $merged );
 	}
 }

--- a/tests/Helper/HelperTest.php
+++ b/tests/Helper/HelperTest.php
@@ -75,20 +75,20 @@ class HelperTest extends CustomPostTypeTest {
 		$arrayOfBookableDates = Helper::mergeRangesToBookableDate(
 			array(
 				array(
-					"start_date" => to_ts('2020-01-01T12:00:00+00:00'),
-					"end_date"   => to_ts('2020-01-02T12:00:00+00:00'),
+					"start_date" => dt_to_ts('2020-01-01T12:00:00+00:00'),
+					"end_date"   => dt_to_ts('2020-01-02T12:00:00+00:00'),
 				),
 				array(
-					"start_date" => to_ts('2020-01-03T12:00:00+00:00'),
-					"end_date"   => to_ts('2020-01-04T12:00:00+00:00'),
+					"start_date" => dt_to_ts('2020-01-03T12:00:00+00:00'),
+					"end_date"   => dt_to_ts('2020-01-04T12:00:00+00:00'),
 				)
 			)
 		);
 
 		$this->assertTrue(count($arrayOfBookableDates) == 2);
 
-		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == to_ts('2020-01-01T12:00:00+00:00'));
-		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == to_ts('2020-01-04T12:00:00+00:00'));
+		$this->assertTrue($arrayOfBookableDates[0]['start_date'] == dt_to_ts('2020-01-01T12:00:00+00:00'));
+		$this->assertTrue($arrayOfBookableDates[1]['end_date']   == dt_to_ts('2020-01-04T12:00:00+00:00'));
 	}
 
 	public function test_whenThreeTimeFramesOverlap_returnOneTimeframe() {


### PR DESCRIPTION
When two or more timeframes overlap, they are now merged into one bookable timeframe when displaying them to the user.

This resolves #1020 