### PR TITLE
Hotfix iCalendar timezone

### DIFF
--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -259,11 +259,36 @@ class Wordpress {
 		return $itemsAndLocations;
 	}
 
+	/**
+	 * This would theoretically work if the timestamp we get from the database is in UTC.
+	 * The problem is, that the timestamp is in the local timezone of the server.
+	 * If we convert it to UTC, we get the wrong date and everything breaks.
+	 *
+	 * @param $timestamp
+	 *
+	 * @return DateTime
+	 * @throws \Exception
+	 */
 	public static function getUTCDateTimeByTimestamp($timestamp) {
 		$dto = new DateTime();
 		$dto->setTimestamp(
 			intval( $timestamp )
 		);
+		$dto->setTimezone(new \DateTimeZone('UTC'));
+
+		return $dto;
+	}
+
+	/**
+	 * This function does what probably the getUTCDateTimeByTimestamp was originally supposed to do.
+	 * @param $timestamp
+	 *
+	 * @return DateTime
+	 * @throws \Exception
+	 */
+	public static function convertTimestampToUTCDatetime($timestamp) {
+		$datetime = date( "Y-m-d H:i:s", $timestamp );
+		$dto      = new DateTime( $datetime,new \DateTimeZone(wp_timezone_string()));
 		$dto->setTimezone(new \DateTimeZone('UTC'));
 
 		return $dto;

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -618,9 +618,9 @@ class Timeframe extends CustomPost {
 	 *
 	 * @return DateTime
 	 */
-	public function getStartDateDateTime(): DateTime {
+	public function getUTCStartDateDateTime(): DateTime {
 		$startDateString = $this->getMeta( self::REPETITION_START );
-		return Wordpress::getUTCDateTimeByTimestamp( $startDateString );
+		return Wordpress::convertTimestampToUTCDatetime( $startDateString );
 	}
 
 	/**
@@ -642,12 +642,25 @@ class Timeframe extends CustomPost {
 
 	/**
 	 * Returns end-date \DateTime.
+	 * This method returns a local date time object, just with the UTC timezone attached but the time is still local.
 	 *
 	 * @return DateTime
 	 */
 	public function getEndDateDateTime(): DateTime {
 		$endDateString = intval( $this->getMeta( self::REPETITION_END ) );
 		return Wordpress::getUTCDateTimeByTimestamp( $endDateString );
+	}
+
+	/**
+	 * Returns end-date \DateTime.
+	 * Provides a UTC date time object.
+	 * We need to do this weird conversion because the end date is stored as a local timestamp.
+	 *
+	 * @return DateTime
+	 */
+	public function getUTCEndDateDateTime(): DateTime {
+		$endDateString = intval( $this->getMeta( self::REPETITION_END ) );
+		return Wordpress::convertTimestampToUTCDatetime( $endDateString );
 	}
 
 	/**

--- a/src/Service/iCalendar.php
+++ b/src/Service/iCalendar.php
@@ -100,8 +100,8 @@ class iCalendar {
             $bookingLocation_longitude = $bookingLocation->getMeta( 'geo_longitude' );
 
             //create immutable DateTime objects from Mutable (recommended by iCal library developer)
-            $booking_startDateDateTime = DateTimeImmutable::createFromMutable( $booking->getStartDateDateTime() );
-            $booking_endDateDateTime = DateTimeImmutable::createFromMutable( $booking->getEndDateDateTime() );
+            $booking_startDateDateTime = DateTimeImmutable::createFromMutable( $booking->getUTCStartDateDateTime() );
+            $booking_endDateDateTime = DateTimeImmutable::createFromMutable( $booking->getUTCEndDateDateTime() );
 
             // Create timezone entity
 	        $php_date_time_zone = wp_timezone();


### PR DESCRIPTION
Ich musste leider feststellen, dass die Wordpress:getUTCDateTimeByTimestamp nicht wie erwartet funktioniert, da der timestamp in den Timeframes als lokalisierte Zeit gespeichert wird. Die Funktion macht nichts anderes als die UTC Timezone anzuhängen. Der Timestamp ist dann aber immer noch nicht in UTC.

Habe jetzt eine kleine convert Funktion geschrieben, die das entsprechend umwandelt damit die iCalendar auch die richtigen Daten kriegt. Wenn ich die aber grundsätzlich auf alles anwenden würde, dann geht einiges mehr kaputt.

Deshalb erstmal nur dieser Hotfix.

closes #1224 