### PR TITLE
Update readme.txt tags to be more descriptive

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 Contributors: wielebenwirteam, m0rb, flegfleg, chriwen  
 Donate link: https://www.wielebenwir.de/verein/unterstutzen  
-Tags: booking, commons, sharing, calendar, commoning, open-source
+Tags: booking, commons, sharing, calendar, commoning, open-source, booking system, booking calendar
 Requires at least: 5.2  
 Tested up to: 6.0
 Stable Tag: 2.8

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 Contributors: wielebenwirteam, m0rb, flegfleg, chriwen  
 Donate link: https://www.wielebenwir.de/verein/unterstutzen  
-Tags: booking, commons, sharing, calendar,  
+Tags: booking, commons, sharing, calendar, commoning, open-source
 Requires at least: 5.2  
 Tested up to: 6.0
 Stable Tag: 2.8

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,7 @@
 {
   "name": "wielebenwir/commonsbooking",
   "description": "~",
-  "tags": [
-    "commons",
-    "commoning",
-    "cargo-bikes",
-    "booking",
-    "calendar",
-    "open-source"
-  ],
+  "version": "0.0.1",
   "config": {
     "platform-check": false
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,14 @@
 {
   "name": "wielebenwir/commonsbooking",
   "description": "~",
-  "version": "0.0.1",
+  "tags": [
+    "commons",
+    "commoning",
+    "cargo-bikes",
+    "booking",
+    "calendar",
+    "open-source"
+  ],
   "config": {
     "platform-check": false
     },

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === CommonsBooking ===
 Contributors: wielebenwirteam, m0rb, flegfleg, chriwen
 Donate link: https://www.wielebenwir.de/verein/unterstutzen  
-Tags: booking, commons, sharing, calendar,  
+Tags: booking, commons, sharing, calendar, commoning, open-source
 Requires at least: 5.2  
 Tested up to: 6.2  
 Stable Tag: 2.8

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === CommonsBooking ===
 Contributors: wielebenwirteam, m0rb, flegfleg, chriwen
 Donate link: https://www.wielebenwir.de/verein/unterstutzen  
-Tags: booking, commons, sharing, calendar, commoning, open-source
+Tags: booking, commons, sharing, calendar, commoning, open-source, booking system, booking calendar
 Requires at least: 5.2  
 Tested up to: 6.2  
 Stable Tag: 2.8


### PR DESCRIPTION
So our plugin can be found more easily.
Removes version because it's not necessary, commonsbooking.php is parsed by Wordpress-Plugin-Backend.

@chriwen @hansmorb vielleicht noch mit diesem Release?