### PR TITLE
Alle Bildformate an Karte übergeben

### DIFF
--- a/src/API/ItemsRoute.php
+++ b/src/API/ItemsRoute.php
@@ -56,7 +56,7 @@ class ItemsRoute extends BaseRoute {
 	/**
 	 * Get a collection of items
 	 *
-	 * @param $request Full data about the request.
+	 * @param $request - Full data about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -123,8 +123,15 @@ class ItemsRoute extends BaseRoute {
 		$preparedItem->description = $this->escapeJsonString( $item->post_content );
 		$preparedItem->projectId = "1";
 
-		if ( get_the_post_thumbnail_url( $item->ID, 'full' ) ) {
-			$preparedItem->image = get_the_post_thumbnail_url( $item->ID, 'full' );
+		$thumbnailId = get_post_thumbnail_id( $item->ID );
+		if ( $thumbnailId ) {
+			$preparedItem->image = wp_get_attachment_image_url( $thumbnailId, 'full' );
+			$preparedItem->	images = [
+				'thumbnail' => wp_get_attachment_image_src( $thumbnailId, 'thumbnail' ),
+				'medium'    => wp_get_attachment_image_src( $thumbnailId, 'medium' ),
+				'large'     => wp_get_attachment_image_src( $thumbnailId, 'large' ),
+				'full'      => wp_get_attachment_image_src( $thumbnailId, 'full' ),
+			];
 		}
 
 		return $preparedItem;

--- a/src/Wordpress/CustomPostType/Map.php
+++ b/src/Wordpress/CustomPostType/Map.php
@@ -237,13 +237,6 @@ class Map extends CustomPostType {
 					];
 				}
 
-				$images[] = [
-					'thumbnail' => get_the_post_thumbnail_url( $item->ID, 'thumbnail' ),
-					'medium'    => get_the_post_thumbnail_url( $item->ID, 'medium' ),
-					'large'     => get_the_post_thumbnail_url( $item->ID, 'large' ),
-					'full'      => get_the_post_thumbnail_url( $item->ID, 'full' ),
-				];
-
 				$thumbnail = get_the_post_thumbnail_url( $item->ID, 'thumbnail' );
 
 				$thumbnailID = get_post_thumbnail_id( $item->ID );

--- a/src/Wordpress/CustomPostType/Map.php
+++ b/src/Wordpress/CustomPostType/Map.php
@@ -237,7 +237,22 @@ class Map extends CustomPostType {
 					];
 				}
 
+				$images[] = [
+					'thumbnail' => get_the_post_thumbnail_url( $item->ID, 'thumbnail' ),
+					'medium'    => get_the_post_thumbnail_url( $item->ID, 'medium' ),
+					'large'     => get_the_post_thumbnail_url( $item->ID, 'large' ),
+					'full'      => get_the_post_thumbnail_url( $item->ID, 'full' ),
+				];
+
 				$thumbnail = get_the_post_thumbnail_url( $item->ID, 'thumbnail' );
+
+				$thumbnailID = get_post_thumbnail_id( $item->ID );
+				$images = [
+					'thumbnail' => wp_get_attachment_image_src( $thumbnailID, 'thumbnail' ),
+					'medium'    => wp_get_attachment_image_src( $thumbnailID, 'medium' ),
+					'large'     => wp_get_attachment_image_src( $thumbnailID, 'large' ),
+					'full'      => wp_get_attachment_image_src( $thumbnailID, 'full' ),
+				];
 				$items[]   = [
 					'id'         => $item->ID,
 					'name'       => $item->post_title,
@@ -246,6 +261,7 @@ class Map extends CustomPostType {
 					'terms'      => $item_terms,
 					'link'       => add_query_arg( 'cb-location', $post->ID, get_permalink( $item->ID ) ),
 					'thumbnail'  => $thumbnail ?: null,
+					'images'     => $images,
 					'timeframes' => $timeframesData
 				];
 			}


### PR DESCRIPTION
Dieser PR sorgt dafür, dass der Karte nicht nur die Thumbnail Größe übergeben wird, sondern auch ein Array mit den verschiedenen, automatisch von WordPress generierten, Bildgrößen. (thumbnail, medium, large, full). 

Dabei werden zusätzlich zu der URL noch die Bildgrößen zur Verfügung gestellt. Dabei orientiert sich dieser PR an dem Layout der https://developer.wordpress.org/reference/functions/wp_get_attachment_image_src/ Funktion.