### PR TITLE
Remove unnecessary sorting

### DIFF
--- a/src/View/Item.php
+++ b/src/View/Item.php
@@ -107,18 +107,7 @@ class Item extends View {
 		$itemData = [];
 		/** @var \CommonsBooking\Model\Item $item */
 		foreach ( $items as $item ) {
-			$shortCodeData = self::getShortcodeData( $item, 'Location' );
-
-			//Sort by start_date when no other order is defined
-			if (empty($queryArgs['orderby'])){
-				foreach ($shortCodeData as $location) {
-					uasort( $location['ranges'], function ( $a, $b ) {
-						return $a['start_date'] <=> $b['start_date'];
-					} );
-				}
-			}
-
-			$itemData[ $item->ID ] = $shortCodeData;
+			$itemData[ $item->ID ] = self::getShortcodeData( $item, 'Location' );
 		}
 
 		if ($itemData) {

--- a/src/View/Location.php
+++ b/src/View/Location.php
@@ -106,18 +106,7 @@ class Location extends View {
 		$locationData = [];
 		/** @var \CommonsBooking\Model\Location $location */
 		foreach ( $locations as $location ) {
-			$shortCodeData = self::getShortcodeData( $location, 'Item' );
-
-			// Sort by start_date when no other order is defined
-			if (empty($queryArgs['orderby'])){
-				foreach ($shortCodeData as $item) {
-					uasort( $item['ranges'], function ( $a, $b ) {
-						return $a['start_date'] <=> $b['start_date'];
-					} );
-				}
-			}
-
-			$locationData[ $location->ID ] = $shortCodeData;
+			$locationData[ $location->ID ] = self::getShortcodeData( $location, 'Item' );
 		}
 
 		if ($locationData){

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -6,6 +6,7 @@ use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use CommonsBooking\View\View;
+use CommonsBooking\View\Location;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
 
 class ViewTest extends CustomPostTypeTest {
@@ -25,11 +26,12 @@ class ViewTest extends CustomPostTypeTest {
 	}
 	
 	public function test_viewsShortcodeInvocation() {
-		// TODO call Location:shortcode / Item:shortcode
-		// $body = ob_get_clean();
-		$body = '<p>Test</p>';
+		$result = Location::shortcode(); // / Item:shortcode
+		$body = ob_get_clean();
+		// $body = '<p>Test</p>';
 		$html = '<html><body>' . $body . '</body></html>';
 		
+		// naive way of testing html validity
 		$doc = new \DOMDocument();
 		$this->assertTrue($doc->loadHTML($html));
 	}

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -28,9 +28,10 @@ class ViewTest extends CustomPostTypeTest {
 		// TODO call Location:shortcode / Item:shortcode
 		// $body = ob_get_clean();
 		$body = '<p>Test</p>';
-		$doc = '<html><body>' . $body . '</body></html>';
+		$html = '<html><body>' . $body . '</body></html>';
 		
-		$this->assertTrue(new DOMDocument()->loadHTML($doc));
+		$doc = new DOMDocument();
+		$this->assertTrue($doc->loadHTML($html));
 	}
 
 	protected function setUp() : void {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -60,8 +60,8 @@ class ViewTest extends CustomPostTypeTest {
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+2 days midnight', $now ),
-			strtotime( '+3 days midnight', $now ),
+			strtotime( '+5 days midnight', $now ),
+			strtotime( '+6 days midnight', $now ),
 			Timeframe::BOOKABLE_ID,
 			'on',
 			'norep'
@@ -72,8 +72,8 @@ class ViewTest extends CustomPostTypeTest {
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+5 days midnight', $now ),
-			strtotime( '+6 days midnight', $now ),
+			strtotime( '+2 days midnight', $now ),
+			strtotime( '+3 days midnight', $now ),
 			Timeframe::BOOKABLE_ID,
 			'on',
 			'norep'

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -11,6 +11,7 @@ use CommonsBooking\Wordpress\CustomPostType\Timeframe;
 class ViewTest extends CustomPostTypeTest {
 
 	protected const bookingDaysInAdvance = 30;
+	protected const now = time();
 
 	public function testGetShortcodeDataWithFourRangesByItem() {
 		$shortCodeData = View::getShortcodeData( new Item( $this->itemId ), 'Item' );
@@ -18,7 +19,7 @@ class ViewTest extends CustomPostTypeTest {
 		$this->assertTrue( count( $shortCodeData[ $this->itemId ]['ranges'] ) == 4 );
 		
 		// Check for specific timeframe start date
-		$this->assertEquals( $shortCodeData[ $this->itemId ]['ranges'][0]['start_date'], strtotime( '+2 days midnight', $now ) );
+		$this->assertEquals( $shortCodeData[ $this->itemId ]['ranges'][0]['start_date'], strtotime( '+2 days midnight', $this->now ) );
 		
 	}
 
@@ -49,7 +50,7 @@ class ViewTest extends CustomPostTypeTest {
 	protected function setUp() : void {
 		parent::setUp();
 
-		$now = time();
+		$now = $this->now;
 
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -27,6 +27,9 @@ class ViewTest extends CustomPostTypeTest {
 		$shortCodeData = View::getShortcodeData( new Location( $this->locationId ), 'Location' );
 		$this->assertTrue( is_array( $shortCodeData[ $this->locationId ]['ranges'] ) );
 		$this->assertTrue( count( $shortCodeData[ $this->locationId ]['ranges'] ) == 4 );
+		
+		// Check for specific timeframe start date
+		$this->assertEquals( $shortCodeData[ $this->locationId ]['ranges'][0]['start_date'], strtotime( '+2 days midnight', $this->now ) );
 	}
 	
 	public function testShortcodeForLocationView() {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -26,9 +26,7 @@ class ViewTest extends CustomPostTypeTest {
 	}
 	
 	public function test_viewsShortcodeInvocation() {
-		$result = Location::shortcode(); // / Item:shortcode
-		$body = ob_get_clean();
-		// $body = '<p>Test</p>';
+		$body = Location::shortcode();
 		$html = '<html><body>' . $body . '</body></html>';
 		
 		// naive way of testing html validity

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -11,7 +11,7 @@ use CommonsBooking\Wordpress\CustomPostType\Timeframe;
 class ViewTest extends CustomPostTypeTest {
 
 	protected const bookingDaysInAdvance = 30;
-	protected const now = time();
+	protected $now;
 
 	public function testGetShortcodeDataWithFourRangesByItem() {
 		$shortCodeData = View::getShortcodeData( new Item( $this->itemId ), 'Item' );
@@ -50,7 +50,8 @@ class ViewTest extends CustomPostTypeTest {
 	protected function setUp() : void {
 		parent::setUp();
 
-		$now = $this->now;
+		$now = time();
+		$this->now = $now;
 
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -16,41 +16,16 @@ class ViewTest extends CustomPostTypeTest {
 		$shortCodeData = View::getShortcodeData( new Item( $this->itemId ), 'Item' );
 		$this->assertTrue( is_array( $shortCodeData[ $this->itemId ]['ranges'] ) );
 		$this->assertTrue( count( $shortCodeData[ $this->itemId ]['ranges'] ) == 4 );
+		
+		// Check for specific timeframe start date
+		$this->assertEquals( $shortCodeData[ $this->itemId ]['ranges'][0]['start_date'], strtotime( '+2 days midnight', $now ) );
+		
 	}
 
 	public function testGetShortcodeDataWithFourRangesByLocation() {
 		$shortCodeData = View::getShortcodeData( new Location( $this->locationId ), 'Location' );
 		$this->assertTrue( is_array( $shortCodeData[ $this->locationId ]['ranges'] ) );
 		$this->assertTrue( count( $shortCodeData[ $this->locationId ]['ranges'] ) == 4 );
-	}
-	
-	public function testGetShortcodeDataWithUnorderedRangesByItem() {
-		// Adds another timeframe (but not in order of start-date)
-		$now = time();
-		$timeframeId = $this->createTimeframe(
-			$this->locationId,
-			$this->itemId,
-			strtotime( '+16 days midnight', $now ),
-			strtotime( '+17 days midnight', $now ),
-			Timeframe::BOOKABLE_ID,
-			'on',
-			'norep'
-		);
-		// set booking days in advance
-		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );	
-		
-		// Check for all timeframes
-		$shortCodeData = View::getShortcodeData( new Item( $this->itemId ), 'Item' );
-		
-		$ranges = $shortCodeData[ $this->itemId ]['ranges'];
-		$this->assertTrue( is_array( $ranges ) );
-		$this->assertEquals( count( $ranges ), 5 );
-		
-		// Check for specific timeframe start date
-		$this->assertEquals( $ranges[5]['start_date'], strtotime( '+4 days midnight', $now ) );
-		
-		// tearDown
-		wp_delete_post( $timeframeId );
 	}
 	
 	public function testShortcodeForLocationView() {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -24,8 +24,17 @@ class ViewTest extends CustomPostTypeTest {
 		$this->assertTrue( count( $shortCodeData[ $this->locationId ]['ranges'] ) == 4 );
 	}
 	
-	public function test_viewsShortcodeInvocation() {
+	public function testShortcodeForLocationView() {
 		$body = \CommonsBooking\View\Location::shortcode( array() );
+		$html = '<html><body>' . $body . '</body></html>';
+		
+		// naive way of testing html validity
+		$doc = new \DOMDocument();
+		$this->assertTrue($doc->loadHTML($html));
+	}
+	
+	public function testShortcodeForItemView() {
+		$body = \CommonsBooking\View\Item::shortcode( array() );
 		$html = '<html><body>' . $body . '</body></html>';
 		
 		// naive way of testing html validity

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -6,7 +6,6 @@ use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use CommonsBooking\View\View;
-use CommonsBooking\View\Location;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
 
 class ViewTest extends CustomPostTypeTest {
@@ -26,7 +25,7 @@ class ViewTest extends CustomPostTypeTest {
 	}
 	
 	public function test_viewsShortcodeInvocation() {
-		$body = Location::shortcode();
+		$body = \CommonsBooking\View\Location::shortcode();
 		$html = '<html><body>' . $body . '</body></html>';
 		
 		// naive way of testing html validity

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -24,6 +24,33 @@ class ViewTest extends CustomPostTypeTest {
 		$this->assertTrue( count( $shortCodeData[ $this->locationId ]['ranges'] ) == 4 );
 	}
 	
+	public function testGetShortcodeDataWithUnorderedRangesByItem() {
+		// Adds another timeframe (but not in order of start-date)
+		$now = time();
+		$timeframeId = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '+4 days midnight', $now ),
+			strtotime( '+5 days midnight', $now ),
+			Timeframe::BOOKABLE_ID,
+			'on',
+			'norep'
+		);
+		// set booking days in advance
+		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );	
+		
+		// Check for all timeframes
+		$shortCodeData = View::getShortcodeData( new Item( $this->itemId ), 'Item' );
+		$this->assertTrue( is_array( $shortCodeData[ $this->itemId ]['ranges'] ) );
+		$this->assertTrue( count( $shortCodeData[ $this->itemId ]['ranges'] ) == 5 );
+		
+		// Check for specific timeframe start date
+		$this->assertEquals( $shortCodeData[ $this->itemId]['ranges'][1]['start_date'], strtotime( '+4 days midnight', $now ) );
+		
+		// tearDown
+		wp_delete_post( $timeframeId );
+	}
+	
 	public function testShortcodeForLocationView() {
 		$body = \CommonsBooking\View\Location::shortcode( array() );
 		$html = '<html><body>' . $body . '</body></html>';

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -30,7 +30,7 @@ class ViewTest extends CustomPostTypeTest {
 		$body = '<p>Test</p>';
 		$html = '<html><body>' . $body . '</body></html>';
 		
-		$doc = new DOMDocument();
+		$doc = new \DOMDocument();
 		$this->assertTrue($doc->loadHTML($html));
 	}
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -25,7 +25,7 @@ class ViewTest extends CustomPostTypeTest {
 	}
 	
 	public function test_viewsShortcodeInvocation() {
-		$body = \CommonsBooking\View\Location::shortcode();
+		$body = \CommonsBooking\View\Location::shortcode( array() );
 		$html = '<html><body>' . $body . '</body></html>';
 		
 		// naive way of testing html validity

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -34,8 +34,10 @@ class ViewTest extends CustomPostTypeTest {
 		$html = '<html><body>' . $body . '</body></html>';
 		
 		// naive way of testing html validity
+		libxml_use_internal_errors(true);
 		$doc = new \DOMDocument();
 		$this->assertTrue($doc->loadHTML($html));
+		$this->assertEquals( 0, count( libxml_get_errors() ));
 	}
 	
 	public function testShortcodeForItemView() {
@@ -43,8 +45,10 @@ class ViewTest extends CustomPostTypeTest {
 		$html = '<html><body>' . $body . '</body></html>';
 		
 		// naive way of testing html validity
+		libxml_use_internal_errors(true);
 		$doc = new \DOMDocument();
 		$this->assertTrue($doc->loadHTML($html));
+		$this->assertEquals( 0, count( libxml_get_errors() ));
 	}
 
 	protected function setUp() : void {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -23,6 +23,15 @@ class ViewTest extends CustomPostTypeTest {
 		$this->assertTrue( is_array( $shortCodeData[ $this->locationId ]['ranges'] ) );
 		$this->assertTrue( count( $shortCodeData[ $this->locationId ]['ranges'] ) == 4 );
 	}
+	
+	public function test_viewsShortcodeInvocation() {
+		// TODO call Location:shortcode / Item:shortcode
+		// $body = ob_get_clean();
+		$body = '<p>Test</p>';
+		$doc = '<html><body>' . $body . '</body></html>';
+		
+		$this->assertTrue(new DOMDocument()->loadHTML($doc));
+	}
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -30,8 +30,8 @@ class ViewTest extends CustomPostTypeTest {
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+4 days midnight', $now ),
-			strtotime( '+5 days midnight', $now ),
+			strtotime( '+16 days midnight', $now ),
+			strtotime( '+17 days midnight', $now ),
 			Timeframe::BOOKABLE_ID,
 			'on',
 			'norep'
@@ -41,11 +41,13 @@ class ViewTest extends CustomPostTypeTest {
 		
 		// Check for all timeframes
 		$shortCodeData = View::getShortcodeData( new Item( $this->itemId ), 'Item' );
-		$this->assertTrue( is_array( $shortCodeData[ $this->itemId ]['ranges'] ) );
-		$this->assertTrue( count( $shortCodeData[ $this->itemId ]['ranges'] ) == 5 );
+		
+		$ranges = $shortCodeData[ $this->itemId ]['ranges'];
+		$this->assertTrue( is_array( $ranges ) );
+		$this->assertEquals( count( $ranges ), 5 );
 		
 		// Check for specific timeframe start date
-		$this->assertEquals( $shortCodeData[ $this->itemId]['ranges'][1]['start_date'], strtotime( '+4 days midnight', $now ) );
+		$this->assertEquals( $ranges[5]['start_date'], strtotime( '+4 days midnight', $now ) );
 		
 		// tearDown
 		wp_delete_post( $timeframeId );


### PR DESCRIPTION
Entfernt überflüssiges Sortieren `getShortcodeData` gibt bereits nach `startdate` sortierte Ranges raus.