### PR TITLE
Enhancement/issue 1248

### DIFF
--- a/assets/public/sass/partials/_forms.scss
+++ b/assets/public/sass/partials/_forms.scss
@@ -81,7 +81,7 @@
         }
     }
 
-    input.cb-action-canceled {
+    input.cb-action-canceled, input.cb-action-delete_unconfirmed {
         background-color: var(--commonsbooking-color-cancel);
         box-shadow: none !important;
         font-size: 0.875rem;

--- a/src/Exception/BookingDeniedException.php
+++ b/src/Exception/BookingDeniedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CommonsBooking\Exception;
+
+class BookingDeniedException extends \Exception
+{
+
+}

--- a/src/Exception/OverlappingException.php
+++ b/src/Exception/OverlappingException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace CommonsBooking\Exception;
-
-class OverlappingException extends \Exception {
-
-}

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -354,23 +354,8 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		$currentStatus    = $this->post->post_status;
 		$cancellationTime = $this->getMeta( 'cancellation_time' );
 
-        if ( get_transient( 'commonsbookig_overlappingBooking_' . $this->post->ID ) && $currentStatus === 'unconfirmed' ) {
-            $noticeText = commonsbooking_sanitizeHTML( __( 'The booking could not be confirmed because there is an overlapping booking in this period.', 'commonsbooking' ) );
-        }
-
-  		if ( $currentStatus == 'unconfirmed' ) {
-            // transient is set in \Model\Booking->handleFormRequest if overlapping booking exists
-            if ( get_transient( 'commonsbooking_overlappingBooking_' . $this->post->ID ) ) {
-                $noticeText = commonsbooking_sanitizeHTML( __( 
-                    '<h1 style="color:red">Notice:</h1> <p>We are sorry. Something went wrong. This booking could not be confirmed because there is another overlapping booking.<br>
-                    Please click the "Cancel"-Button and select another booking period.</p>
-                    <p>Normally, the booking system ensures that no overlapping bookings can be created. If you think there is a bug, please contact the contact persons of this website.</p> 
-                ', 'commonsbooking' ) );
-
-                delete_transient( 'commonsbooking_overlappingBooking_' . $this->post->ID );
-            } else {
+    		if ( $currentStatus == 'unconfirmed' ) {
                 $noticeText = commonsbooking_sanitizeHTML( __( 'Please check your booking and click confirm booking', 'commonsbooking' ) );
-            }
 		} elseif ( $currentStatus == 'confirmed' ) {
 			$noticeText = commonsbooking_sanitizeHTML( Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_templates', 'booking-confirmed-notice' ) );
 		}

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -281,6 +281,28 @@ class Booking extends View {
 		return ob_get_clean();
 	}
 
+	/**
+	 * Renders error for frontend notice. We use transients to pass the error message.
+	 * It is ensured that only the user where the error occurred can see the error message.
+	 */
+	public static function renderError() {
+		$errorTypes = [
+			\CommonsBooking\Wordpress\CustomPostType\Booking::ERROR_TYPE . '-' . get_current_user_id()
+		];
+
+		foreach ($errorTypes as $errorType) {
+			if ($error = get_transient($errorType)) {
+				$class = 'cb-notice error';
+				printf(
+					'<div class="%1$s"><p>%2$s</p></div>',
+					esc_attr($class),
+					nl2br(commonsbooking_sanitizeHTML($error))
+				);
+				delete_transient($errorType);
+			}
+		}
+	}
+
 	public static function getBookingListiCal($user = null):String{
 		$eventTitle_unparsed = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title' );
 		$eventDescription_unparsed = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_desc' );

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -232,6 +232,7 @@ class Booking extends Timeframe {
 				if ( ( ! $isEdit || count( $existingBookings ) > 1 ) && $post_status != 'canceled' ) {
                     if ($booking) {
                         $post_status = 'unconfirmed';
+						//TODO: Check if we can replace this transient with throwing a BookingDeniedException
                         set_transient( 'commonsbooking_overlappingBooking_' . $booking->ID, $booking->ID );
                     } else {
                         throw new BookingDeniedException( __('There is already a booking in this timerange.', 'commonsbooking') );

--- a/templates/booking-single-form.php
+++ b/templates/booking-single-form.php
@@ -3,9 +3,9 @@
  * This template is called in the method \CommonsBooking\Model\Booking\booking_action_buttons($form_action)
  */
 
-if ( $current_status === 'unconfirmed' && $form_action === 'cancel' ) {
-    $form_post_status = 'canceled';
-    $button_label     = esc_html__( 'Cancel', 'commonsbooking' );
+if ( $current_status === 'unconfirmed' && $form_action === 'delete_unconfirmed' ) {
+    $form_post_status = 'delete_unconfirmed';
+    $button_label     = esc_html__( 'Cancel booking process', 'commonsbooking' );
 }
 
 if ( $current_status === 'unconfirmed' && $form_action === 'confirm' ) {

--- a/templates/booking-single.php
+++ b/templates/booking-single.php
@@ -191,7 +191,8 @@ if ( $current_status && $current_status !== 'draft' ) {
 
 		// if booking is unconfirmed cancel link throws user back to item detail page
 		if ( $booking->post_status() == 'unconfirmed' ) {
-			echo '<a href="' . esc_url( get_permalink( $item->ID ) ) . '">' . esc_html__( 'Cancel', 'commonsbooking' ) . '</a>';
+            $form_action = 'delete_unconfirmed';
+            include COMMONSBOOKING_PLUGIN_DIR . 'templates/booking-single-form.php';
 		} else {
 			// if booking is confirmed we display the cancel booking button
 			$form_action = 'cancel';

--- a/templates/item-single.php
+++ b/templates/item-single.php
@@ -11,6 +11,8 @@
 
     do_action( 'commonsbooking_before_item-single' );
 
+	\CommonsBooking\View\Booking::renderError();
+
     // Single Item View
     if(array_key_exists('location', $templateData) && $templateData['location']) { // item selected, so we display the booking calendar
         echo '<h2>' . esc_html__( $bookThisItemText, 'commonsbooking') . '</h2>';


### PR DESCRIPTION
@hansmorb  Ich hab jetzt doch deinen enhanced-Branch genommen und dort meine Transient-Teile gelöscht. Das Exception-Handling funktioniert aus meiner Sicht gut und so wie es soll. Habe noch nen Cancel-Button für unconfirmed-Bookings hinzugefügt, mit dem die unconfirmed Buchung direkt gelöscht wird und wir so die Overlapping-Fehler generell auch nochmal vermindern können.