### PR TITLE
added unit tests for cache invalidation

### DIFF
--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -58,7 +58,7 @@ class Wordpress {
 	 */
 	public static function getPostIdArray($posts): array {
 		 return array_map( function ( $post ) {
-			return strval($post->ID);
+			return intval($post->ID);
 		}, $posts);
 	}
 
@@ -95,9 +95,7 @@ class Wordpress {
 		// Remove empty tags
 		$postIds = array_filter($postIds);
 
-		return array_map( function ( $postId ) {
-			return strval($postId);
-		}, $postIds);
+		return array_map( 'strval', $postIds );
 	}
 
 	/**
@@ -119,6 +117,7 @@ class Wordpress {
 
 	/**
 	 * Returns all post ids in relation to $postId.
+	 * CAREFUL: This will not get the location that the item is in relation to.
 	 * @param $postId
 	 *
 	 * @return array
@@ -207,7 +206,9 @@ class Wordpress {
 			$relatedPostIds = array_merge($relatedPostIds, Wordpress::getPostIdArray($timeframes));
 		}
 
-		return $relatedPostIds;
+		return array_unique(
+			array_map( 'intval', $relatedPostIds)
+		);
 	}
 
 	/**
@@ -256,7 +257,7 @@ class Wordpress {
 				true
 			);
 		});
-		return $itemsAndLocations;
+		return array_map('intval', $itemsAndLocations);
 	}
 
 	/**

--- a/src/Repository/Restriction.php
+++ b/src/Repository/Restriction.php
@@ -182,6 +182,9 @@ class Restriction extends PostRepository {
 	/**
 	 * Filters posts by locations and items.
 	 *
+	 * WARNING: This method will filter out posts that are only queried by item OR location.
+	 * Meaning, if a restriction is created that has a location and an item, but the query only contains the location, the restriction will not be returned.
+	 *
 	 * @param array $posts
 	 * @param array $locations
 	 * @param array $items

--- a/tests/Helper/WordpressTest.php
+++ b/tests/Helper/WordpressTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace CommonsBooking\Tests\Helper;
+
+use CommonsBooking\Helper\Wordpress;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * These are unit tests for the helper class WordPress.
+ * The methods tested are mainly used to get related posts for cache invalidation.
+ */
+class WordpressTest extends CustomPostTypeTest
+{
+
+	private int $timeframeId;
+	private int $bookingId;
+	private int $restrictionId;
+
+    public function testGetRelatedPostsIdsForItem() {
+	    $related = Wordpress::getRelatedPostsIdsForItem( $this->itemId );
+	    $this->assertIsArray( $related );
+	    $this->assertContains( $this->bookingId, $related );
+	    $this->assertContains( $this->timeframeId, $related );
+		//We cannot search for the restriction, because the restriction repository will filter out queries where we are not searching for both the item and the corresponding location.
+	    //@see \CommonsBooking\Repository\Restriction::filterPosts()
+	    //$this->assertContains( $this->restrictionId, $related );
+	    $this->assertEquals( 3, count( $related ) );
+    }
+
+    public function testGetRelatedPostsIdsForTimeframe()
+    {
+		$related = Wordpress::getRelatedPostsIdsForTimeframe( $this->timeframeId );
+		$this->assertIsArray( $related );
+	    $this->assertContains( $this->timeframeId, $related );
+	    $this->assertContains( $this->itemId, $related );
+		$this->assertContains( $this->locationId, $related );
+		$this->assertEquals( 3, count( $related ) );
+    }
+
+    public function testGetLocationAndItemIdsFromPosts()
+    {
+		//test for timeframe with single assigned item / location
+		$timeframePost = get_post( $this->timeframeId );
+		$related = Wordpress::getLocationAndItemIdsFromPosts( [$timeframePost] );
+		$this->assertIsArray( $related );
+		$this->assertContains( $this->itemId, $related );
+		$this->assertContains( $this->locationId, $related );
+		$this->assertEquals( 2, count( $related ) );
+    }
+
+    public function testGetRelatedPostsIdsForLocation()
+    {
+		$related = Wordpress::getRelatedPostsIdsForLocation( $this->locationId );
+		$this->assertIsArray( $related );
+		$this->assertContains( $this->locationId, $related );
+		$this->assertContains( $this->timeframeId, $related );
+		$this->assertContains( $this->bookingId, $related );
+		//We cannot search for the restriction, because the restriction repository will filter out queries where we are not searching for both the item and the corresponding location.
+	    //@see \CommonsBooking\Repository\Restriction::filterPosts()
+		//$this->assertContains( $this->restrictionId, $related );
+	    $this->assertEquals( 3, count( $related ) );
+    }
+
+    public function testGetRelatedPostsIdsForBooking()
+    {
+		$related = Wordpress::getRelatedPostsIdsForBooking( $this->bookingId );
+		$this->assertIsArray( $related );
+		$this->assertContains( $this->bookingId, $related );
+		$this->assertContains( $this->itemId, $related );
+		$this->assertContains( $this->locationId, $related );
+		$this->assertContains( $this->timeframeId, $related );
+		$this->assertEquals( 4, count( $related ));
+    }
+
+    public function testGetRelatedPostsIdsForRestriction()
+    {
+		$related = Wordpress::getRelatedPostsIdsForRestriction( $this->restrictionId );
+		$this->assertIsArray( $related );
+		$this->assertContains( $this->itemId, $related );
+		$this->assertContains( $this->locationId, $related );
+		$this->assertContains( $this->timeframeId, $related);
+		$this->assertContains( $this->bookingId, $related);
+		$this->assertContains( $this->restrictionId, $related);
+		$this->assertEquals( 5, count( $related ));
+    }
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->timeframeId = $this->createBookableTimeFrameIncludingCurrentDay();
+		$this->bookingId = $this->createConfirmedBookingStartingToday();
+		$this->restrictionId = 	$this->createRestriction(
+			"hint",
+			$this->locationId,
+			$this->itemId,
+			strtotime(self::CURRENT_DATE),
+			strtotime("+1 day", strtotime(self::CURRENT_DATE))
+		);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+}

--- a/tests/Repository/RestrictionTest.php
+++ b/tests/Repository/RestrictionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CommonsBooking\Tests\Repository;
+
+use CommonsBooking\Repository\Restriction;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use PHPUnit\Framework\TestCase;
+
+class RestrictionTest extends CustomPostTypeTest
+{
+
+	protected $timeframeId;
+	protected $restrictionId;
+
+	/**
+	 * We cannot test the getting for items and locations separately, because the filterPosts method in the restriction repository will filter
+	 * out queries where we are not searching for both the item and the corresponding location.
+	 *
+	 * @see \CommonsBooking\Repository\Restriction::filterPosts()
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function testGetByItemAndLocation()
+	{
+	    $restrictions = Restriction::get( [$this->locationId], [$this->itemId]);
+	    $this->assertIsArray( $restrictions );
+	    $this->assertEquals( 1, count( $restrictions ) );
+	    $this->assertEquals( $this->restrictionId, $restrictions[0]->ID );
+	}
+
+
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->timeframeId = $this->createBookableTimeFrameIncludingCurrentDay();
+		$this->restrictionId = 	$this->createRestriction(
+			"hint",
+			$this->locationId,
+			$this->itemId,
+			strtotime(self::CURRENT_DATE),
+			strtotime("+1 day", strtotime(self::CURRENT_DATE))
+		);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+}

--- a/tests/Repository/TimeframeTest.php
+++ b/tests/Repository/TimeframeTest.php
@@ -11,11 +11,14 @@ class TimeframeTest extends CustomPostTypeTest {
 
 	const REPETITION_END = '1661472000';
 
+	protected int $timeframeId;
+	protected int $timeframe2Id;
+
 	protected function setUp() : void {
 		parent::setUp();
 
 		// Timeframe with enddate
-		$this->createTimeframe(
+		$this->timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
 			self::REPETITION_START,
@@ -23,7 +26,7 @@ class TimeframeTest extends CustomPostTypeTest {
 		);
 
 		// Timeframe without enddate
-		$this->createTimeframe(
+		$this->timeframe2Id = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
 			self::REPETITION_START,
@@ -38,6 +41,48 @@ class TimeframeTest extends CustomPostTypeTest {
 	public function testGetInRange() {
 		$inRangeTimeFrames = Timeframe::getInRange(self::REPETITION_START, self::REPETITION_END);
 		$this->assertTrue(count($inRangeTimeFrames) == 2);
+		$postIds = array_map(function($timeframe) {
+			return $timeframe->ID;
+		}, $inRangeTimeFrames);
+		$this->assertContains($this->timeframeId, $postIds);
+		$this->assertContains($this->timeframe2Id, $postIds);
 	}
 
+	public function testGetForItem() {
+		$inItemTimeframes = Timeframe::get(
+			[],
+			[$this->itemId],
+		);
+		$this->assertEquals(2,count($inItemTimeframes));
+		$postIds = array_map(function($timeframe) {
+			return $timeframe->ID;
+		}, $inItemTimeframes);
+		$this->assertContains($this->timeframeId, $postIds);
+		$this->assertContains($this->timeframe2Id, $postIds);
+	}
+
+	public function testGetForLocation() {
+		$inLocationTimeframes = Timeframe::get(
+			[$this->locationId],
+		);
+		$this->assertEquals(2,count($inLocationTimeframes));
+		$postIds = array_map(function($timeframe) {
+			return $timeframe->ID;
+		}, $inLocationTimeframes);
+		$this->assertContains($this->timeframeId, $postIds);
+		$this->assertContains($this->timeframe2Id, $postIds);
+	}
+
+	public function testGetForLocationAndItem() {
+		$inLocationAndItemTimeframes = Timeframe::get(
+			[$this->locationId],
+			[$this->itemId],
+		);
+		$this->assertEquals(2,count($inLocationAndItemTimeframes));
+		$postIds = array_map(function($timeframe) {
+			return $timeframe->ID;
+		}, $inLocationAndItemTimeframes);
+		$this->assertContains($this->timeframeId, $postIds);
+		$this->assertContains($this->timeframe2Id, $postIds);
+	}
 }


### PR DESCRIPTION
Der Cache erwartet anscheined stringvals, da aber die getRelatedPostIds schon stringval benutzt, habe ich mir das hier gespart.

So kann ich das auch einfacher Unit testen.

Ich bewahre hier mehr den Status quo, die Tests sind an den aktuellen Ergebnissen der Funktion orientiert. Ganz genau bin ich in der Funktionsweise noch nicht durchgestiegen.