### PR TITLE
#1302 moved cacheItem to variable

### DIFF
--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -70,8 +70,9 @@ class Calendar {
 		);
 
 
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$weeks = [];
 			while ( $startDate <= $endDate ) {

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -485,8 +485,9 @@ class Day {
 	protected function getTimeframeSlots(): array {
 		$customCacheKey = $this->getDate() . serialize( $this->items ) . serialize( $this->locations );
 		$customCacheKey = md5( $customCacheKey );
-		if ( Plugin::getCacheItem( $customCacheKey ) ) {
-			return Plugin::getCacheItem( $customCacheKey );
+		$cacheItem     = Plugin::getCacheItem( $customCacheKey );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$slots       = [];
 			$slotsPerDay = 24;

--- a/src/Model/Week.php
+++ b/src/Model/Week.php
@@ -68,8 +68,9 @@ class Week {
 			serialize( $this->types )
 		);
 
-		if (Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 
 			$yearTimestamp = mktime(0,0,0, 1, 1, $this->year);

--- a/src/Repository/BookablePost.php
+++ b/src/Repository/BookablePost.php
@@ -39,8 +39,9 @@ abstract class BookablePost extends PostRepository {
 
 		$customId = md5( $current_user->ID . static::getPostType() );
 
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			// Get all Locations where current user is author
 			$args = array(
@@ -140,8 +141,9 @@ abstract class BookablePost extends PostRepository {
 	public static function getByUserId( $userId, bool $asModel = false ): array {
 		$cbPosts = [];
 
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$userId = intval( $userId );
 			// Get all Locations where current user is author
@@ -213,8 +215,9 @@ abstract class BookablePost extends PostRepository {
 
 		$customCacheKey = md5( serialize( $args ) );
 
-		if ( Plugin::getCacheItem( $customCacheKey ) ) {
-			return Plugin::getCacheItem( $customCacheKey );
+		$cacheItem = Plugin::getCacheItem( $customCacheKey );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$defaults = array(
 				'post_status' => array( 'publish', 'inherit' ),
@@ -265,8 +268,9 @@ abstract class BookablePost extends PostRepository {
 			$postId = $postId->ID;
 		}
 
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$posts = self::getRelatedPosts( $postId, $originType, $relatedType );
 			foreach ( $posts as $key => &$relatedPost ) {
@@ -305,8 +309,9 @@ abstract class BookablePost extends PostRepository {
 			$postId = $postId->ID;
 		}
 
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$relatedPosts   = [];
 			$relatedPostIds = [];

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -328,8 +328,9 @@ class Booking extends PostRepository {
 	public static function getForUser( $user, bool $asModel = false, $startDate = null ): array {
 		$customId = $user->ID;
 
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$posts = self::get(
 				[],

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -29,8 +29,9 @@ class BookingCodes {
 	 * @return array
 	 */
 	public static function getCodes( $timeframeId ): array {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 
 			$startDate = date( 'Y-m-d', intval( get_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::REPETITION_START, true ) ) );
@@ -80,8 +81,9 @@ class BookingCodes {
 	 * @return BookingCode|mixed|null
 	 */
 	public static function getCode( $timeframeId, $itemId, $locationId, $date ) {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			global $wpdb;
 			$table_name = $wpdb->prefix . self::$tablename;

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -20,8 +20,9 @@ abstract class PostRepository {
 	 * @throws \Psr\Cache\InvalidArgumentException
 	 */
 	public static function getPostById( $postId ) {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$post = get_post( $postId );
 

--- a/src/Repository/Restriction.php
+++ b/src/Repository/Restriction.php
@@ -25,8 +25,9 @@ class Restriction extends PostRepository {
 	): array {
 		$customCacheKey = serialize( $postStatus );
 
-		if ( Plugin::getCacheItem( $customCacheKey ) ) {
-			return Plugin::getCacheItem( $customCacheKey );
+		$cacheItem = Plugin::getCacheItem( $customCacheKey );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 
 			$posts = self::queryPosts( $date, $minTimestamp, $postStatus );
@@ -63,8 +64,9 @@ class Restriction extends PostRepository {
 	 * @return array|object|null
 	 */
 	private static function queryPosts( $date, $minTimestamp, $postStatus ) {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			global $wpdb;
 			$table_posts = $wpdb->prefix . 'posts';

--- a/src/Repository/Timeframe.php
+++ b/src/Repository/Timeframe.php
@@ -120,8 +120,9 @@ class Timeframe extends PostRepository {
 		}
 
 		$customId = md5( serialize( $types ) );
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 
 			$posts = [];
@@ -181,8 +182,9 @@ class Timeframe extends PostRepository {
 		}
 
 		$customId = md5( serialize( $types ) );
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			global $wpdb;
 			$table_postmeta = $wpdb->prefix . 'postmeta';
@@ -267,8 +269,9 @@ class Timeframe extends PostRepository {
 	 * @return array
 	 */
 	private static function getPostsByBaseParams( ?string $date, ?int $minTimestamp, ?int $maxTimestamp, array $postIds, array $postStatus ): array {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			global $wpdb;
 			$table_postmeta = $wpdb->prefix . 'postmeta';
@@ -449,8 +452,9 @@ class Timeframe extends PostRepository {
 	 * @throws \Psr\Cache\InvalidArgumentException
 	 */
 	private static function filterTimeframesByConfiguredDays( array $posts, ?string $date ): array {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			if ( $date ) {
 				$posts = array_filter( $posts, function ( $post ) use ( $date ) {
@@ -550,8 +554,9 @@ class Timeframe extends PostRepository {
 	 * @throws Exception
 	 */
 	public static function getByLocationItemTimestamp( int $locationId, int $itemId, int $timestamp ): ?\CommonsBooking\Model\Timeframe {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$time_format        = esc_html(get_option( 'time_format' ));
 			$startTimestampTime = date( $time_format, $timestamp );
@@ -617,8 +622,9 @@ class Timeframe extends PostRepository {
 		}
 
 		$customId = md5( serialize( $types ) );
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$posts = [];
 

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -81,8 +81,9 @@ class Booking extends View {
 			serialize( $user->ID )
 		);
 
-		if ( Plugin::getCacheItem( $customId ) ) {
-			return Plugin::getCacheItem( $customId );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$bookingDataArray             = [];
 			$bookingDataArray['page']     = $page;

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -131,8 +131,9 @@ class Calendar {
 				// loop through location
 				foreach ( $locations as $locationId => $locationName ) {
 					$customCacheKey = $item->ID . $locationId . $today;
-					if ( Plugin::getCacheItem($customCacheKey) ) {
-						$rowHtml .= Plugin::getCacheItem($customCacheKey);
+					$cacheItem     = Plugin::getCacheItem( $customCacheKey );
+					if ( $cacheItem ) {
+						$rowHtml .= $cacheItem;
 					} else {
 						// Check for category term
 						if ( $locationCategory ) {
@@ -231,8 +232,9 @@ class Calendar {
 	 * @throws Exception
 	 */
 	protected static function renderItemLocationRow( $item, $locationId, $locationName, $today, $last_day, $days, $days_display ): string {
-		if ( Plugin::getCacheItem() ) {
-			return Plugin::getCacheItem();
+		$cacheItem = Plugin::getCacheItem();
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$divider  = "</td><td>";
 			$itemName = $item->post_title;

--- a/src/View/Item.php
+++ b/src/View/Item.php
@@ -25,8 +25,9 @@ class Item extends View {
 		$location  = get_query_var( 'cb-location' ) ?: false;
 		$customId = md5($item->ID . $location);
 
-		if ( Plugin::getCacheItem($customId) ) {
-			return Plugin::getCacheItem($customId);
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$locations = \CommonsBooking\Repository\Location::getByItem( $item->ID, true );
 			$locationIds = array_map(

--- a/src/View/Location.php
+++ b/src/View/Location.php
@@ -25,8 +25,9 @@ class Location extends View {
 		$item     = get_query_var( 'cb-item' ) ?: false;
 		$customId = md5($item . $location->ID);
 
-		if ( Plugin::getCacheItem($customId) ) {
-			return Plugin::getCacheItem($customId);
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem ) {
+			return $cacheItem;
 		} else {
 			$items    = \CommonsBooking\Repository\Item::getByLocation( $location->ID, true );
 			$itemIds = array_map(


### PR DESCRIPTION
closes #1302 

Ich habe das gemacht, weil die Fehlermeldung in der verlinkten issue sehr stark darauf schließen lässt, dass sich der Cache Wert zwischen den Abfragen verändert hat. Sowieso wäre es ja vielleicht gut nicht zweimal auf das gleiche Cache Element zuzugreifen wenn es nicht nötig ist, oder? Vor allem weil die meisten ja einen langsamen filesystem Cache nutzen.