### PR TITLE
GBFS: fix URL prefix for GBFS root / Discovery endpoint

### DIFF
--- a/src/API/GBFS/Discovery.php
+++ b/src/API/GBFS/Discovery.php
@@ -47,7 +47,7 @@ class Discovery extends \CommonsBooking\API\BaseRoute {
 	private function get_feed( $name ): stdClass {
 		$feed = new stdClass();
 		$feed->name = $name;
-		$feed->url = site_url() . '/wp-json/commonsbooking/v1/' . $name . '.json';
+		$feed->url = get_rest_url() . 'commonsbooking/v1/' . $name . '.json';
 		return $feed;
 	}
 }


### PR DESCRIPTION
The asumption `site_url() . '/wp-json/' == get_rest_url()` is not always true, esp. when the site uses a prefix.