### PR TITLE
Trigger release action only on semantic versions

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -3,7 +3,7 @@ name: Deploy to WordPress.org
 on:
   push:
     tags:
-    - "*"
+      - "v*.*.*"
     
 jobs:
   deploy:


### PR DESCRIPTION
So it doesn't get triggered accidentally.