### PR TITLE
Fixes missing tiles and positiong on map

### DIFF
--- a/assets/map/js/cb-map-locationview.js
+++ b/assets/map/js/cb-map-locationview.js
@@ -15,9 +15,9 @@ var cb_map_locationview = {
         }, 500); });
 
         // create the tile layer with correct attribution
-        var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        var osmUrl = 'https://{s}.tile.osm.org/{z}/{x}/{y}.png';
         var osmAttrib = 'Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
-        var osm = new L.TileLayer(osmUrl, {minZoom: 10, maxZoom: 19, attribution: osmAttrib});
+        var osm = new L.TileLayer(osmUrl, {minZoom: 10, maxZoom: 17, attribution: osmAttrib});
 
         map.setView(new L.LatLng(latitude, longitude), 18);
         map.addLayer(osm);

--- a/assets/map/js/cb-map-locationview.js
+++ b/assets/map/js/cb-map-locationview.js
@@ -7,6 +7,13 @@ var cb_map_locationview = {
         // set up the map
         map = new L.Map('cb_locationview_map');
 
+        // TODO generalize this part into method/class construct (see cb-map-positioning.js)
+        // possible fix to avoid missing tiles, found on: https://stackoverflow.com/questions/38832273/leafletjs-not-loading-all-tiles-until-moving-map
+        // also see https://github.com/wielebenwir/commonsbooking/issues/1060
+        map.on("load", function() { setTimeout(() => {
+            map.invalidateSize();
+        }, 500); });
+
         // create the tile layer with correct attribution
         var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
         var osmAttrib = 'Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';

--- a/assets/map/js/cb-map-positioning.js
+++ b/assets/map/js/cb-map-positioning.js
@@ -10,9 +10,10 @@ var cb_map_positioning = {
         const self = this;
         
         // possible fix to avoid missing tiles, found on: https://stackoverflow.com/questions/38832273/leafletjs-not-loading-all-tiles-until-moving-map
-        map.on("load",function() { setTimeout(() => {
+        // also see https://github.com/wielebenwir/commonsbooking/issues/1060
+        map.on("load", function() { setTimeout(() => {
             map.invalidateSize();
-        }, 1); });
+        }, 500); });
 
         // create the tile layer with correct attribution
         var osmUrl = 'https://{s}.tile.osm.org/{z}/{x}/{y}.png';


### PR DESCRIPTION
This increases the timeout of the callback to Map-'load'-event, which eventually invalidates the size of the map to trigger a repaint.