### PR TITLE
Refactors possible constant

### DIFF
--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -52,7 +52,7 @@ class Calendar {
 
 		// defines the number of days shown in the calendar table view. If not set, default is 31 days
 		// TODO: max days should be made configurable in options
-		$days = is_array( $atts ) && array_key_exists( 'days', $atts ) ? $atts['days'] : 31;
+		$days = is_array( $atts ) && array_key_exists( 'days', $atts ) ? $atts['days'] : \CommonsBooking\Wordpress\CustomPostType\Timeframe::ADVANCE_BOOKING_DAYS;
 
 		$desc  = $atts['desc'] ?? '';
 		$date  = Wordpress::getUTCDateTimeByTimestamp( current_time( 'timestamp' ) );

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -3,7 +3,6 @@
 
 namespace CommonsBooking\View;
 
-use CommonsBooking\CB\CB;
 use CommonsBooking\Helper\Helper;
 use CommonsBooking\Helper\Wordpress;
 use CommonsBooking\Model\CustomPost;
@@ -13,11 +12,13 @@ use CommonsBooking\Plugin;
 use CommonsBooking\Wordpress\CustomPostType\Item;
 use CommonsBooking\Wordpress\CustomPostType\Location;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
-use DateInterval;
-use DateTime;
+
 use Exception;
 use WP_Post;
 
+/**
+ * Different methods to render shortcode view on item availabilities, with calls to repository/model layer.
+ */
 class Calendar {
 
 	/**
@@ -35,7 +36,7 @@ class Calendar {
 	 * Many thanks to fLotte Berlin!
 	 * Forked from https://github.com/flotte-berlin/cb-shortcodes/blob/master/custom-shortcodes-cb-items.php
 	 *
-	 * @param $atts
+	 * @param array $atts assoc array for mainly passing query params.
 	 *
 	 * @return string
 	 * @throws Exception


### PR DESCRIPTION
Mit der Diskussion um https://github.com/wielebenwir/commonsbooking/pull/1359 habe ich nochmal den Code nach möglichen Vorkommen von 31 durchsucht. Wenn ich es richtig verstehe müsste das doch die ADVANCE_BOOKING_DAYS Konstante sein?

Das Todo von @chriwen ist aber noch nicht gelöst, da die allgemein Einstellung 31 als Default ja nicht über das Backend veränderbar ist. Sondern nur als meta für jeden Timeframe. Oder wie war das gemeint @chriwen?