### PR TITLE
Fix:  GBFS: Availability wird nicht berücksichtigt #1332 

### DIFF
--- a/src/API/AvailabilityRoute.php
+++ b/src/API/AvailabilityRoute.php
@@ -39,10 +39,14 @@ class AvailabilityRoute extends BaseRoute {
 	/**
 	 * This retrieves bookable timeframes and the different items assigned, with their respective availability.
 	 *
+	 * @param bool $id The id of a \CommonsBooking\Wordpress\CustomPostType\Item::post_type post to search for
+	 * @param null $startTime The start date of the calendar to get the data for
+	 * @param null $endTime The end date of the calendar to get the data for
+	 *
+	 * @return array
 	 * @throws Exception
 	 */
 	public function getItemData( $id = false ): array {
-		$slots    = [];
 		$calendar = new Calendar(
 			new Day( date( 'Y-m-d', time() ) ),
 			new Day( date( 'Y-m-d', strtotime( '+2 weeks' ) ) ), // TODO why two weeks? seems like a configurable option
@@ -50,50 +54,7 @@ class AvailabilityRoute extends BaseRoute {
 			$id ? [ $id ] : []
 		);
 
-		$doneSlots = [];
-		/** @var Week $week */
-		foreach ( $calendar->getWeeks() as $week ) {
-			/** @var Day $day */
-			foreach ( $week->getDays() as $day ) {
-				foreach ( $day->getGrid() as $slot ) {
-					$timeframe     = new Timeframe( $slot['timeframe'] );
-					$timeFrameType = get_post_meta( $slot['timeframe']->ID, 'type', true );
-
-					if ( $timeFrameType != \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID ) {
-						continue;
-					}
-					$availabilitySlot = new stdClass();
-
-					// Init DateTime object for start
-					$dateTimeStart = Wordpress::getUTCDateTime('now');
-					$dateTimeStart->setTimestamp( $slot['timestampstart'] );
-					$availabilitySlot->start = $dateTimeStart->format( 'Y-m-d\TH:i:sP' );
-
-					// Init DateTime object for end
-					$dateTimeend = Wordpress::getUTCDateTime('now');
-					$dateTimeend->setTimestamp( $slot['timestampend'] );
-					$availabilitySlot->end = $dateTimeend->format( 'Y-m-d\TH:i:sP' );
-
-					$availabilitySlot->locationId = "";
-					if ( $timeframe->getLocation() ) {
-						$availabilitySlot->locationId = $timeframe->getLocation()->ID . "";
-					}
-
-					$availabilitySlot->itemId = "";
-					if ( $timeframe->getItem() ) {
-						$availabilitySlot->itemId = $timeframe->getItem()->ID . "";
-					}
-
-					$slotId = md5( serialize( $availabilitySlot ) );
-					if ( ! in_array( $slotId, $doneSlots ) ) {
-						$doneSlots[] = $slotId;
-						$slots[]     = $availabilitySlot;
-					}
-				}
-			}
-		}
-
-		return $slots;
+		return $calendar->getAvailabilitySlots();
 	}
 
 	/**

--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -51,8 +51,6 @@ class StationStatus extends BaseRoute {
 	 * or can only be booked through overbooking.
 	 * This is because the GBFS spec only accounts for items available in that instant.
 	 *
-	 * TODO: If an item is booked from 08:00AM to 10:00AM, it will be shown as available before and after, regardless of the grid set in the timeframe.
-	 *       This means that an item that can only be booked for two hours each day will be shown as available for the rest of the day.
 	 * @param $locationId
 	 *
 	 * @return int|null

--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -4,6 +4,7 @@
 namespace CommonsBooking\API\GBFS;
 
 
+use CommonsBooking\Model\Day;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Repository\Item;
 use Geocoder\Exception\Exception;
@@ -32,9 +33,10 @@ class StationStatus extends BaseRoute {
 	 * @throws \Exception
 	 */
 	public function prepare_item_for_response( $item, $request ): stdClass {
+		$today                             = new Day(date( 'Y-m-d', time()), [$item->ID], Item::getByLocation( $item->ID ) );
 		$preparedItem                      = new stdClass();
 		$preparedItem->station_id          = $item->ID . "";
-		$preparedItem->num_bikes_available = count( Item::getByLocation( $item->ID ) ); // TODO should be the item availability in this moment
+		$preparedItem->num_bikes_available = count ($today->getBookableItems()); // TODO should be the item availability in this moment
 		$preparedItem->is_installed        = true;
 		$preparedItem->is_renting          = true;
 		$preparedItem->is_returning        = true;

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -53,6 +53,11 @@ class Calendar {
 	 * @param array $types
 	 */
 	public function __construct( Day $startDate, Day $endDate, array $locations = [], array $items = [], array $types = [] ) {
+		//check, that it spans at least two days
+		if ( $startDate->getDate() == $endDate->getDate() ) {
+			throw new \InvalidArgumentException( 'Calendar must span at least two days' );
+		}
+
 		$this->startDate = $startDate;
 		$this->endDate   = $endDate;
 		$this->items     = $items;
@@ -105,7 +110,11 @@ class Calendar {
 
 	/**
 	 * Will retrieve the respective availability slots for a given calendar.
-	 * This is used to display availabilites for the API routes.
+	 * This is used to display availabilities for the API routes.
+	 *
+	 * Because we process the calendar by weeks, at least two days are needed to get a valid calendar.
+	 * The calendar does not consider the individual boundaries set by $startDate and $endDate but will always return a full week.
+	 *
 	 * @return array
 	 * @throws \Exception
 	 */

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -133,6 +133,12 @@ class Calendar {
 					if ( $timeFrameType != \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID ) {
 						continue;
 					}
+
+					//Skip timeframes that are not bookable today
+					if ( $timeframe->getFirstBookableDay() > $day->getDate() ) {
+						continue;
+					}
+
 					$availabilitySlot = new stdClass();
 
 					// Init DateTime object for start

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -477,6 +477,25 @@ class Day {
 	}
 
 	/**
+	 * Will get all IDS of items that are bookable on this day.
+	 * Bookable means, that they would be marked green in the calendar.
+	 *
+	 * @return int[]
+	 */
+	public function getBookableItems () {
+		$bookableItems = [];
+
+		foreach ($this->getTimeframes() as $timeframe) {
+			$item = $timeframe->getItem();
+			if ($item) {
+				$bookableItems[] = $item->ID;
+			}
+		}
+
+		return array_unique($bookableItems);
+	}
+
+	/**
 	 * Returns array of timeslots filled with timeframes.
 	 *
 	 * @return array

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -484,15 +484,16 @@ class Day {
 	 */
 	public function getBookableItems () {
 		$bookableItems = [];
-
-		foreach ($this->getTimeframes() as $timeframe) {
-			$item = $timeframe->getItem();
-			if ($item) {
-				$bookableItems[] = $item->ID;
+		$grid          = $this->getGrid();
+		foreach ( $grid as $slot) {
+			if ($slot['timeframe']->post_type === Timeframe::$postType) {
+				$itemId = get_post_meta($slot['timeframe']->ID, 'item-id', true);
+				if ($itemId) {
+					$bookableItems[] = $itemId;
+				}
 			}
 		}
-
-		return array_unique($bookableItems);
+		return $bookableItems;
 	}
 
 	/**

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -98,7 +98,9 @@ class Day {
 	}
 
 	/**
-	 * Returns array with timeframes.
+	 * Returns array with timeframes relevant for the Day.
+	 * This function will only be able to run once.
+	 * When on the first try, no Timeframes are found, it will set it to an empty array
 	 * @return array
 	 * @throws Exception
 	 */
@@ -474,26 +476,6 @@ class Day {
 				unset( $slots[ $slotNr ] );
 			}
 		}
-	}
-
-	/**
-	 * Will get all IDS of items that are bookable on this day.
-	 * Bookable means, that they would be marked green in the calendar.
-	 *
-	 * @return int[]
-	 */
-	public function getBookableItems () {
-		$bookableItems = [];
-		$grid          = $this->getGrid();
-		foreach ( $grid as $slot) {
-			if ($slot['timeframe']->post_type === Timeframe::$postType) {
-				$itemId = get_post_meta($slot['timeframe']->ID, 'item-id', true);
-				if ($itemId) {
-					$bookableItems[] = $itemId;
-				}
-			}
-		}
-		return $bookableItems;
 	}
 
 	/**

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -819,7 +819,7 @@ class Timeframe extends CustomPost {
     /**
      * Returns first bookable day based on the defined booking startday offset in timeframe
      *
-     * @return date string Y-m-d
+     * @return string  date format Y-m-d
      */
     public function getFirstBookableDay() {
         $offset = $this->getFieldValue( 'booking-startday-offset' ) ?: 0;

--- a/src/Repository/BookablePost.php
+++ b/src/Repository/BookablePost.php
@@ -256,7 +256,7 @@ abstract class BookablePost extends PostRepository {
 	 * @param $relatedType
 	 * @param bool $bookable
 	 *
-	 * @return array
+	 * @return int[] Array of post ids
 	 * @throws Exception
 	 */
 	protected static function getByRelatedPost( $postId, $originType, $relatedType, bool $bookable = false ): array {

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -517,7 +517,7 @@ class Calendar {
 	/**
 	 * Processes day for calendar view of json.
 	 *
-	 * @param $day
+	 * @param Day $day
 	 * @param $lastBookableDate
 	 * @param $endDate
 	 * @param $jsonResponse

--- a/tests/php/API/GBFS/StationStatusTest.php
+++ b/tests/php/API/GBFS/StationStatusTest.php
@@ -33,10 +33,6 @@ class StationStatusTest extends CustomPostTypeTest
 
 		//now let's book the current day and check, that the station is empty
 		$this->createConfirmedBookingStartingToday();
-		//we set the time to lunch, because the booking start at 08:00AM. If we set the time to 00:00AM, the booking would not be recognized
-		//This is regardless of the fact if more than one booking is available today or not
-		$currDate->setTime(12,0,0);
-		ClockMock::freeze( $currDate );
 		$stationStatus = $routeObject->prepare_item_for_response($locationObject, null);
 		$this->assertEquals(0, $stationStatus->num_bikes_available);
 

--- a/tests/php/API/GBFS/StationStatusTest.php
+++ b/tests/php/API/GBFS/StationStatusTest.php
@@ -13,10 +13,6 @@ class StationStatusTest extends CustomPostTypeTest
 
     public function testPrepare_item_for_response()
     {
-
-    }
-
-	public function testGetBookableItems() {
 		$currDate = new \DateTime( self::CURRENT_DATE );
 		$locationObject = new Location($this->locationId);
 		ClockMock::freeze( $currDate );

--- a/tests/php/API/GBFS/StationStatusTest.php
+++ b/tests/php/API/GBFS/StationStatusTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\API\GBFS\StationStatus;
+use CommonsBooking\Model\Day;
+use CommonsBooking\Model\Location;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use SlopeIt\ClockMock\ClockMock;
+
+class StationStatusTest extends CustomPostTypeTest
+{
+
+    public function testPrepare_item_for_response()
+    {
+
+    }
+
+	public function testGetBookableItems() {
+		$currDate = new \DateTime( self::CURRENT_DATE );
+		$locationObject = new Location($this->locationId);
+		ClockMock::freeze( $currDate );
+		$routeObject = new StationStatus();
+		$spanningTimeframe = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+10 days', strtotime( self::CURRENT_DATE ) )
+		);
+		$stationStatus = $routeObject->prepare_item_for_response($locationObject, null);
+		$this->assertEquals($this->locationId, $stationStatus->station_id);
+		$this->assertEquals(1, $stationStatus->num_bikes_available);
+		$this->assertTrue($stationStatus->is_installed);
+		$this->assertTrue($stationStatus->is_renting);
+		$this->assertTrue($stationStatus->is_returning);
+		$this->assertEquals(current_time('timestamp'), $stationStatus->last_reported);
+
+		//now let's book the current day and check, that the station is empty
+		$this->createConfirmedBookingStartingToday();
+		//we set the time to lunch, because the booking start at 08:00AM. If we set the time to 00:00AM, the booking would not be recognized
+		//This is regardless of the fact if more than one booking is available today or not
+		$currDate->setTime(12,0,0);
+		ClockMock::freeze( $currDate );
+		$stationStatus = $routeObject->prepare_item_for_response($locationObject, null);
+		$this->assertEquals(0, $stationStatus->num_bikes_available);
+
+
+		//the timeframe has ended now, so the station should be empty
+		$currDate->modify('+11 days');
+		ClockMock::freeze( $currDate );
+		$stationStatus = $routeObject->prepare_item_for_response($locationObject, null);
+		$this->assertEquals(0, $stationStatus->num_bikes_available);
+
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+}

--- a/tests/php/API/GBFS/StationStatusTest.php
+++ b/tests/php/API/GBFS/StationStatusTest.php
@@ -70,9 +70,7 @@ class StationStatusTest extends CustomPostTypeTest
 		//remove the offset and the station should have the item
 	    update_post_meta($timeframeID, 'booking-startday-offset', 0);
 		$stationStatus = $routeObject->prepare_item_for_response(new Location($otherLocationId), null);
-
-
-
+		$this->assertEquals(1, $stationStatus->num_bikes_available);
 	}
 
 	protected function setUp(): void {

--- a/tests/php/Model/BookingTest.php
+++ b/tests/php/Model/BookingTest.php
@@ -389,6 +389,8 @@ class BookingTest extends CustomPostTypeTest {
 			$this->itemId,
 			strtotime( '+1 day',  strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+2 days', strtotime( self::CURRENT_DATE ) ),
+			'08:00 AM',
+			'12:00 PM'
 		);
 		$this->testBookingFixedDate = new Booking( get_post( $this->testFixedDateBooking ) );
 		$this->subscriberBookingInFuture = new Booking(

--- a/tests/php/Model/CalendarTest.php
+++ b/tests/php/Model/CalendarTest.php
@@ -8,6 +8,7 @@ use CommonsBooking\Model\Calendar;
 
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
+use SlopeIt\ClockMock\ClockMock;
 
 
 /**
@@ -33,41 +34,43 @@ class CalendarTest extends CustomPostTypeTest {
 	}
 
 	public function testGetAvailabilitySlots() {
-		$yesterday = date( 'Y-m-d', strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ) );
-		$tomorrow = date( 'Y-m-d', strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ) );
-		$this->calendar = new Calendar(
-			new Day($yesterday, [$this->locationId], [$this->itemId]),
-			new Day($tomorrow, [$this->locationId], [$this->itemId]),
+		$this->createBookableTimeFrameIncludingCurrentDay();
+		$this->createBookableTimeFrameStartingInAWeek();
+		$yesterday         = date( 'Y-m-d', strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ) );
+		$tomorrow          = date( 'Y-m-d', strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ) );
+		$this->calendar    = new Calendar(
+			new Day( $yesterday, [ $this->locationId ], [ $this->itemId ] ),
+			new Day( $tomorrow, [ $this->locationId ], [ $this->itemId ] ),
 			[ $this->locationId ],
 			[ $this->itemId ]
 		);
 		$availabilitySlots = $this->calendar->getAvailabilitySlots();
-		$yesterdayEnd = $this->getEndOfDayTimestamp($yesterday);
-		$todayEnd = $this->getEndOfDayTimestamp(self::CURRENT_DATE);
-		$tomorrowEnd = $this->getEndOfDayTimestamp($tomorrow);
+		$yesterdayEnd      = $this->getEndOfDayTimestamp( $yesterday );
+		$todayEnd          = $this->getEndOfDayTimestamp( self::CURRENT_DATE );
+		$tomorrowEnd       = $this->getEndOfDayTimestamp( $tomorrow );
 
 		$this->assertEquals( 3, count( $availabilitySlots ) );
 		$expectedSlotObject = [
 			(object) [
-				'start' => date('Y-m-d\TH:i:sP', strtotime($yesterday)),
-				'end' => date('Y-m-d\TH:i:sP', $yesterdayEnd),
-				'itemId' => $this->itemId,
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( $yesterday ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', $yesterdayEnd ),
+				'itemId'     => $this->itemId,
 				'locationId' => $this->locationId
 			],
 			(object) [
-				'start' => date('Y-m-d\TH:i:sP', strtotime(self::CURRENT_DATE)),
-				'end' => date('Y-m-d\TH:i:sP', $todayEnd),
-				'itemId' => $this->itemId,
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( self::CURRENT_DATE ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', $todayEnd ),
+				'itemId'     => $this->itemId,
 				'locationId' => $this->locationId
 			],
 			(object) [
-				'start' => date('Y-m-d\TH:i:sP', strtotime($tomorrow)),
-				'end' => date('Y-m-d\TH:i:sP', $tomorrowEnd),
-				'itemId' => $this->itemId,
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( $tomorrow ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', $tomorrowEnd ),
+				'itemId'     => $this->itemId,
 				'locationId' => $this->locationId
 			]
 		];
-		$this->assertEquals($expectedSlotObject, $availabilitySlots);
+		$this->assertEquals( $expectedSlotObject, $availabilitySlots );
 
 		//now let's book the current day and check, that only yesterday is available
 		$this->createConfirmedBookingStartingToday();
@@ -75,20 +78,19 @@ class CalendarTest extends CustomPostTypeTest {
 		$this->assertEquals( 1, count( $availabilitySlots ) );
 		$expectedSlotObject = [
 			(object) [
-				'start' => date('Y-m-d\TH:i:sP', strtotime($yesterday)),
-				'end' => date('Y-m-d\TH:i:sP', $yesterdayEnd),
-				'itemId' => $this->itemId,
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( $yesterday ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', $yesterdayEnd ),
+				'itemId'     => $this->itemId,
 				'locationId' => $this->locationId
 			]
 		];
-		$this->assertEquals($expectedSlotObject, $availabilitySlots);
+		$this->assertEquals( $expectedSlotObject, $availabilitySlots );
+	}
 
-		//test with hourly available timeframe, we create a new item and location for that test to prevent overlapping with next week
-		$itemID = $this->createItem("Hourly Item",'publish');
-		$locationID = $this->createLocation("Hourly Location",'publish');
+	public function testGetAvailabilitySlotsWithHourlyTimeframe() {
 		$this->createTimeframe(
-			$locationID,
-			$itemID,
+			$this->locationId,
+			$this->itemId,
 			strtotime( self::CURRENT_DATE ),
 			strtotime( self::CURRENT_DATE ),
 			Timeframe::BOOKABLE_ID,
@@ -98,29 +100,143 @@ class CalendarTest extends CustomPostTypeTest {
 			'8:00 AM',
 			'12:00 PM'
 		);
-		$start = new \DateTime( self::CURRENT_DATE);
-		$start->setTime(8,0,0);
-		$end = new \DateTime( self::CURRENT_DATE);
-		$end->setTime(24,0,0);
-		$expectedPeriod = new \DatePeriod(
+		$start = new \DateTime( self::CURRENT_DATE );
+		$start->setTime( 8, 0, 0 );
+		$end = new \DateTime( self::CURRENT_DATE );
+		$end->setTime( 24, 0, 0 );
+		$expectedPeriod    = new \DatePeriod(
 			$start,
-			new \DateInterval('PT1H'),
+			new \DateInterval( 'PT1H' ),
 			$end
 		);
-		$this->calendar = new Calendar(
-			new Day($start->format('Y-m-d'), [$locationID], [$itemID]),
+		$this->calendar    = new Calendar(
+			new Day( $start->format( 'Y-m-d' ), [ $this->locationId ], [ $this->itemId ] ),
 			//we do this because the calendar needs to span at least one day
-			new Day(date('Y-m-d', strtotime('+1 day', $end->getTimestamp())), [$locationID], [$itemID]),
-			[ $locationID ],
-			[ $itemID ]
+			new Day( date( 'Y-m-d', strtotime( '+1 day', $end->getTimestamp() ) ), [ $this->locationId ], [ $this->itemId ] ),
+			[ $this->locationId ],
+			[ $this->itemId ]
 		);
 		$availabilitySlots = $this->calendar->getAvailabilitySlots();
-		$this->assertEquals( iterator_count($expectedPeriod), count( $availabilitySlots ) );
+		$this->assertEquals( iterator_count( $expectedPeriod ), count( $availabilitySlots ) );
+	}
+
+	public function testGetAvailabilitySlotsWithOffset() {
+		//check with offset, first two days should not be marked as bookable
+		$offsetTF = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( self::CURRENT_DATE ) ,
+			strtotime( '+1 week', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			"on",
+			'd',
+			0,
+			'8:00 AM',
+			'12:00 PM',
+			'publish',
+			[],
+			self::USER_ID,
+			3,
+			30,
+			2
+		);
+		$now = new \DateTime( self::CURRENT_DATE );
+		ClockMock::freeze( $now );
+		$this->calendar = new Calendar(
+			new Day($now->format('Y-m-d'), [$this->locationId], [$this->itemId]),
+			new Day(date('Y-m-d', strtotime('+1 weeks', strtotime(self::CURRENT_DATE))), [$this->locationId], [$this->itemId]),
+			[ $this->locationId ],
+			[ $this->itemId ]
+		);
+		$availabilitySlots = $this->calendar->getAvailabilitySlots();
+		$expectedSlotsObject = [
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+2 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+2 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+3 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+3 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+4 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+4 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+5 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+5 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+6 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+6 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+7 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+7 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			]
+		];
+		$this->assertEquals( $expectedSlotsObject, $availabilitySlots );
+	}
+
+	public function testGetAvailabilitySlotsWithHoliday() {
+		$this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( self::CURRENT_DATE ) ,
+			strtotime( '+4 days', strtotime( self::CURRENT_DATE ) ),
+		);
+		$this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			Timeframe::HOLIDAYS_ID
+		);
+		$now = new \DateTime( self::CURRENT_DATE );
+		ClockMock::freeze( $now );
+		$this->calendar = new Calendar(
+			new Day($now->format('Y-m-d'), [$this->locationId], [$this->itemId]),
+			new Day(date('Y-m-d', strtotime('+1 week', strtotime(self::CURRENT_DATE))), [$this->locationId], [$this->itemId]),
+			[ $this->locationId ],
+			[ $this->itemId ]
+		);
+		$availabilitySlots = $this->calendar->getAvailabilitySlots();
+		$expectedSlotsObject = [
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+2 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+2 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+3 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+3 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start'      => date( 'Y-m-d\TH:i:sP', strtotime( '+4 days', $now->getTimestamp() ) ),
+				'end'        => date( 'Y-m-d\TH:i:sP', strtotime( '+4 days 23:59:59', $now->getTimestamp() ) ),
+				'itemId'     => $this->itemId,
+				'locationId' => $this->locationId
+			]
+		];
+		$this->assertEquals( $expectedSlotsObject, $availabilitySlots );
 	}
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->createBookableTimeFrameIncludingCurrentDay();
-		$this->createBookableTimeFrameStartingInAWeek();
 	}
 }

--- a/tests/php/Model/CalendarTest.php
+++ b/tests/php/Model/CalendarTest.php
@@ -7,6 +7,7 @@ use CommonsBooking\Model\Week;
 use CommonsBooking\Model\Calendar;
 
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use CommonsBooking\Wordpress\CustomPostType\Timeframe;
 
 
 /**
@@ -29,5 +30,97 @@ class CalendarTest extends CustomPostTypeTest {
 			),
 			$this->calendar->getWeeks()
 		);
+	}
+
+	public function testGetAvailabilitySlots() {
+		$yesterday = date( 'Y-m-d', strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ) );
+		$tomorrow = date( 'Y-m-d', strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ) );
+		$this->calendar = new Calendar(
+			new Day($yesterday, [$this->locationId], [$this->itemId]),
+			new Day($tomorrow, [$this->locationId], [$this->itemId]),
+			[ $this->locationId ],
+			[ $this->itemId ]
+		);
+		$availabilitySlots = $this->calendar->getAvailabilitySlots();
+		$yesterdayEnd = $this->getEndOfDayTimestamp($yesterday);
+		$todayEnd = $this->getEndOfDayTimestamp(self::CURRENT_DATE);
+		$tomorrowEnd = $this->getEndOfDayTimestamp($tomorrow);
+
+		$this->assertEquals( 3, count( $availabilitySlots ) );
+		$expectedSlotObject = [
+			(object) [
+				'start' => date('Y-m-d\TH:i:sP', strtotime($yesterday)),
+				'end' => date('Y-m-d\TH:i:sP', $yesterdayEnd),
+				'itemId' => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start' => date('Y-m-d\TH:i:sP', strtotime(self::CURRENT_DATE)),
+				'end' => date('Y-m-d\TH:i:sP', $todayEnd),
+				'itemId' => $this->itemId,
+				'locationId' => $this->locationId
+			],
+			(object) [
+				'start' => date('Y-m-d\TH:i:sP', strtotime($tomorrow)),
+				'end' => date('Y-m-d\TH:i:sP', $tomorrowEnd),
+				'itemId' => $this->itemId,
+				'locationId' => $this->locationId
+			]
+		];
+		$this->assertEquals($expectedSlotObject, $availabilitySlots);
+
+		//now let's book the current day and check, that only yesterday is available
+		$this->createConfirmedBookingStartingToday();
+		$availabilitySlots = $this->calendar->getAvailabilitySlots();
+		$this->assertEquals( 1, count( $availabilitySlots ) );
+		$expectedSlotObject = [
+			(object) [
+				'start' => date('Y-m-d\TH:i:sP', strtotime($yesterday)),
+				'end' => date('Y-m-d\TH:i:sP', $yesterdayEnd),
+				'itemId' => $this->itemId,
+				'locationId' => $this->locationId
+			]
+		];
+		$this->assertEquals($expectedSlotObject, $availabilitySlots);
+
+		//test with hourly available timeframe, we create a new item and location for that test to prevent overlapping with next week
+		$itemID = $this->createItem("Hourly Item",'publish');
+		$locationID = $this->createLocation("Hourly Location",'publish');
+		$this->createTimeframe(
+			$locationID,
+			$itemID,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( self::CURRENT_DATE ),
+			Timeframe::BOOKABLE_ID,
+			'off',
+			"d",
+			1,
+			'8:00 AM',
+			'12:00 PM'
+		);
+		$start = new \DateTime( self::CURRENT_DATE);
+		$start->setTime(8,0,0);
+		$end = new \DateTime( self::CURRENT_DATE);
+		$end->setTime(24,0,0);
+		$expectedPeriod = new \DatePeriod(
+			$start,
+			new \DateInterval('PT1H'),
+			$end
+		);
+		$this->calendar = new Calendar(
+			new Day($start->format('Y-m-d'), [$locationID], [$itemID]),
+			//we do this because the calendar needs to span at least one day
+			new Day(date('Y-m-d', strtotime('+1 day', $end->getTimestamp())), [$locationID], [$itemID]),
+			[ $locationID ],
+			[ $itemID ]
+		);
+		$availabilitySlots = $this->calendar->getAvailabilitySlots();
+		$this->assertEquals( iterator_count($expectedPeriod), count( $availabilitySlots ) );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->createBookableTimeFrameIncludingCurrentDay();
+		$this->createBookableTimeFrameStartingInAWeek();
 	}
 }

--- a/tests/php/Model/CalendarTest.php
+++ b/tests/php/Model/CalendarTest.php
@@ -119,6 +119,18 @@ class CalendarTest extends CustomPostTypeTest {
 		);
 		$availabilitySlots = $this->calendar->getAvailabilitySlots();
 		$this->assertEquals( iterator_count( $expectedPeriod ), count( $availabilitySlots ) );
+
+		//book two hours and check that the slots are not available
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '10:00 AM', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '01:00 PM', strtotime( self::CURRENT_DATE ) ),
+			'10:00 AM',
+			'01:00 PM'
+		);
+		$availabilitySlots = $this->calendar->getAvailabilitySlots();
+		$this->assertEquals( iterator_count( $expectedPeriod ) - 3, count( $availabilitySlots ) );
 	}
 
 	public function testGetAvailabilitySlotsWithOffset() {

--- a/tests/php/Model/DayTest.php
+++ b/tests/php/Model/DayTest.php
@@ -65,6 +65,32 @@ class DayTest extends CustomPostTypeTest {
 		parent::tearDown();
 	}
 
+	public function testGetBookableItems() {
+		$this->assertCount( 1, $this->instance->getBookableItems() );
+
+		//create separate item / location for the other tests because that norep stuff seems broken to me
+		$secondLocation = $this->createLocation("second location",'publish');
+		$secondItem = $this->createItem("second item",'publish');
+		$this->createBookableTimeFrameIncludingCurrentDay($secondLocation,$secondItem);
+		$day = new Day(
+			self::CURRENT_DATE,
+			[ $secondLocation ],
+			[ $secondItem ]
+		);
+		$this->assertCount( 1, $day->getBookableItems() );
+
+		$inTwoDays = new Day(
+			date( 'Y-m-d', strtotime( '+2 days', strtotime( self::CURRENT_DATE ) ) ),
+			[ $secondLocation ],
+			[ $secondItem ]
+		);
+		$this->assertEmpty( $inTwoDays->getBookableItems() );
+
+		//now, let's book tomorrow
+		$this->createConfirmedBookingStartingToday($secondLocation,$secondItem);
+		$this->assertEmpty( $day->getBookableItems() );
+	}
+
 	public function testGetFormattedDate() {
 		$this->assertTrue( self::CURRENT_DATE == $this->instance->getFormattedDate( 'd.m.Y' ) );
 	}

--- a/tests/php/Model/DayTest.php
+++ b/tests/php/Model/DayTest.php
@@ -65,32 +65,6 @@ class DayTest extends CustomPostTypeTest {
 		parent::tearDown();
 	}
 
-	public function testGetBookableItems() {
-		$this->assertCount( 1, $this->instance->getBookableItems() );
-
-		//create separate item / location for the other tests because that norep stuff seems broken to me
-		$secondLocation = $this->createLocation("second location",'publish');
-		$secondItem = $this->createItem("second item",'publish');
-		$this->createBookableTimeFrameIncludingCurrentDay($secondLocation,$secondItem);
-		$day = new Day(
-			self::CURRENT_DATE,
-			[ $secondLocation ],
-			[ $secondItem ]
-		);
-		$this->assertCount( 1, $day->getBookableItems() );
-
-		$inTwoDays = new Day(
-			date( 'Y-m-d', strtotime( '+2 days', strtotime( self::CURRENT_DATE ) ) ),
-			[ $secondLocation ],
-			[ $secondItem ]
-		);
-		$this->assertEmpty( $inTwoDays->getBookableItems() );
-
-		//now, let's book tomorrow
-		$this->createConfirmedBookingStartingToday($secondLocation,$secondItem);
-		$this->assertEmpty( $day->getBookableItems() );
-	}
-
 	public function testGetFormattedDate() {
 		$this->assertTrue( self::CURRENT_DATE == $this->instance->getFormattedDate( 'd.m.Y' ) );
 	}

--- a/tests/php/View/CalendarTest.php
+++ b/tests/php/View/CalendarTest.php
@@ -82,6 +82,45 @@ class CalendarTest extends CustomPostTypeTest {
 		$this->assertTrue($jsonresponse['minDate'] == date('Y-m-d'));
 	}
 
+	public function testBookingOffset() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ));
+		$startDate = date( 'Y-m-d', strtotime( '-1 day', strtotime(self::CURRENT_DATE) ) );
+		$today = date( 'Y-m-d', strtotime( self::CURRENT_DATE ) );
+		$endDate   = date( 'Y-m-d', strtotime( '+60 days midnight', strtotime(self::CURRENT_DATE) ) );
+		$otherItemId = $this->createItem("Other Item",'publish');
+		$otherLocationId = $this->createLocation("Other Location",'publish');
+		$offsetTF = $this->createTimeframe(
+			$otherLocationId,
+			$otherItemId,
+			strtotime($startDate),
+			strtotime($endDate),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			"on",
+			'd',
+			0,
+			'8:00 AM',
+			'12:00 PM',
+			'publish',
+			[],
+			self::USER_ID,
+			3,
+			30,
+			2
+		);
+		$jsonresponse = Calendar::getCalendarDataArray(
+			$otherItemId,
+			$otherLocationId,
+			$startDate,
+			$endDate
+		);
+		//considering the advance booking days
+		$days = $jsonresponse['days'];
+		$this->assertEquals(32, count($days));
+		//considering the offset, today and tomorrow should be locked
+		$this->assertTrue($days[$today]['locked']);
+		$this->assertTrue($days[date('Y-m-d', strtotime('+1 day', strtotime($today)))]['locked']);
+	}
+
 	protected function setUp() : void {
 		parent::setUp();
 

--- a/tests/php/View/CalendarTest.php
+++ b/tests/php/View/CalendarTest.php
@@ -6,6 +6,7 @@ use CommonsBooking\Model\Timeframe;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use CommonsBooking\View\Calendar;
 use DateTime;
+use SlopeIt\ClockMock\ClockMock;
 
 /**
  * @TODO: Write test for restriction cache invalidation.

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -136,6 +136,10 @@ abstract class CustomPostTypeTest extends TestCase {
 		return $restrictionId;
 	}
 
+	/**
+	 * Creates booking from -1 day -> +1 day midnight (relative to self::CURRENT_DATE)
+	 * @return int|\WP_Error
+	 */
 	protected function createConfirmedBookingEndingToday() {
 		return $this->createBooking(
 			$this->locationId,
@@ -145,6 +149,10 @@ abstract class CustomPostTypeTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Creates booking from -1 day -> +2 days midnight (relative to self::CURRENT_DATE)
+	 * @return int|\WP_Error
+	 */
 	protected function createUnconfirmedBookingEndingTomorrow() {
 		return $this->createBooking(
 			$this->locationId,
@@ -162,8 +170,8 @@ abstract class CustomPostTypeTest extends TestCase {
 		$itemId,
 		$repetitionStart,
 		$repetitionEnd,
-		$startTime = '8:00 AM',
-		$endTime = '12:00 PM',
+		$startTime = '0:00 AM',
+		$endTime = '23:59 PM',
 		$postStatus = 'confirmed',
 		$postAuthor = self::USER_ID,
 		$timeframeRepetition = 'w',
@@ -201,6 +209,13 @@ abstract class CustomPostTypeTest extends TestCase {
 		return strtotime( '+1 day midnight', strtotime( $date ) ) - 1;
 	}
 
+	/**
+	 * Creates booking from midnight -> +2 days (relative to self::CURRENT_DATE)
+	 * @param $locationId
+	 * @param $itemId
+	 *
+	 * @return int|\WP_Error
+	 */
 	protected function createConfirmedBookingStartingToday($locationId = null, $itemId = null) {
 		if ( $locationId === null ) {
 			$locationId = $this->locationId;
@@ -216,6 +231,13 @@ abstract class CustomPostTypeTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Creates timeframe from -1 day -> +1 day (relative to self::CURRENT_DATE)
+	 * @param $locationId
+	 * @param $itemId
+	 *
+	 * @return int|\WP_Error
+	 */
 	protected function createBookableTimeFrameIncludingCurrentDay($locationId = null, $itemId = null) {
 		if ( $locationId === null ) {
 			$locationId = $this->locationId;
@@ -279,6 +301,13 @@ abstract class CustomPostTypeTest extends TestCase {
 		return [ $tf1, $tf2 ];
 	}
 
+	/**
+	 * Creates timeframe from +7 days -> +30 days (relative to self::CURRENT_DATE)
+	 * @param $locationId
+	 * @param $itemId
+	 *
+	 * @return int|\WP_Error
+	 */
 	protected function createBookableTimeFrameStartingInAWeek($locationId = null, $itemId = null) {
 		if ( $locationId === null ) {
 			$locationId = $this->locationId;

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -201,10 +201,16 @@ abstract class CustomPostTypeTest extends TestCase {
 		return strtotime( '+1 day midnight', strtotime( $date ) ) - 1;
 	}
 
-	protected function createConfirmedBookingStartingToday() {
+	protected function createConfirmedBookingStartingToday($locationId = null, $itemId = null) {
+		if ( $locationId === null ) {
+			$locationId = $this->locationId;
+		}
+		if ( $itemId === null ) {
+			$itemId = $this->itemId;
+		}
 		return $this->createBooking(
-			$this->locationId,
-			$this->itemId,
+			$locationId,
+			$itemId,
 			strtotime( 'midnight', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+2 days', strtotime( self::CURRENT_DATE ) )
 		);


### PR DESCRIPTION
Ziel dieses Fix ist es, dass nur Artikel, die tatsächlich gerade an der Station direkt ausleihbar wären auch als solchen angezeigt werden, weil die GBFS Spezifikationen das so fordern. 

Vor diesem Patch war es so, dass einfach alle Artikel an der Station angezeigt wurden. Unabhängig von Verfügbarkeit: Gebucht / Urlaub / Reperatur.

Zu diesem Zweck habe ich die API/AvailabilityRoute refactored und das Berechnen der verfügbaren Slots in die Model/Calendar Klasse ausgelagert. So kann diese Methode auch zum Berechnen der verfügbaren Artikel  für die GBFS API Route verwendet werden. Dabei werden immer nur die Daten für den heutigen Tag genommen, weil GBFS sich nicht für zukünftige Verfügbarkeiten interessiert.

Diese Methode hat vorher auch nicht das booking-offset mit einberechnet, dh., dass Artikel z.B. für den heutigen Tag als buchbar angezeigt wurden, obwohl sie einen Vorlauf von x Tagen haben. 

Das wurde umgebaut und die extrahierte Methode sowie die Methode für die GBFS Route mit Unit Tests versehen.

closes #1332 

