### PR TITLE
add action to build zip on release branch

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,0 +1,48 @@
+name: Build from release branch
+on:
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+
+    - uses: ruby/setup-ruby@v1
+      with:
+          ruby-version: '3.0.6' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: gem install compass
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+
+    - name: Compile with Grunt
+      uses: elstudio/actions-js-build/build@v4
+      with:
+        args: build
+
+    - name: Commit changes
+      uses: elstudio/actions-js-build/commit@v4
+      with:
+        commitMessage: Ran grunt 
+        
+    - name: Run build script
+      run: bin/build-zip.sh
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: commonsbooking.zip
+        path: ./commonsbooking.zip


### PR DESCRIPTION
Damit können wir bei einem Push auf einen release branch uns sofort eine Plugin zip generieren lassen, die war dann direkt zum Testen nutzen können bevor wir den release auf wordpress.org veröffentlichen.