### PR TITLE
#1388: fix last_updated / last_reported

### DIFF
--- a/src/API/GBFS/BaseRoute.php
+++ b/src/API/GBFS/BaseRoute.php
@@ -23,7 +23,7 @@ class BaseRoute extends \CommonsBooking\API\BaseRoute {
 		$data                 = new stdClass();
 		$data->data           = new stdClass();
 		$data->data->stations = $this->getItemData( $request );
-		$data->last_updated   = current_time('timestamp');
+		$data->last_updated   = current_time('timestamp', true);
 		$data->ttl            = 60;
 		$data->version        = "2.3";
 

--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -38,7 +38,7 @@ class StationStatus extends BaseRoute {
 		$preparedItem->is_installed        = true;
 		$preparedItem->is_renting          = true;
 		$preparedItem->is_returning        = true;
-		$preparedItem->last_reported       = current_time('timestamp');
+		$preparedItem->last_reported       = current_time('timestamp', true);
 
 		return $preparedItem;
 	}


### PR DESCRIPTION
Fixes the "easy" part of the issue, the wrong last_updated / last_reported GBFS field. 

The other part is the wrong status calculation. Here, I'm not sure in which timezone booking dates are supposed to be saved in the DB.