### PR TITLE
Upgrade Methoden umbauen

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -501,19 +501,6 @@ class Plugin {
 	}
 
 	/**
-	 * Gets location position for locations without coordinates.
-	 */
-	public static function updateLocationCoordinates() {
-		$locations = Repository\Location::get();
-
-		foreach ( $locations as $location ) {
-			if ( ! ( $location->getMeta( 'geo_latitude' ) && $location->getMeta( 'geo_longitude' ) ) ) {
-				$location->updateGeoLocation();
-			}
-		}
-	}
-
-	/**
 	 *  Init hooks.
 	 */
 	public function init() {

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -55,7 +55,7 @@ class Upgrade
 	 */
 	public function run(): bool {
 		// check if version has changed, or it is a new installation
-		if ( empty($this->currentVersion) || $this->previousVersion == $this->currentVersion ) {
+		if ( ! empty($this->previousVersion) && ( $this->previousVersion == $this->currentVersion  ) ) {
 			return false;
 		}
 

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -38,7 +38,8 @@ class Upgrade
 			[\CommonsBooking\Service\Scheduler::class, 'unscheduleOldEvents']
 		],
 		'2.8.2' => [
-			[self::class, 'resetBrokenColorScheme']
+			[self::class, 'resetBrokenColorScheme'],
+			[self::class, 'fixBrokenICalTitle']
 		]
 	];
 

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -5,7 +5,6 @@ namespace CommonsBooking\Service;
 use CommonsBooking\Model\Timeframe;
 use CommonsBooking\Plugin;
 use CommonsBooking\Settings\Settings;
-use CommonsBooking\Wordpress\CustomPostType\CustomPostType;
 use CommonsBooking\Wordpress\Options\AdminOptions;
 use Psr\Cache\InvalidArgumentException;
 
@@ -93,7 +92,7 @@ class Upgrade {
 	 *
 	 * @return void
 	 */
-	public function runUpgradeTasks() {
+	public function runUpgradeTasks() : void {
 		foreach ( self::$upgradeTasks as $version => $tasks ) {
 			if ( version_compare( $this->previousVersion, $version, '<' ) && version_compare( $this->currentVersion, $version, '>=' ) ) {
 				foreach ( $tasks as $task ) {
@@ -109,7 +108,7 @@ class Upgrade {
 	 *
 	 * @return void
 	 */
-	public static function runTasksAfterUpdate() {
+	public static function runTasksAfterUpdate() : void  {
 		$upgrade = new Upgrade(
 			esc_html( get_option( self::VERSION_OPTION ) ),
 			COMMONSBOOKING_VERSION
@@ -122,9 +121,9 @@ class Upgrade {
 	 * in a major release e.g. 2.5 -> 2.6
 	 * This is a warning to users BEFORE they update to a new version.
 	 *
-	 * @return void
+	 * @return void (but renders html)
 	 */
-	public function updateNotice() {
+	public function updateNotice() : void {
 		if ( ! $this->isMajorUpdate() ) {
 			return;
 		}
@@ -194,7 +193,7 @@ class Upgrade {
 	/**
 	 * Gets location position for locations without coordinates.
 	 */
-	public static function updateLocationCoordinates() {
+	public static function updateLocationCoordinates() : void {
 		$locations = \CommonsBooking\Repository\Location::get();
 
 		foreach ( $locations as $location ) {
@@ -212,7 +211,7 @@ class Upgrade {
 	 *
 	 * @return void
 	 */
-	public static function setAdvanceBookingDaysDefault() {
+	public static function setAdvanceBookingDaysDefault() : void {
 		$timeframes = \CommonsBooking\Repository\Timeframe::getBookable( [], [], null, true );
 
 		foreach ( $timeframes as $timeframe ) {
@@ -228,7 +227,7 @@ class Upgrade {
 	 * @since 2.8.2
 	 * @return void
 	 */
-	public static function resetBrokenColorScheme() {
+	public static function resetBrokenColorScheme() : void {
 		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_greyedoutcolor', '#e0e0e0' );
 		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_lighttext', '#a0a0a0' );
 	}
@@ -239,7 +238,7 @@ class Upgrade {
 	 * @since 2.8.2
 	 * @return void
 	 */
-	public static function fixBrokenICalTitle() {
+	public static function fixBrokenICalTitle() : void {
 		$eventTitle      = Settings::getOption( 'commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title' );
 		$otherEventTitle = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title' );
 		if ( str_contains( $eventTitle, 'post_name' ) ) {

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace CommonsBooking\Service;
+
+use CommonsBooking\Model\Timeframe;
+use CommonsBooking\Plugin;
+use CommonsBooking\Settings\Settings;
+use CommonsBooking\Wordpress\CustomPostType\CustomPostType;
+use CommonsBooking\Wordpress\Options\AdminOptions;
+use Psr\Cache\InvalidArgumentException;
+
+/**
+ * This class contains all the functions that are run when the plugin is upgraded to a new version.
+ * When upgrading, create a new instance of this class and call the run() function.
+ *
+ * The versions should use semantic versioning (https://semver.org/).
+ */
+class Upgrade
+{
+	const VERSION_OPTION = COMMONSBOOKING_PLUGIN_SLUG . '_plugin_version';
+	private string $previousVersion;
+	private string $currentVersion;
+
+	/**
+	 * This array contains all the tasks that need to be run when upgrading from a version lower than the key to the version of the value.
+	 * For example, if you introduce a new feature in version 2.6.0,
+	 * you would add a new entry to this array with the key being "2.6.0" and the value being the function that needs to be run.
+	 *
+	 * This is so that once the upgrade from a specific version has been run, it will not be run again.
+	 * @var array[]
+	 */
+	private static array $upgradeTasks = [
+		'2.6.0' => [
+			[\CommonsBooking\Migration\Booking::class, 'migrate'],
+			[self::class, 'setAdvanceBookingDaysDefault']
+		],
+		'2.8.0' => [
+			[\CommonsBooking\Service\Scheduler::class, 'unscheduleOldEvents']
+		],
+		'2.8.2' => [
+			[self::class, 'resetBrokenColorScheme']
+		]
+	];
+
+	public function __construct( string $previousVersion, string $currentVersion ) {
+		$this->previousVersion = $previousVersion;
+		$this->currentVersion  = $currentVersion;
+	}
+
+	/**
+	 * Run a complete upgrade from the previous version to the current version.
+	 * Will return true if the version has changed and the upgrade has been run.
+	 * Will return false if the version has not changed and the upgrade has not been run.
+	 */
+	public function run(): bool {
+		// check if version has changed, or it is a new installation
+		if ( empty($this->currentVersion) || $this->previousVersion == $this->currentVersion ) {
+			return false;
+		}
+
+		// run upgrade tasks
+		$this->runUpgradeTasks();
+
+		// set Options default values (e.g. if there are new fields added)
+		AdminOptions::SetOptionsDefaultValues();
+
+		// flush rewrite rules
+		flush_rewrite_rules();
+
+		// Update Location Coordinates
+		self::updateLocationCoordinates();
+
+		// add role caps for custom post types
+		Plugin::addCPTRoleCaps();
+
+		// update version number in options
+		update_option( self::VERSION_OPTION, $this->currentVersion );
+
+		// Clear cache
+		try {
+			Cache::clearCache();
+		} catch ( InvalidArgumentException $e ) {
+			// Do nothing
+		}
+		return true;
+	}
+
+	/**
+	 * This runs the tasks that are specific for version updates and should only run once.
+	 * @return void
+	 */
+	public function runUpgradeTasks() {
+		foreach (self::$upgradeTasks as $version => $tasks) {
+			if (version_compare($this->previousVersion, $version, '<') && version_compare($this->currentVersion, $version, '>=')) {
+				foreach ($tasks as $task) {
+					list($className, $methodName) = $task;
+					call_user_func([$className, $methodName]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * This function will determine if the plugin has been updated and run the upgrade tasks if necessary.
+	 *
+	 * @return void
+	 */
+	public static function runTasksAfterUpdate() {
+		$upgrade = new Upgrade(
+			esc_html( get_option( self::VERSION_OPTION ) ),
+			COMMONSBOOKING_VERSION );
+		$upgrade->run();
+	}
+
+	/**
+	 * renders a custom update notice in plugin list if the version number increases
+	 * in a major release e.g. 2.5 -> 2.6
+	 * This is a warning to users BEFORE they update to a new version.
+	 *
+	 * @return void
+	 */
+	public function updateNotice() {
+		if (! $this->isMajorUpdate()) {
+			return;
+		}
+		?>
+		<hr class="cb-major-update-warning__separator" />
+		<div class="cb-major-update-warning">
+			<div class="cb-major-update-warning__icon">
+				<i class="dashicons dashicons-megaphone"></i>
+			</div>
+			<div>
+				<div class="cb-major-update-warning__title">
+					<?php echo esc_html__( 'New features and changes: Please backup your site before upgrading!', 'commonsbooking' ); ?>
+				</div>
+				<div class="e-major-update-warning__message">
+					<?php
+					printf(
+					/* translators: %1$s Link open tag, %2$s: Link close tag. */
+						commonsbooking_sanitizeHTML(
+							__(
+								'
+					This CommonsBooking update has a lot of new features and changes on some templates.<br>
+					If you have modified any template files, please back them up and re-apply your changes after the update. <br>
+					<br><br>We highly recommend you to <strong>%1$sread the update information%2$s </strong> and make a backup of your site before upgrading.',
+								'commonsbooking'
+							)
+						),
+						'<a target="_blank" href="https://commonsbooking.org/docs/installation/update-info/">',
+						'</a>'
+					);
+					?>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Will get if the current version is a major update.
+	 * Note, that in CB, major updates are not the same as in semantic versioning.
+	 *
+	 * We consider a major update to be a change in the first or second number of the version.
+	 * The third number is considered a minor update or a patch.
+	 *
+	 * We do not usually update the first number, but if we do, it is a major update.
+	 *
+	 * Example:
+	 * 2.5.0 -> 2.6.0 is a major update
+	 * 2.5.0 -> 2.5.1 is a minor update
+	 *
+	 * @return bool
+	 */
+	public function isMajorUpdate() : bool {
+		$previousVersion = explode( '.', $this->previousVersion );
+		$currentVersion  = explode( '.', $this->currentVersion );
+
+		if ( $previousVersion[0] < $currentVersion[0] ) {
+			return true;
+		}
+
+		if ( $previousVersion[1] < $currentVersion[1] ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gets location position for locations without coordinates.
+	 */
+	public static function updateLocationCoordinates() {
+		$locations = \CommonsBooking\Repository\Location::get();
+
+		foreach ( $locations as $location ) {
+			if ( ! ( $location->getMeta( 'geo_latitude' ) && $location->getMeta( 'geo_longitude' ) ) ) {
+				$location->updateGeoLocation();
+			}
+		}
+	}
+
+	/**
+	 * sets advance booking days to default value for existing timeframes.
+	 * Advances booking timeframes are available since 2.6 - all timeframes created prior to this version need to have this value set to a default value.
+	 * @since 2.6
+	 * @see \CommonsBooking\Wordpress\CustomPostType\Timeframe::ADVANCE_BOOKING_DAYS
+	 *
+	 * @return void
+	 */
+	public static function setAdvanceBookingDaysDefault() {
+		$timeframes = \CommonsBooking\Repository\Timeframe::getBookable( [], [], null, true );
+
+		foreach ( $timeframes as $timeframe ) {
+			if ( $timeframe->getMeta( Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS ) < 1 ) {
+				update_post_meta( $timeframe->ID, Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, strval( \CommonsBooking\Wordpress\CustomPostType\Timeframe::ADVANCE_BOOKING_DAYS ) );
+			}
+		}
+	}
+
+	/**
+	 * reset greyed out color when upgrading, see issue #1121
+	 * @since 2.8.2
+	 * @return void
+	 */
+	public static function resetBrokenColorScheme() {
+		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_greyedoutcolor', '#e0e0e0' );
+		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_lighttext', '#a0a0a0');
+	}
+
+	/**
+	 * reset iCalendar Titles when upgrading, see issue #1251
+	 * @since 2.8.2
+	 * @return void
+	 */
+	public static function fixBrokenICalTitle() {
+		$eventTitle = Settings::getOption( 'commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title' );
+		$otherEventTitle = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title' );
+		if ( str_contains( $eventTitle, 'post_name' ) ){
+			$updatedString = str_replace( 'post_name', 'post_title', $eventTitle );
+			Settings::updateOption( 'commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title', $updatedString );
+		}
+		if ( str_contains( $otherEventTitle, 'post_name' ) ){
+			$updatedString = str_replace( 'post_name', 'post_title', $otherEventTitle );
+			Settings::updateOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title', $updatedString );
+		}
+	}
+}

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -9,10 +9,13 @@ use CommonsBooking\Wordpress\Options\AdminOptions;
 use Psr\Cache\InvalidArgumentException;
 
 /**
- * This class contains all the functions that are run when the plugin is upgraded to a new version.
- * When upgrading, create a new instance of this class and call the run() function.
+ * This class contains migration functionality that is run when the plugin is upgraded
+ * to a newer version. When upgrading, create a new instance of this class and call the
+ * run() function.
  *
- * The versions should use semantic versioning (https://semver.org/).
+ * At the moment you can implement your own migrations in $upgradeTasks.
+ *
+ * A version string must be given in semantic versioning format (https://semver.org/).
  */
 class Upgrade {
 
@@ -42,6 +45,12 @@ class Upgrade {
 		]
 	];
 
+	/**
+	 * Constructs new upgrade object for a version range
+	 *
+	 * @param string $previousVersion
+	 * @param string $currentVersion
+	 */
 	public function __construct( string $previousVersion, string $currentVersion ) {
 		$this->previousVersion = $previousVersion;
 		$this->currentVersion  = $currentVersion;
@@ -54,7 +63,7 @@ class Upgrade {
 	 */
 	public function run(): bool {
 		// check if version has changed, or it is a new installation
-		if ( ! empty( $this->previousVersion ) && ( $this->previousVersion == $this->currentVersion ) ) {
+		if ( ! empty( $this->previousVersion ) && ( $this->previousVersion === $this->currentVersion ) ) {
 			return false;
 		}
 
@@ -93,6 +102,7 @@ class Upgrade {
 	 * @return void
 	 */
 	public function runUpgradeTasks() : void {
+		// TODO let thirdparty plugins be able to hook into this part, then they don't have to add their own implementation of this class
 		foreach ( self::$upgradeTasks as $version => $tasks ) {
 			if ( version_compare( $this->previousVersion, $version, '<' ) && version_compare( $this->currentVersion, $version, '>=' ) ) {
 				foreach ( $tasks as $task ) {
@@ -108,7 +118,7 @@ class Upgrade {
 	 *
 	 * @return void
 	 */
-	public static function runTasksAfterUpdate() : void  {
+	public static function runTasksAfterUpdate() : void {
 		$upgrade = new Upgrade(
 			esc_html( get_option( self::VERSION_OPTION ) ),
 			COMMONSBOOKING_VERSION

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -15,8 +15,8 @@ use Psr\Cache\InvalidArgumentException;
  *
  * The versions should use semantic versioning (https://semver.org/).
  */
-class Upgrade
-{
+class Upgrade {
+
 	const VERSION_OPTION = COMMONSBOOKING_PLUGIN_SLUG . '_plugin_version';
 	private string $previousVersion;
 	private string $currentVersion;
@@ -55,14 +55,14 @@ class Upgrade
 	 */
 	public function run(): bool {
 		// check if version has changed, or it is a new installation
-		if ( ! empty($this->previousVersion) && ( $this->previousVersion == $this->currentVersion  ) ) {
+		if ( ! empty( $this->previousVersion ) && ( $this->previousVersion == $this->currentVersion ) ) {
 			return false;
 		}
 
 		// run upgrade tasks that are specific for version updates and should only run once
 		$this->runUpgradeTasks();
 
-		//the following tasks will be run on every update
+		// the following tasks will be run on every update
 
 		// set Options default values (e.g. if there are new fields added)
 		AdminOptions::SetOptionsDefaultValues();
@@ -90,14 +90,15 @@ class Upgrade
 
 	/**
 	 * This runs the tasks that are specific for version updates and should only run once.
+	 *
 	 * @return void
 	 */
 	public function runUpgradeTasks() {
-		foreach (self::$upgradeTasks as $version => $tasks) {
-			if (version_compare($this->previousVersion, $version, '<') && version_compare($this->currentVersion, $version, '>=')) {
-				foreach ($tasks as $task) {
+		foreach ( self::$upgradeTasks as $version => $tasks ) {
+			if ( version_compare( $this->previousVersion, $version, '<' ) && version_compare( $this->currentVersion, $version, '>=' ) ) {
+				foreach ( $tasks as $task ) {
 					list($className, $methodName) = $task;
-					call_user_func([$className, $methodName]);
+					call_user_func( array( $className, $methodName ) );
 				}
 			}
 		}
@@ -111,7 +112,8 @@ class Upgrade
 	public static function runTasksAfterUpdate() {
 		$upgrade = new Upgrade(
 			esc_html( get_option( self::VERSION_OPTION ) ),
-			COMMONSBOOKING_VERSION );
+			COMMONSBOOKING_VERSION
+		);
 		$upgrade->run();
 	}
 
@@ -123,7 +125,7 @@ class Upgrade
 	 * @return void
 	 */
 	public function updateNotice() {
-		if (! $this->isMajorUpdate()) {
+		if ( ! $this->isMajorUpdate() ) {
 			return;
 		}
 		?>
@@ -222,27 +224,29 @@ class Upgrade
 
 	/**
 	 * reset greyed out color when upgrading, see issue #1121
+	 *
 	 * @since 2.8.2
 	 * @return void
 	 */
 	public static function resetBrokenColorScheme() {
 		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_greyedoutcolor', '#e0e0e0' );
-		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_lighttext', '#a0a0a0');
+		Settings::updateOption( 'commonsbooking_options_templates', 'colorscheme_lighttext', '#a0a0a0' );
 	}
 
 	/**
 	 * reset iCalendar Titles when upgrading, see issue #1251
+	 *
 	 * @since 2.8.2
 	 * @return void
 	 */
 	public static function fixBrokenICalTitle() {
-		$eventTitle = Settings::getOption( 'commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title' );
+		$eventTitle      = Settings::getOption( 'commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title' );
 		$otherEventTitle = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title' );
-		if ( str_contains( $eventTitle, 'post_name' ) ){
+		if ( str_contains( $eventTitle, 'post_name' ) ) {
 			$updatedString = str_replace( 'post_name', 'post_title', $eventTitle );
 			Settings::updateOption( 'commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title', $updatedString );
 		}
-		if ( str_contains( $otherEventTitle, 'post_name' ) ){
+		if ( str_contains( $otherEventTitle, 'post_name' ) ) {
 			$updatedString = str_replace( 'post_name', 'post_title', $otherEventTitle );
 			Settings::updateOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title', $updatedString );
 		}

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -59,8 +59,10 @@ class Upgrade
 			return false;
 		}
 
-		// run upgrade tasks
+		// run upgrade tasks that are specific for version updates and should only run once
 		$this->runUpgradeTasks();
+
+		//the following tasks will be run on every update
 
 		// set Options default values (e.g. if there are new fields added)
 		AdminOptions::SetOptionsDefaultValues();

--- a/tests/php/Service/UpgradeTest.php
+++ b/tests/php/Service/UpgradeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Model\Restriction;
+use CommonsBooking\Service\Upgrade;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use CommonsBooking\Wordpress\CustomPostType\CustomPostType;
+
+class UpgradeTest extends CustomPostTypeTest
+{
+	private static bool $functionHasRun = false;
+
+    public function testSetRestrictionAllOption()
+    {
+		$oldRestrictionForAll = $this->createRestriction(
+			Restriction::META_HINT,
+			'',
+			'',
+			strtotime(self::CURRENT_DATE),
+			null
+		);
+		//using CMB2, when the default value was set (which was "all" before), the meta value was not set
+		delete_post_meta($oldRestrictionForAll, Restriction::META_ITEM_ID);
+		delete_post_meta($oldRestrictionForAll, Restriction::META_LOCATION_ID);
+		Upgrade::setRestrictionAllOption();
+		$this->assertEquals( CustomPostType::SELECTION_ALL_POSTS, get_post_meta($oldRestrictionForAll, Restriction::META_ITEM_ID, true));
+		$this->assertEquals( CustomPostType::SELECTION_ALL_POSTS, get_post_meta($oldRestrictionForAll, Restriction::META_LOCATION_ID, true));
+    }
+
+    public function testFixBrokenICalTitle()
+    {
+		\CommonsBooking\Settings\Settings::updateOption(
+			'commonsbooking_options_templates',
+			'emailtemplates_mail-booking_ics_event-title',
+		'Booking for {{item:post_name}}'
+		);
+		\CommonsBooking\Settings\Settings::updateOption(
+			COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options',
+			'event_title',
+			'Booking for {{item:post_name}}'
+		);
+		Upgrade::fixBrokenICalTitle();
+		$this->assertEquals('Booking for {{item:post_title}}', \CommonsBooking\Settings\Settings::getOption('commonsbooking_options_templates', 'emailtemplates_mail-booking_ics_event-title'));
+		$this->assertEquals('Booking for {{item:post_title}}', \CommonsBooking\Settings\Settings::getOption(COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title'));
+    }
+
+    public function testIsMajorUpdate()
+    {
+		$majorUpdate = new Upgrade('2.5.0', '2.6.0');
+		$this->assertTrue($majorUpdate->isMajorUpdate());
+		$minorUpdate = new Upgrade('2.5.0', '2.5.1');
+		$this->assertFalse($minorUpdate->isMajorUpdate());
+		$majorestUpdate = new Upgrade('2.5.0', '3.0.0');
+		$this->assertTrue($majorestUpdate->isMajorUpdate());
+		$downgrade = new Upgrade('2.6.0', '2.5.0');
+		$this->assertFalse($downgrade->isMajorUpdate());
+    }
+
+	/**
+	 * This will test if the upgrade tasks are run correctly.
+	 * The test function should only run, when upgrading on or over version 2.5.2.
+	 * It should for example not run when upgrading from 2.5.2 to 2.5.3.
+	 *
+	 * @dataProvider provideUpgradeConditions
+	 */
+	public function testRunUpgradeTasks($previousVersion, $currentVersion, $shouldRunFunction) {
+		$upgrade = new Upgrade($previousVersion, $currentVersion);
+		$upgrade->runUpgradeTasks();
+		$this->assertEquals($shouldRunFunction, self::$functionHasRun);
+	}
+
+	public function provideUpgradeConditions() {
+		return array(
+			"Upgrade directly on version with new function (major)" => ["2.4.0", "2.5.2", true],
+			"Upgrade past version with new function (major)" => ["2.4.0", "2.6.0", true],
+			"Direct minor upgrade on same version" => ["2.5.1", "2.5.2", true],
+			"Direct minor upgrade on version without new function" => ["2.5.0", "2.5.1", false], //This is a weird case that should not happen, usually the function would not be added before it is needed
+			"Direct minor upgrade past version with new function" => ["2.5.2", "2.5.3", false],
+			"Direct minor upgrade past version with new function (major)" => ["2.5.2", "2.6.0", false],
+			"Downgrade from previous versions" => ["2.5.3", "2.5.2", false],
+		);
+	}
+
+	public static function fakeUpdateFunction()
+	{
+		self::$functionHasRun = true;
+	}
+
+	public function testRunTasksAfterUpdate() {
+		$olderVersion = '2.5.0';
+		update_option(Upgrade::VERSION_OPTION, $olderVersion);
+		Upgrade::runTasksAfterUpdate();
+		$this->assertEquals(COMMONSBOOKING_VERSION, get_option(Upgrade::VERSION_OPTION));
+	}
+
+	public function testRun() {
+		$upgrade = new Upgrade('2.5.0', '2.6.0');
+		$this->assertTrue($upgrade->run());
+		$this->assertEquals('2.6.0', get_option(Upgrade::VERSION_OPTION));
+
+		$upgrade = new Upgrade('2.5.0', '2.5.1');
+		$this->assertTrue($upgrade->run());
+		$this->assertEquals('2.5.1', get_option(Upgrade::VERSION_OPTION));
+
+		//new installation
+		$upgrade = new Upgrade('', '2.5.0');
+		$this->assertTrue($upgrade->run());
+		$this->assertEquals('2.5.0', get_option(Upgrade::VERSION_OPTION));
+
+		//no version change
+		$upgrade = new Upgrade('2.5.0', '2.5.0');
+		$this->assertFalse($upgrade->run());
+	}
+
+	public function testSetAdvanceBookingDaysDefault() {
+		//create timeframe without advance booking days
+		$timeframeId = $this->createBookableTimeFrameIncludingCurrentDay();
+		update_post_meta($timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, '');
+		Upgrade::setAdvanceBookingDaysDefault();
+		$this->assertEquals(\CommonsBooking\Wordpress\CustomPostType\Timeframe::ADVANCE_BOOKING_DAYS, get_post_meta($timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, true));
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		//This replaces the original update tasks with a internal test function that just sets a variable to true
+		$testTasks = new \ReflectionProperty('\CommonsBooking\Service\Upgrade', 'upgradeTasks');
+		$testTasks->setAccessible(true);
+		$testTasks->setValue(
+			[
+				'2.5.2' => [
+					[self::class, 'fakeUpdateFunction' ]
+				]
+			]
+		);
+	}
+
+	protected function tearDown(): void {
+		self::$functionHasRun = false;
+		//resets version back to current version
+		update_option(\CommonsBooking\Service\Upgrade::VERSION_OPTION, COMMONSBOOKING_VERSION);
+		parent::tearDown();
+	}
+}

--- a/tests/php/Service/UpgradeTest.php
+++ b/tests/php/Service/UpgradeTest.php
@@ -54,6 +54,13 @@ class UpgradeTest extends CustomPostTypeTest
 		$this->assertEquals($shouldRunFunction, self::$functionHasRun);
 	}
 
+	/**
+	 * The set_up defines a fake upgrade task that should only run when upgrading on or over version 2.5.2.
+	 * The data provider will provide different upgrade conditions and the test will check if the function has run or not.
+	 * true means, that the function is expected to run under these conditions, false means it is not expected to run.
+	 *
+	 * @return array[]
+	 */
 	public function provideUpgradeConditions() {
 		return array(
 			"Upgrade directly on version with new function (major)" => ["2.4.0", "2.5.2", true],

--- a/tests/php/Service/UpgradeTest.php
+++ b/tests/php/Service/UpgradeTest.php
@@ -9,24 +9,8 @@ use CommonsBooking\Wordpress\CustomPostType\CustomPostType;
 
 class UpgradeTest extends CustomPostTypeTest
 {
-	private static bool $functionHasRun = false;
 
-    public function testSetRestrictionAllOption()
-    {
-		$oldRestrictionForAll = $this->createRestriction(
-			Restriction::META_HINT,
-			'',
-			'',
-			strtotime(self::CURRENT_DATE),
-			null
-		);
-		//using CMB2, when the default value was set (which was "all" before), the meta value was not set
-		delete_post_meta($oldRestrictionForAll, Restriction::META_ITEM_ID);
-		delete_post_meta($oldRestrictionForAll, Restriction::META_LOCATION_ID);
-		Upgrade::setRestrictionAllOption();
-		$this->assertEquals( CustomPostType::SELECTION_ALL_POSTS, get_post_meta($oldRestrictionForAll, Restriction::META_ITEM_ID, true));
-		$this->assertEquals( CustomPostType::SELECTION_ALL_POSTS, get_post_meta($oldRestrictionForAll, Restriction::META_LOCATION_ID, true));
-    }
+    private static bool $functionHasRun = false;
 
     public function testFixBrokenICalTitle()
     {

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -78,7 +78,7 @@ abstract class CustomPostTypeTest extends TestCase {
 		update_post_meta( $timeframeId, 'location-id', $locationId );
 		update_post_meta( $timeframeId, 'item-id', $itemId );
 		update_post_meta( $timeframeId, 'timeframe-max-days', $maxDays );
-		update_post_meta( $timeframeId, 'timeframe-advance-booking-days', $advanceBookingDays );
+		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, $advanceBookingDays );
 		update_post_meta( $timeframeId, 'booking-startday-offset', $bookingStartdayOffset );
 		update_post_meta( $timeframeId, 'full-day', $fullday );
 		update_post_meta( $timeframeId, 'timeframe-repetition', $repetition );


### PR DESCRIPTION
Das war ursprünglich Teil von #1306 , wurde aber zum einfacheren Review ausgegliedert.

Warum:
-Die Plugin Klasse wurde mit den ganzen Migrationen langsam etwas unübersichtlich
-Jetzt haben wir eine Möglichkeit Upgrade Tasks nur 1x (nämlich bei dem Upgrade über die Version) laufen zu lassen. So wird zum Beispiel nicht ständig das Farbschema bei jedem Upgrade zurückgesetzt
