### PR TITLE
Unit-Tests: Mock calls to nominatim geocoding service

### DIFF
--- a/src/Helper/GeoCodeService.php
+++ b/src/Helper/GeoCodeService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CommonsBooking\Helper;
+
+use Geocoder\Location;
+
+interface GeoCodeService {
+
+	/**
+	 * Returns a geocoded location object from a given address string
+	 *
+	 * @param string $addressString
+	 *
+	 * @return Location|null
+	 */
+	public function getAddressData( string $addressString ): ?Location;
+}

--- a/src/Helper/GeoCoderServiceProxy.php
+++ b/src/Helper/GeoCoderServiceProxy.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace CommonsBooking\Helper;
+
+use Geocoder\Exception\Exception;
+use Geocoder\Location;
+use Geocoder\Provider\Nominatim\Nominatim;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\StatefulGeocoder;
+use Http\Client\Curl\Client;
+
+/**
+ * Proxy to wrap web service calls, so we can properly test/mock them.
+ */
+class GeoCoderServiceProxy {
+
+	/**
+	 * @var GeoCoderServiceProxy Singleton holder
+	 */
+	private static GeoCoderServiceProxy $geoCoder;
+
+	/**
+	 * Singleton
+	 */
+	private function __construct() {}
+
+	/**
+	 * @param $addressString
+	 *
+	 * @return ?Location
+	 */
+	public function getAddressData( $addressString ): ?Location {
+		$defaultUserAgent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0";
+
+		$client = new Client(
+			null,
+			null,
+			[
+				CURLOPT_SSL_VERIFYHOST => 0,
+				CURLOPT_SSL_VERIFYPEER => 0,
+			]
+		);
+
+		$provider = Nominatim::withOpenStreetMapServer(
+			$client,
+			array_key_exists( 'HTTP_USER_AGENT', $_SERVER ) ? $_SERVER['HTTP_USER_AGENT'] : $defaultUserAgent
+		);
+		$geoCoder = new StatefulGeocoder( $provider, 'en' );
+
+		try {
+			$addresses = $geoCoder->geocodeQuery( GeocodeQuery::create( $addressString ) );
+			if ( ! $addresses->isEmpty() ) {
+				return $addresses->first();
+			}
+		} catch ( Exception $exception ) {
+			// Nothing to do in this case
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return GeoCoderServiceProxy singleton instance
+	 */
+	public static function getInstance() : GeoCoderServiceProxy {
+		if ( self::$geoCoder === null ) {
+			self::$geoCoder = new GeoCoderServiceProxy();
+		}
+		return self::$geoCoder;
+	}
+
+	/**
+	 * @param GeoCoderSerivceProxy $inst
+	 *
+	 * @return void
+	 */
+	public static function setInstance(GeoCoderServiceProxy $inst) : void {
+		self::$geoCoder = $inst;
+	}
+}

--- a/src/Helper/GeoHelper.php
+++ b/src/Helper/GeoHelper.php
@@ -1,51 +1,20 @@
 <?php
 
-
 namespace CommonsBooking\Helper;
 
-
-use Geocoder\Exception\Exception;
 use Geocoder\Location;
-use Geocoder\Provider\Nominatim\Nominatim;
-use Geocoder\Query\GeocodeQuery;
-use Geocoder\StatefulGeocoder;
-use Http\Client\Curl\Client;
 
+/**
+ * Wrapper for calling the geoCoder service
+ */
 class GeoHelper {
 
 	/**
-	 * @param $addressString
+	 * @param string $addressString
 	 *
-	 * @return ?Location
+	 * @return Location|null
 	 */
 	public static function getAddressData( $addressString ): ?Location {
-		$defaultUserAgent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0";
-
-		$client = new Client(
-			null,
-			null,
-			[
-				CURLOPT_SSL_VERIFYHOST => 0,
-				CURLOPT_SSL_VERIFYPEER => 0,
-			]
-		);
-
-		$provider = Nominatim::withOpenStreetMapServer(
-			$client,
-			array_key_exists('HTTP_USER_AGENT', $_SERVER) ? $_SERVER['HTTP_USER_AGENT'] : $defaultUserAgent
-		);
-		$geoCoder = new StatefulGeocoder( $provider, 'en' );
-
-		try {
-			$addresses = $geoCoder->geocodeQuery( GeocodeQuery::create( $addressString ) );
-			if ( ! $addresses->isEmpty() ) {
-				return $addresses->first();
-			}
-		} catch (Exception $exception) {
-			// Nothing to do in this case
-		}
-
-		return null;
+		return GeoCoderServiceProxy::getInstance()->getAddressData( $addressString );
 	}
-
 }

--- a/src/Helper/GeoHelper.php
+++ b/src/Helper/GeoHelper.php
@@ -5,9 +5,15 @@ namespace CommonsBooking\Helper;
 use Geocoder\Location;
 
 /**
- * Wrapper for calling the geoCoder service
+ * Wrapper for calling the geoCoder service.
+ * Defaults to implementation of {@see NominatimGeoCodeService}.
  */
 class GeoHelper {
+
+	/**
+	 * @var GeoCodeService Singleton instance
+	 */
+	private static GeoCodeService $geoCodeService;
 
 	/**
 	 * @param string $addressString
@@ -15,6 +21,24 @@ class GeoHelper {
 	 * @return Location|null
 	 */
 	public static function getAddressData( $addressString ): ?Location {
-		return GeoCoderServiceProxy::getInstance()->getAddressData( $addressString );
+		if ( ! isset( self::$geoCodeService ) ) {
+			self::resetGeoCoder();
+		}
+		return self::$geoCodeService->getAddressData( $addressString );
+	}
+
+	/**
+	 * Configure the service implementation in use
+	 *
+	 * @param GeoCodeService $instance
+	 *
+	 * @return void
+	 */
+	public static function setGeoCodeServiceInstance( GeoCodeService $instance ) : void {
+		self::$geoCodeService = $instance;
+	}
+
+	public static function resetGeoCoder() : void {
+		GeoHelper::setGeoCodeServiceInstance( new NominatimGeoCodeService() );
 	}
 }

--- a/src/Helper/NominatimGeoCodeService.php
+++ b/src/Helper/NominatimGeoCodeService.php
@@ -10,19 +10,10 @@ use Geocoder\StatefulGeocoder;
 use Http\Client\Curl\Client;
 
 /**
- * Proxy to wrap web service calls, so we can properly test/mock them.
+ * Implementation of geocoding web service calls.
+ * Helps to properly mock/unit-test 3rd-party components.
  */
-class GeoCoderServiceProxy {
-
-	/**
-	 * @var GeoCoderServiceProxy Singleton holder
-	 */
-	private static GeoCoderServiceProxy $geoCoder;
-
-	/**
-	 * Singleton
-	 */
-	private function __construct() {}
+class NominatimGeoCodeService implements GeoCodeService {
 
 	/**
 	 * @param $addressString
@@ -30,7 +21,7 @@ class GeoCoderServiceProxy {
 	 * @return ?Location
 	 */
 	public function getAddressData( $addressString ): ?Location {
-		$defaultUserAgent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0";
+		$defaultUserAgent = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0';
 
 		$client = new Client(
 			null,
@@ -57,24 +48,5 @@ class GeoCoderServiceProxy {
 		}
 
 		return null;
-	}
-
-	/**
-	 * @return GeoCoderServiceProxy singleton instance
-	 */
-	public static function getInstance() : GeoCoderServiceProxy {
-		if ( self::$geoCoder === null ) {
-			self::$geoCoder = new GeoCoderServiceProxy();
-		}
-		return self::$geoCoder;
-	}
-
-	/**
-	 * @param GeoCoderSerivceProxy $inst
-	 *
-	 * @return void
-	 */
-	public static function setInstance(GeoCoderServiceProxy $inst) : void {
-		self::$geoCoder = $inst;
 	}
 }

--- a/tests/php/API/CB_REST_UnitTestCase.php
+++ b/tests/php/API/CB_REST_UnitTestCase.php
@@ -2,8 +2,10 @@
 
 namespace CommonsBooking\Tests\API;
 
+use CommonsBooking\Helper\GeoCoderServiceProxy;
 use CommonsBooking\Plugin;
 use CommonsBooking\Settings\Settings;
+use CommonsBooking\Tests\Helper\GeoHelperTest;
 
 /**
  * Abstract Unit Test case, which initializes REST functionality
@@ -16,6 +18,8 @@ class CB_REST_UnitTestCase extends \WP_UnitTestCase {
 
 	public function setUp() : void {
 		parent::setUp();
+		GeoHelperTest::setupGeoHelperMock($this);
+
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new \WP_REST_Server;

--- a/tests/php/API/CB_REST_UnitTestCase.php
+++ b/tests/php/API/CB_REST_UnitTestCase.php
@@ -2,7 +2,7 @@
 
 namespace CommonsBooking\Tests\API;
 
-use CommonsBooking\Helper\GeoCoderServiceProxy;
+use CommonsBooking\Helper\NominatimGeoCodeService;
 use CommonsBooking\Plugin;
 use CommonsBooking\Settings\Settings;
 use CommonsBooking\Tests\Helper\GeoHelperTest;
@@ -18,7 +18,7 @@ class CB_REST_UnitTestCase extends \WP_UnitTestCase {
 
 	public function setUp() : void {
 		parent::setUp();
-		GeoHelperTest::setupGeoHelperMock($this);
+		GeoHelperTest::setUpGeoHelperMock( $this );
 
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;

--- a/tests/php/BaseTestCase.php
+++ b/tests/php/BaseTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CommonsBooking\Tests;
+
+use CommonsBooking\Tests\Helper\GeoHelperTest;
+use PHPUnit\Framework\TestCase;
+
+class BaseTestCase extends TestCase {
+
+	protected function setUp(): void {
+
+		// Default case: Tests should work offline
+		GeoHelperTest::setUpGeoHelperMock( $this );
+	}
+}

--- a/tests/php/Helper/GeoHelperTest.php
+++ b/tests/php/Helper/GeoHelperTest.php
@@ -2,19 +2,53 @@
 
 namespace CommonsBooking\Tests\Helper;
 
+use CommonsBooking\Helper\GeoCoderServiceProxy;
 use CommonsBooking\Helper\GeoHelper;
+use Geocoder\Location;
+use Geocoder\Model\AddressBuilder;
 use PHPUnit\Framework\TestCase;
 
 class GeoHelperTest extends TestCase
 {
 
-	/*
-	 * DISABLED BECAUSE IT KEEPS FAILING IN CI. TODO: PROBABLY MOCK THE API CALLS
+	/**
+	 * Mocks a location
+	 *
+	 * @return Location|null
 	 */
+	private static function mockedLocation() : ?Location {
+		$location = new AddressBuilder("Mock");
+		$location->setStreetName("Karl-Marx-Straße")
+		         ->setStreetNumber("1")
+		         ->setPostalCode("12043")
+		         ->setLocality("Berlin")
+		         ->setCountry("Germany")
+		         ->setCoordinates(52.4863922, 13.424689);
+
+		return $location->build();
+	}
+
+	/**
+	 * This can be used to get mocked locations from nominatim
+	 *
+	 * @param TestCase $case
+	 *
+	 * @return void
+	 */
+	public static function setupGeoHelperMock( TestCase $case ) : void {
+
+		$sut = $case->createStub(GeoCoderServiceProxy::class);
+		$sut->method('getAddressData')
+		           ->willReturn(self::mockedLocation());
+		GeoCoderServiceProxy::setInstance($sut);
+	}
+
+	public function setup() : void {
+		self::setupGeoHelperMock($this);
+	}
+
     public function testGetAddressData()
     {
-		$this->assertTrue(true);
-		/*
 		$address = GeoHelper::getAddressData('Karl-Marx-Straße 1, 12043 Berlin');
 
 		$this->assertEquals('Karl-Marx-Straße', $address->getStreetName());
@@ -24,6 +58,6 @@ class GeoHelperTest extends TestCase
 		$this->assertEquals('Germany', $address->getCountry());
 		$this->assertEquals('52.4863922', $address->getCoordinates()->getLatitude());
 		$this->assertEquals('13.424689', $address->getCoordinates()->getLongitude());
-		*/
+
     }
 }

--- a/tests/php/Helper/GeoHelperTest.php
+++ b/tests/php/Helper/GeoHelperTest.php
@@ -54,14 +54,13 @@ class GeoHelperTest extends BaseTestCase
 		$this->assertThatKarlMarxLocationIsProperlyGeoCoded( $address );
 	}
     private function assertThatKarlMarxLocationIsProperlyGeoCoded( Location $address ) : void {
-
-	    $this->assertEquals( 'Karl-Marx-Straße', $address->getStreetName() );
-	    $this->assertEquals( '1', $address->getStreetNumber() );
-	    $this->assertEquals( '12043', $address->getPostalCode() );
-	    $this->assertEquals( 'Berlin', $address->getLocality() );
-	    $this->assertEquals( 'Germany', $address->getCountry() );
-	    $this->assertEquals( 52.4863573, $address->getCoordinates()->getLatitude() );
-	    $this->assertEquals( 13.4247667, $address->getCoordinates()->getLongitude() );
-
+		$this->assertEquals( 'Karl-Marx-Straße', $address->getStreetName() );
+		$this->assertEquals( '1', $address->getStreetNumber() );
+		$this->assertEquals( '12043', $address->getPostalCode() );
+		$this->assertEquals( 'Berlin', $address->getLocality() );
+		$this->assertEquals( 'Germany', $address->getCountry() );
+		// This won't check exact coords on purpose, because sometimes there are different results
+		$this->assertStringStartsWith( '52.4863', '' . $address->getCoordinates()->getLatitude() );
+		$this->assertStringStartsWith( '13.4247', '' . $address->getCoordinates()->getLongitude() );
     }
 }

--- a/tests/php/Helper/GeoHelperTest.php
+++ b/tests/php/Helper/GeoHelperTest.php
@@ -61,6 +61,6 @@ class GeoHelperTest extends BaseTestCase
 		$this->assertEquals( 'Germany', $address->getCountry() );
 		// This won't check exact coords on purpose, because sometimes there are different results
 		$this->assertStringStartsWith( '52.4863', '' . $address->getCoordinates()->getLatitude() );
-		$this->assertStringStartsWith( '13.4247', '' . $address->getCoordinates()->getLongitude() );
+		$this->assertStringStartsWith( '13.424', '' . $address->getCoordinates()->getLongitude() );
     }
 }

--- a/tests/php/Helper/GeoHelperTest.php
+++ b/tests/php/Helper/GeoHelperTest.php
@@ -2,15 +2,15 @@
 
 namespace CommonsBooking\Tests\Helper;
 
-use CommonsBooking\Helper\GeoCoderServiceProxy;
+use CommonsBooking\Helper\GeoCodeService;
 use CommonsBooking\Helper\GeoHelper;
+use CommonsBooking\Tests\BaseTestCase;
 use Geocoder\Location;
 use Geocoder\Model\AddressBuilder;
 use PHPUnit\Framework\TestCase;
 
-class GeoHelperTest extends TestCase
+class GeoHelperTest extends BaseTestCase
 {
-
 	/**
 	 * Mocks a location
 	 *
@@ -23,7 +23,7 @@ class GeoHelperTest extends TestCase
 		         ->setPostalCode("12043")
 		         ->setLocality("Berlin")
 		         ->setCountry("Germany")
-		         ->setCoordinates(52.4863922, 13.424689);
+		         ->setCoordinates(52.4863573, 13.4247667);
 
 		return $location->build();
 	}
@@ -35,29 +35,33 @@ class GeoHelperTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public static function setupGeoHelperMock( TestCase $case ) : void {
+	public static function setUpGeoHelperMock( TestCase $case ) : void {
 
-		$sut = $case->createStub(GeoCoderServiceProxy::class);
-		$sut->method('getAddressData')
-		           ->willReturn(self::mockedLocation());
-		GeoCoderServiceProxy::setInstance($sut);
+		$sut = $case->createStub( GeoCodeService::class );
+		$sut->method( 'getAddressData' )
+		           ->willReturn( self::mockedLocation() );
+		GeoHelper::setGeoCodeServiceInstance( $sut );
+	}
+	public function testThatGeoCoding_worksOffline() {
+		$address = GeoHelper::getAddressData( 'Karl-Marx-Straße 1, 12043 Berlin' );
+		$this->assertThatKarlMarxLocationIsProperlyGeoCoded( $address );
 	}
 
-	public function setup() : void {
-		self::setupGeoHelperMock($this);
+	public function testThatGeoCoding_worksOnline() {
+		GeoHelper::resetGeoCoder();
+
+		$address = GeoHelper::getAddressData( 'Karl-Marx-Straße 1, 12043 Berlin' );
+		$this->assertThatKarlMarxLocationIsProperlyGeoCoded( $address );
 	}
+    private function assertThatKarlMarxLocationIsProperlyGeoCoded( Location $address ) : void {
 
-    public function testGetAddressData()
-    {
-		$address = GeoHelper::getAddressData('Karl-Marx-Straße 1, 12043 Berlin');
-
-		$this->assertEquals('Karl-Marx-Straße', $address->getStreetName());
-		$this->assertEquals('1', $address->getStreetNumber());
-		$this->assertEquals('12043', $address->getPostalCode());
-		$this->assertEquals('Berlin', $address->getLocality());
-		$this->assertEquals('Germany', $address->getCountry());
-		$this->assertEquals('52.4863922', $address->getCoordinates()->getLatitude());
-		$this->assertEquals('13.424689', $address->getCoordinates()->getLongitude());
+	    $this->assertEquals( 'Karl-Marx-Straße', $address->getStreetName() );
+	    $this->assertEquals( '1', $address->getStreetNumber() );
+	    $this->assertEquals( '12043', $address->getPostalCode() );
+	    $this->assertEquals( 'Berlin', $address->getLocality() );
+	    $this->assertEquals( 'Germany', $address->getCountry() );
+	    $this->assertEquals( 52.4863573, $address->getCoordinates()->getLatitude() );
+	    $this->assertEquals( 13.4247667, $address->getCoordinates()->getLongitude() );
 
     }
 }

--- a/tests/php/Helper/GeoHelperTest.php
+++ b/tests/php/Helper/GeoHelperTest.php
@@ -9,6 +9,9 @@ use Geocoder\Location;
 use Geocoder\Model\AddressBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests wrapper impl for nominatim and provides mocking code to prevent real service calls
+ */
 class GeoHelperTest extends BaseTestCase
 {
 	/**
@@ -42,6 +45,7 @@ class GeoHelperTest extends BaseTestCase
 		           ->willReturn( self::mockedLocation() );
 		GeoHelper::setGeoCodeServiceInstance( $sut );
 	}
+
 	public function testThatGeoCoding_worksOffline() {
 		$address = GeoHelper::getAddressData( 'Karl-Marx-Straße 1, 12043 Berlin' );
 		$this->assertThatKarlMarxLocationIsProperlyGeoCoded( $address );

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -2,14 +2,18 @@
 
 namespace CommonsBooking\Tests\Wordpress;
 
+use CommonsBooking\Helper\GeoCoderServiceProxy;
+use CommonsBooking\Helper\GeoHelper;
 use CommonsBooking\Plugin;
 use CommonsBooking\Repository\BookingCodes;
+use CommonsBooking\Tests\Helper\GeoHelperTest;
 use CommonsBooking\Wordpress\CustomPostType\Booking;
 use CommonsBooking\Wordpress\CustomPostType\Item;
 use CommonsBooking\Wordpress\CustomPostType\Location;
 use CommonsBooking\Wordpress\CustomPostType\Map;
 use CommonsBooking\Wordpress\CustomPostType\Restriction;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
+use Geocoder\Model\AddressBuilder;
 use PHPUnit\Framework\TestCase;
 use SlopeIt\ClockMock\ClockMock;
 
@@ -429,7 +433,8 @@ abstract class CustomPostTypeTest extends TestCase {
 	}
 
   protected function setUp() : void {
-        parent::setUp();
+		parent::setUp();
+		GeoHelperTest::setupGeoHelperMock( $this );
 
 	$this->dateFormatted  = date( 'Y-m-d', strtotime( self::CURRENT_DATE ) );
 

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -2,22 +2,18 @@
 
 namespace CommonsBooking\Tests\Wordpress;
 
-use CommonsBooking\Helper\GeoCoderServiceProxy;
-use CommonsBooking\Helper\GeoHelper;
 use CommonsBooking\Plugin;
 use CommonsBooking\Repository\BookingCodes;
-use CommonsBooking\Tests\Helper\GeoHelperTest;
+use CommonsBooking\Tests\BaseTestCase;
 use CommonsBooking\Wordpress\CustomPostType\Booking;
 use CommonsBooking\Wordpress\CustomPostType\Item;
 use CommonsBooking\Wordpress\CustomPostType\Location;
 use CommonsBooking\Wordpress\CustomPostType\Map;
 use CommonsBooking\Wordpress\CustomPostType\Restriction;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
-use Geocoder\Model\AddressBuilder;
-use PHPUnit\Framework\TestCase;
 use SlopeIt\ClockMock\ClockMock;
 
-abstract class CustomPostTypeTest extends TestCase {
+abstract class CustomPostTypeTest extends BaseTestCase {
 
 	/**
 	 * This is the date that is used in the tests.
@@ -434,7 +430,6 @@ abstract class CustomPostTypeTest extends TestCase {
 
   protected function setUp() : void {
 		parent::setUp();
-		GeoHelperTest::setupGeoHelperMock( $this );
 
 	$this->dateFormatted  = date( 'Y-m-d', strtotime( self::CURRENT_DATE ) );
 


### PR DESCRIPTION
Das funktioniert. Ich war mir unsicher ob es nicht doch schöner (wartbarer/lesbarer) ist, das direkt über das StatefulGeocoder oder Provider interface/class zu lösen. Habe es jetzt erstmal so gelassen, da es eine so kleine API ist und so wenig Funktionatlität betrifft, die wir nutzen, sodass wir die nicht besonders konfigurierbar hervorheben müssen.

Siehe: https://github.com/wielebenwir/commonsbooking/discussions/1411