### PR TITLE
remove ruby from actions

### DIFF
--- a/.github/actions/build-plugin/action.yml
+++ b/.github/actions/build-plugin/action.yml
@@ -9,13 +9,6 @@ runs:
       with:
         php-version: '7.4'
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.0.6' # Not needed with a .ruby-version file
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: gem install compass
-      shell: bash
-
     - name: Cache Composer packages
       id: composer-cache
       uses: actions/cache@v3

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -54,12 +54,6 @@ jobs:
       with:
         php-version: '7.4'
 
-    - uses: ruby/setup-ruby@v1
-      with:
-          ruby-version: '3.0.6' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: gem install compass
-
     - uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'


### PR DESCRIPTION
Da wir jetzt node-sass nutzen müssen wir compass nicht mehr installieren.