### PR TITLE
Fix für E-Mail-Absender-Namen mit Sonderzeichen wie "Frieda & Friedrich"

### DIFF
--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -50,7 +50,7 @@ class BookingMessage extends Message {
 		// Setup email: From
 		$fromHeaders = sprintf(
 			"From: %s <%s>",
-			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', false ),
+			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', array($this, 'sanitizeNameInEmailHeader') ),
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 

--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -44,7 +44,7 @@ class BookingMessage extends Message {
 		$template_body    = Settings::getOption( 'commonsbooking_options_templates',
 			'emailtemplates_mail-booking-' . $this->action . '-body' );
 		$template_subject = Settings::getOption( 'commonsbooking_options_templates',
-			'emailtemplates_mail-booking-' . $this->action . '-subject' );
+			'emailtemplates_mail-booking-' . $this->action . '-subject', 'sanitize_text_field' );
 
 
 		// Setup email: From

--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -50,7 +50,7 @@ class BookingMessage extends Message {
 		// Setup email: From
 		$fromHeaders = sprintf(
 			"From: %s <%s>",
-			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', array($this, 'sanitizeNameInEmailHeader') ),
+			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', 'sanitize_text_field' ),
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 

--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -50,7 +50,7 @@ class BookingMessage extends Message {
 		// Setup email: From
 		$fromHeaders = sprintf(
 			"From: %s <%s>",
-			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name' ),
+			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', false ),
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 

--- a/src/Messages/BookingReminderMessage.php
+++ b/src/Messages/BookingReminderMessage.php
@@ -31,7 +31,7 @@ class BookingReminderMessage extends Message {
 		$template_body    = Settings::getOption( 'commonsbooking_options_reminder',
 			$this->action . '-body' );
 		$template_subject = Settings::getOption( 'commonsbooking_options_reminder',
-			$this->action . '-subject' );
+			$this->action . '-subject', 'sanitize_text_field' );
 
 		// Setup email: From
 		$fromHeaders = sprintf(

--- a/src/Messages/BookingReminderMessage.php
+++ b/src/Messages/BookingReminderMessage.php
@@ -36,7 +36,7 @@ class BookingReminderMessage extends Message {
 		// Setup email: From
 		$fromHeaders = sprintf(
 			"From: %s <%s>",
-			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name' ),
+			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', false ),
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 

--- a/src/Messages/BookingReminderMessage.php
+++ b/src/Messages/BookingReminderMessage.php
@@ -36,7 +36,7 @@ class BookingReminderMessage extends Message {
 		// Setup email: From
 		$fromHeaders = sprintf(
 			"From: %s <%s>",
-			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', array($this, 'sanitizeNameInEmailHeader') ),
+			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', 'sanitize_text_field' ),
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 

--- a/src/Messages/BookingReminderMessage.php
+++ b/src/Messages/BookingReminderMessage.php
@@ -36,7 +36,7 @@ class BookingReminderMessage extends Message {
 		// Setup email: From
 		$fromHeaders = sprintf(
 			"From: %s <%s>",
-			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', false ),
+			Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name', array($this, 'sanitizeNameInEmailHeader') ),
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -116,7 +116,7 @@ abstract class Message {
 
 		// parse templates & replaces template tags (e.g. {{item:name}})
 		$this->body    = commonsbooking_sanitizeHTML( commonsbooking_parse_template( $template_body, $objects ) );
-		$this->subject = commonsbooking_sanitizeHTML( commonsbooking_parse_template( $template_subject, $objects ) );
+		$this->subject = sanitize_text_field( commonsbooking_parse_template( $template_subject, $objects ) );
 
 		// Setup mime type
 		$this->headers[] = "MIME-Version: 1.0";
@@ -145,7 +145,7 @@ abstract class Message {
 	 */
 	public function SendNotificationMail() {
 		$to      = apply_filters( 'commonsbooking_mail_to', $this->to, $this->action );
-		$subject = apply_filters( 'commonsbooking_mail_subject', $this->subject, $this->action );
+		$subject = apply_filters( 'commonsbooking_mail_subject', $this->subject, $this->action, 'sanitize_text_field' );
 		$body    = apply_filters( 'commonsbooking_mail_body', $this->body, $this->action );
 		$attachment = apply_filters( 'commonsbooking_mail_attachment', $this->attachment, $this->action);
 		$headers = implode( "\r\n", $this->headers );

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -284,4 +284,22 @@ abstract class Message {
 		}
 		return $atts;
 	}
+
+	/**
+	 * Sanitize the name part of e-mail From/To/Reply-To/Cc/Bcc header:
+	 * Firstname Lastname <firstname.lastname@example.com>
+	 * "Firstname Lastname" is the name and it should not contain
+	 * any HTML entities, control characters, line breaks or < and >
+	 * These get stripped out by this function.
+	 * Also " and ' will be stripped out.
+	 *
+	 * @param $input The name as input string
+	 * @return The sanitized name
+	 *
+	 */
+	public static function sanitizeNameInEmailHeader($input) {
+
+		return preg_replace('/[\x00-\x1F\x7F\"\'<>]/u', '', $input);
+
+	}
 }

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -284,22 +284,4 @@ abstract class Message {
 		}
 		return $atts;
 	}
-
-	/**
-	 * Sanitize the name part of e-mail From/To/Reply-To/Cc/Bcc header:
-	 * Firstname Lastname <firstname.lastname@example.com>
-	 * "Firstname Lastname" is the name and it should not contain
-	 * any HTML entities, control characters, line breaks or < and >
-	 * These get stripped out by this function.
-	 * Also " and ' will be stripped out.
-	 *
-	 * @param $input The name as input string
-	 * @return The sanitized name
-	 *
-	 */
-	public static function sanitizeNameInEmailHeader($input) {
-
-		return preg_replace('/[\x00-\x1F\x7F\"\'<>]/u', '', $input);
-
-	}
 }

--- a/src/Messages/RestrictionMessage.php
+++ b/src/Messages/RestrictionMessage.php
@@ -116,7 +116,7 @@ class RestrictionMessage extends Message {
 	 * @throws \Exception
 	 */
 	protected function prepareRestrictionMail( $body, $subject ) {
-		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name' ) .
+		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name', false ) .
 		              ' <' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-email' ) . '>';
 		$restriction = $this->getRestriction();
 

--- a/src/Messages/RestrictionMessage.php
+++ b/src/Messages/RestrictionMessage.php
@@ -67,7 +67,7 @@ class RestrictionMessage extends Message {
 	 */
 	protected function sendHintMail() {
 		$body    = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-hint-body' );
-		$subject = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-hint-subject' );
+		$subject = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-hint-subject', 'sanitize_text_field' );
 
 		$this->prepareRestrictionMail(
 			$body,
@@ -82,7 +82,7 @@ class RestrictionMessage extends Message {
 	 */
 	protected function sendRepairMail() {
 		$body    = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-repair-body' );
-		$subject = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-repair-subject' );
+		$subject = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-repair-subject', 'sanitize_text_field' );
 
 		$this->prepareRestrictionMail(
 			$body,
@@ -97,7 +97,7 @@ class RestrictionMessage extends Message {
 	 */
 	protected function sendRestrictionCancelationMail() {
 		$body    = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-restriction-cancelled-body' );
-		$subject = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-restriction-cancelled-subject' );
+		$subject = Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-restriction-cancelled-subject', 'sanitize_text_field' );
 
 		$this->prepareRestrictionMail(
 			$body,

--- a/src/Messages/RestrictionMessage.php
+++ b/src/Messages/RestrictionMessage.php
@@ -116,7 +116,7 @@ class RestrictionMessage extends Message {
 	 * @throws \Exception
 	 */
 	protected function prepareRestrictionMail( $body, $subject ) {
-		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name', array($this, 'sanitizeNameInEmailHeader') ) .
+		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name', 'sanitize_text_field' ) .
 		              ' <' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-email' ) . '>';
 		$restriction = $this->getRestriction();
 

--- a/src/Messages/RestrictionMessage.php
+++ b/src/Messages/RestrictionMessage.php
@@ -116,7 +116,7 @@ class RestrictionMessage extends Message {
 	 * @throws \Exception
 	 */
 	protected function prepareRestrictionMail( $body, $subject ) {
-		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name', false ) .
+		$fromHeader = 'From: ' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-name', array($this, 'sanitizeNameInEmailHeader') ) .
 		              ' <' . Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-from-email' ) . '>';
 		$restriction = $this->getRestriction();
 

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -16,58 +16,30 @@ use function get_option;
 class Settings {
 
 	/**
-	 * array_flatten
-	 * Flattens a multidimensional array to get $key->value into a single dimension.
-	 *
-	 * @param mixed $array
-     * @param string|bool $parent
-     * @return array|bool
-     */
-	static function flattenArray( $array , $parent = false) {
-		if ( ! is_array( $array ) ) {
-			return false;
-		}
-		$result = array();
-
-		foreach ( $array as $key => $value ) {
-			if($parent === false) {
-				if ( is_array( $value ) ) {
-	                    $result = array_merge($result, self::flattenArray($value, $key));
-				} else {
-					$result[ $key ] = commonsbooking_sanitizeHTML($value);
-				}
-            } else {
-                $result[$parent][$key] = $value;
-            }
-
-		}
-
-		return $result;
-	}
-
-	/**
 	 * GetOption
 	 *
 	 * Retrieves a single value from the options table based on the options key and field_id
 	 *
 	 * @param $options_key
 	 * @param $field_id
+	 * @param $sanitizeFunction Optional. Function to sanitize return value (if array: each element recursively). Default: 'commonsbooking_sanitizeHTML'. Use false to not sanitize.
 	 *
-     * @return mixed
+	 * @return mixed
 	 */
-	public static function getOption( $options_key, $field_id ) {
+	public static function getOption( $options_key, $field_id, $sanitizeFunction = 'commonsbooking_sanitizeHTML' ) {
 		$cb_options_array = get_option( $options_key );
 
-		// as multiple values can be  stored as an multidimensional array we need to flatten the array into one dimensional array
-		$flat_array = self::flattenArray( $cb_options_array );
-
-		if ( is_array( $cb_options_array ) && array_key_exists( $field_id, $flat_array ) ) {
-			$result = $flat_array[ $field_id ];
+		if ( is_array( $cb_options_array ) && array_key_exists( $field_id, $cb_options_array ) ) {
+			$optionValue = $cb_options_array[ $field_id ];
+			if (function_exists($sanitizeFunction)) {
+				return map_deep($optionValue, $sanitizeFunction);
+			} else {
+				return $optionValue;
+			}
 		} else {
-			$result = false;
+			return false;
 		}
 
-		return $result;
 	}
 
 

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -31,7 +31,7 @@ class Settings {
 
 		if ( is_array( $cb_options_array ) && array_key_exists( $field_id, $cb_options_array ) ) {
 			$optionValue = $cb_options_array[ $field_id ];
-			if (function_exists($sanitizeFunction)) {
+			if (is_callable($sanitizeFunction)) {
 				return map_deep($optionValue, $sanitizeFunction);
 			} else {
 				return $optionValue;

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -7,22 +7,24 @@ use function get_option;
 /**
  * Settings class
  *
- * The Options are determined in the settings page and saved in the options table.
- * Each setting has a unique key and a field_id.
+ * The Options are accessible via the settings page and saved in the wp options table.
+ * Each setting has a unique options_key and a field_id.
  * Both are needed to write and read the option from the options table.
  *
- * The options are determined in the \includes\OptionsArray.php file
+ * The options are defined in the \includes\OptionsArray.php file
  */
 class Settings {
 
 	/**
 	 * GetOption
 	 *
-	 * Retrieves a single value from the options table based on the options key and field_id
+	 * Retrieves a single value from the options table based on options_key and field_id.
 	 *
-	 * @param $options_key
-	 * @param $field_id
-	 * @param $sanitizeFunction Optional. Function to sanitize return value (if array: each element recursively). Default: 'commonsbooking_sanitizeHTML'. Use false to not sanitize.
+	 * @param mixed $options_key
+	 * @param mixed $field_id
+	 * @param mixed $sanitizeFunction Optional. Function to sanitize return value. If an array, each element 
+     *                                 is sanitized recursively. Use false to not sanitize. 
+	 *                                 Default: 'commonsbooking_sanitizeHTML'. 
 	 *
 	 * @return mixed
 	 */
@@ -31,8 +33,8 @@ class Settings {
 
 		if ( is_array( $cb_options_array ) && array_key_exists( $field_id, $cb_options_array ) ) {
 			$optionValue = $cb_options_array[ $field_id ];
-			if (is_callable($sanitizeFunction)) {
-				return map_deep($optionValue, $sanitizeFunction);
+			if ( is_callable( $sanitizeFunction ) ) {
+				return map_deep( $optionValue, $sanitizeFunction );
 			} else {
 				return $optionValue;
 			}

--- a/tests/php/Settings/SettingsTest.php
+++ b/tests/php/Settings/SettingsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CommonsBooking\Tests\Settings;
+
+use CommonsBooking\Settings\Settings;
+use CommonsBooking\Wordpress\Options\AdminOptions;
+use PHPUnit\Framework\TestCase;
+
+class SettingsTest extends TestCase
+{
+
+    public function testGetOption()
+    {
+		AdminOptions::setOptionsDefaultValues();
+		$emailHeaderExpected = get_option( 'admin_email' );
+		$emailBodyActual = Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' );
+		$this->assertEquals($emailHeaderExpected, $emailBodyActual);
+    }
+}


### PR DESCRIPTION
Hallo zusammen,
wenn ein Absender-Name mit Sonderzeichen gewählt ist, in meinem Fall so:
![grafik](https://github.com/wielebenwir/commonsbooking/assets/2667894/340b04b8-9339-489f-8cc6-5bfed06f9a48)

Dann werden beim Senden die Sonderzeichen in HTML Entities in Settings::getOption mit commonsbooking_sanitizeHTML() umgewandelt. Leider sind HTML Entities wie &amp; in E-Mail-Headers nicht zulässig. Das Ergebnis:

![grafik](https://github.com/wielebenwir/commonsbooking/assets/2667894/146f745e-5dde-497a-8aaa-ad928a423a2f)

Ein "legales" Zeichen wie & soll besser einfach belassen werden. Mit diesem PR habe ich 

1. den Code in getOption vereinfacht. Die Funktion Settings::flattenArray tat gar nicht was der Name glauben lässt, sondern ließ die Array-Struktur exakt gleich bleiben. flattenArray ließ commonsbooking_sanitizeHTML auf jedes Element laufen. Das kann man besser mit der Wordpress-Funktion map_deep machen. Außerdem wurde unnötig viel Rechenleistung beansprucht, denn die gesamte Optionsarray wurde bisher mit commonsbooking_sanitizeHTML bearbeitet, nicht nur das zurückzugebende Element.
2. einen neuen Parameter $sanitizeFunction für getOption() eingeführt. Defaultwert ist commonsbooking_sanitizeHTML, so dass das Verhalten unverändert bleibt, wenn die Funktion wie bisher aufgerufen wird. Dies habe ich getestet. Die Rückgabewert ist immer exakt wie bisher.
3. Für drei Message-Arten habe ich ausgeschaltet, dass das From-Feld (Teil mit dem Namen) mit commonsbooking_sanitizeHTML bearbeitet wird.

Damit kommen die Mails mit dem korrekten From-Namen an.

Ich bin gespannt, was ihr von meinem ersten PR hält. Ich passe es bei Bedarf gerne noch an und finde es ebenfalls super, wenn ihr das Problem auf einer alternativen Art und Weise löst.
