### PR TITLE
Bugfix/issue 1429 (Zeitzone Cronjobs)

### DIFF
--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -744,7 +744,7 @@ For booking details and cancellation, click on this booking link: {{booking:book
 						'name'             => esc_html__( 'Time', 'commonsbooking' ),
 						'id'               => 'pre-booking-time',
 						'desc'             => '<br>' . commonsbooking_sanitizeHTML( __(
-								'Define when the reminder should be sent. The actual sending may differ from the defined value by a few hours, depending on how your WordPress is configured.'
+								'Define when the reminder should be sent.'
 								, 'commonsbooking' ) ),
 						'type'             => 'select',
 						'show_option_none' => false,

--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -296,11 +296,43 @@ class Wordpress {
 		return $dto;
 	}
 
+	/**
+	 * This function does no actual conversion to another timezone, it just sets the timezone to UTC
+	 *
+	 * @param $datetime
+	 *
+	 * @return DateTime
+	 * @throws \Exception
+	 */
 	public static function getUTCDateTime($datetime = 'now'): DateTime {
 		$dto = new DateTime($datetime);
 		$dto->setTimezone(new \DateTimeZone('UTC'));
 
 		return $dto;
+	}
+
+	/**
+	 * Converts a datestring to a Datetime object in the UTC timezone.
+	 * Modelled after WordPress get_gmt_from_date().
+	 *
+	 * As opposed to @see self::getUTCDateTime()
+	 * this function sees the datestring as local time and converts the time to UTC.
+	 * @param $dateString
+	 *
+	 * @return DateTime
+	 * @throws \Exception
+	 */
+	public static function getUTCFromDate ($dateString): DateTime {
+		$datetime = date_create( $dateString, wp_timezone() );
+
+		if ( $datetime === false ) {
+			//use this as fallback if date_create fails
+			return self::getUTCDateTime( $dateString );
+		}
+
+		$datetime->setTimezone( new \DateTimeZone( 'UTC' ) );
+
+		return $datetime;
 	}
 
 	public static function getLocalDateTime($timestamp): DateTime {

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -2,6 +2,7 @@
 
 namespace CommonsBooking\Service;
 
+use CommonsBooking\Helper\Wordpress;
 use CommonsBooking\Settings\Settings;
 use CommonsBooking\View\TimeframeExport;
 
@@ -52,15 +53,15 @@ class Scheduler {
 			$this->unscheduleJob();
 			return false;
 		}
-
 		if (empty($executionTime)){
 			$this->timestamp = time();
-		} 
+		}
 		elseif ($reccurence == 'daily'){
-			$this->timestamp = strtotime($executionTime);
-			if($this->timestamp < time()) { //if timestamp is in the past, add one day
-				$this->timestamp = strtotime("+1 day",$this->timestamp);
+			$dto = Wordpress::getUTCFromDate( $executionTime );
+			if( $dto->getTimestamp() < current_time( 'timestamp', true ) ) { //if timestamp is in the past, add one day
+				$dto->modify('+1 day');
 			}
+			$this->timestamp = $dto->getTimestamp();
 		}
 		else {
 			return false;

--- a/tests/php/Helper/WordpressTest.php
+++ b/tests/php/Helper/WordpressTest.php
@@ -85,6 +85,14 @@ class WordpressTest extends CustomPostTypeTest
 		$this->assertEquals( 5, count( $related ));
     }
 
+	public function testGetUTCFromDate() {
+		update_option( 'timezone_string', 'Europe/Berlin' );
+		$local = '2023-11-27 17:43:56';
+		$gmt   = '2023-11-27 16:43:56';
+		$dt = Wordpress::getUTCFromDate( $local );
+		$this->assertEquals( $gmt, $dt->format( 'Y-m-d H:i:s' ) );
+	}
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->timeframeId = $this->createBookableTimeFrameIncludingCurrentDay();


### PR DESCRIPTION
Habe jetzt doch nicht wie geplant die get_gmt_from_date (  https://developer.wordpress.org/reference/functions/get_gmt_from_date/ ) genutzt sondern nur die Implementierung kopiert und dafür ein DateTime Objekt statt eines formatierten Strings zurückgegeben. Das hat jetzt bei mir wie erwartet funktioniert. Das ist hier für den einen Case nicht so spannend, aber mit der #1423 kommen zwei neue E-Mails hinzu die diese Funktion nutzen, da wird das schon semi relevant. 