### PR TITLE
Bugfix/issue 1428 (Positionierungskarte)

### DIFF
--- a/assets/map/js/cb-map-positioning.js
+++ b/assets/map/js/cb-map-positioning.js
@@ -69,7 +69,7 @@ var cb_map_positioning = {
         }
 
         const noAddressFound = function () {
-            // show error message if adress couldnt be found
+            // show error message if address couldn't be found
             if(document.getElementById("_cb_location_street").value.length != 0)
             {
                 jQuery( "#nogpsresult" ).show();

--- a/assets/map/js/cb-map-positioning.js
+++ b/assets/map/js/cb-map-positioning.js
@@ -7,8 +7,6 @@ var cb_map_positioning = {
         // set up the map
         map = new L.Map('cb_positioning_map');
 
-        const self = this;
-        
         // possible fix to avoid missing tiles, found on: https://stackoverflow.com/questions/38832273/leafletjs-not-loading-all-tiles-until-moving-map
         // also see https://github.com/wielebenwir/commonsbooking/issues/1060
         map.on("load", function() { setTimeout(() => {
@@ -70,6 +68,19 @@ var cb_map_positioning = {
             limit: 1
         }
 
+        const noAddressFound = function () {
+            // show error message if adress couldnt be found
+            if(document.getElementById("_cb_location_street").value.length != 0)
+            {
+                jQuery( "#nogpsresult" ).show();
+            }
+            cb_map_positioning.init_map(
+                cb_map_positioning.defaults.latitude || 50.937531,
+                cb_map_positioning.defaults.longitude || 6.960279,
+                false
+            );
+        }
+
 
         jQuery.getJSON(url, params, function (data) {
 
@@ -80,19 +91,12 @@ var cb_map_positioning = {
                 cb_map_positioning.set_marker_position( data[0].lat, data[0].lon );
   
             } else {
-        
-                // show error message if adress couldnt be found
-                if(document.getElementById("_cb_location_street").value.length != 0)
-                {
-                    jQuery( "#nogpsresult" ).show();
-                }
-                cb_map_positioning.init_map(
-                    cb_map_positioning.defaults.latitude || 50.937531,
-                    cb_map_positioning.defaults.longitude || 6.960279,
-                    false
-                );
+                noAddressFound();
             }
 
+        })
+        .fail(function() {
+            noAddressFound();
         });
     },
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -667,7 +667,7 @@ class Plugin {
 		add_filter( 'parent_file', array( $this, 'setParentFile' ) );
 
 		// register scripts
-		add_action('wp_enqueue_scripts', array($this, 'registerScriptsAndStyles'));
+		add_action('init', array($this, 'registerScriptsAndStyles'));
 
 		// register shortcodes
 		add_action('init', array($this, 'registerShortcodes'));

--- a/src/View/Map.php
+++ b/src/View/Map.php
@@ -3,6 +3,7 @@
 namespace CommonsBooking\View;
 
 use CommonsBooking\Map\MapAdmin;
+use CommonsBooking\Plugin;
 
 /**
  * The Map shortcode. Further logic is found in @see \CommonsBooking\Map\
@@ -13,6 +14,7 @@ class Map extends View {
 	 * load needed assets for the map that provides fine tuning of the location's position
 	 **/
 	public static function render_cb_map( $field, $escaped_value, $object_id, $object_type, $field_type_object ) {
+		Plugin::registerScriptsAndStyles(); //usually, these scripts are only registered on the frontend, but we need the map here so we register them here as well
 		//map
 		wp_enqueue_style( 'cb-leaflet');
 		wp_enqueue_script( 'cb-leaflet');

--- a/src/View/Map.php
+++ b/src/View/Map.php
@@ -14,7 +14,6 @@ class Map extends View {
 	 * load needed assets for the map that provides fine tuning of the location's position
 	 **/
 	public static function render_cb_map( $field, $escaped_value, $object_id, $object_type, $field_type_object ) {
-		Plugin::registerScriptsAndStyles(); //usually, these scripts are only registered on the frontend, but we need the map here so we register them here as well
 		//map
 		wp_enqueue_style( 'cb-leaflet');
 		wp_enqueue_script( 'cb-leaflet');

--- a/tests/cypress/e2e/cpt-creation.cy.js
+++ b/tests/cypress/e2e/cpt-creation.cy.js
@@ -34,7 +34,8 @@ describe('correctly render metaboxes for backend CPT creation', () => {
         cy.get('#_cb_location_info').should('exist');
 	    //TODO: This does not capture all metaboxes in screenshot because of a scrolling div, fix to show metaboxes
         //we abuse the fact here, that cypress refuses to take a screenshot if the map does not work, maybe we can do this more elegantly
-        cy.get('#cb_positioning_map').scrollIntoView().screenshot('cb-location-metaboxes-positioning-map')
+        //wait a bit for the map to load
+        cy.wait(5000).get('#cb_positioning_map').scrollIntoView().screenshot('cb-location-metaboxes-positioning-map')
     })
 
     it('shows timeframe metaboxes', () => {

--- a/tests/cypress/e2e/cpt-creation.cy.js
+++ b/tests/cypress/e2e/cpt-creation.cy.js
@@ -27,13 +27,14 @@ describe('correctly render metaboxes for backend CPT creation', () => {
         cy.screenshot('cb-item-metaboxes')
     })
 
-    it('shows location metaboxes', () => {
+    it.only('shows location metaboxes', () => {
         cy.visit( '/wp-admin/edit.php?post_type=cb_location' );
         cy.get('.page-title-action').click();
         cy.get('#_cb_location_adress').should('exist');
         cy.get('#_cb_location_info').should('exist');
-	//TODO: This does not capture all metaboxes in screenshot because of a scrolling div, fix to show metaboxes
-        cy.screenshot('cb-location-metaboxes')
+	    //TODO: This does not capture all metaboxes in screenshot because of a scrolling div, fix to show metaboxes
+        //we abuse the fact here, that cypress refuses to take a screenshot if the map does not work, maybe we can do this more elegantly
+        cy.get('#cb_positioning_map').scrollIntoView().screenshot('cb-location-metaboxes-positioning-map')
     })
 
     it('shows timeframe metaboxes', () => {

--- a/tests/cypress/e2e/cpt-creation.cy.js
+++ b/tests/cypress/e2e/cpt-creation.cy.js
@@ -27,11 +27,12 @@ describe('correctly render metaboxes for backend CPT creation', () => {
         cy.screenshot('cb-item-metaboxes')
     })
 
-    it.only('shows location metaboxes', () => {
+    it('shows location metaboxes', () => {
         cy.visit( '/wp-admin/edit.php?post_type=cb_location' );
         cy.get('.page-title-action').click();
         cy.get('#_cb_location_adress').should('exist');
         cy.get('#_cb_location_info').should('exist');
+        cy.screenshot('cb-location-metaboxes')
 	    //TODO: This does not capture all metaboxes in screenshot because of a scrolling div, fix to show metaboxes
         //we abuse the fact here, that cypress refuses to take a screenshot if the map does not work, maybe we can do this more elegantly
         //wait a bit for the map to load

--- a/tests/cypress/e2e/cpt-frontend-pages.cy.js
+++ b/tests/cypress/e2e/cpt-frontend-pages.cy.js
@@ -9,6 +9,8 @@ describe('check load of CPT frontend pages where available', () => {
       //Check that location is correctly assigned
       cy.get('.cb-title > a').contains(testName);
       cy.get('.cb-timeframe-calendar').should('be.visible');
+      cy.get('#cb_locationview_map').should('be.visible')
+      cy.get('#cb_locationview_map').scrollIntoView().screenshot('cb-itemtemplate-locationview-map')
   })
   it ('loads locations', () => {
       cy.visit('/?cb_location=basictest-koln-dom-locmap-noadmin')
@@ -18,6 +20,7 @@ describe('check load of CPT frontend pages where available', () => {
       cy.get('.entry-title').contains(testName);
       //check for location map
       cy.get('#cb_locationview_map').should('be.visible')
+      cy.get('#cb_locationview_map').scrollIntoView().screenshot('cb-locationtemplate-locationview-map')
       //check address
       cy.get('.cb-location-address > :nth-child(2)').contains("Domkloster 4, 50667 Köln")
       //check item

--- a/tests/cypress/wordpress-files/e2e-override.json
+++ b/tests/cypress/wordpress-files/e2e-override.json
@@ -2,7 +2,8 @@
   "phpVersion": "VERSION_PLACEHOLDER",
   "plugins": [
     "./build/commonsbooking",
-    "https://downloads.wordpress.org/plugin/wordpress-importer.zip"
+    "https://downloads.wordpress.org/plugin/wordpress-importer.zip",
+    "https://downloads.wordpress.org/plugin/disable-welcome-messages-and-tips.zip"
   ],
   "themes": [
     "flegfleg/kasimir-theme"


### PR DESCRIPTION
In den Feldern für die Erstellung / des Bearbeitens eines Standorts wird automatisch die Karte für die Adresse abgerufen (wenn keine Latitude oder Longitude übergeben wurde). Vorher hat das auch für neue Posts funktioniert, weil die API bei leerer Adresse einfach eine leere Antwort gegeben hat um dann die Default Koordinaten einzustellen. Anscheinend haben die bei OSM ihre API geändert, jetzt schlägt der JSON Befehl fehl, wenn keine Addresse definiert wurde (wie zum Beispiel bei einem neuen Artikel). Das alte JS hat mit einer leeren Antwort gerechnet und nicht den "fail" case in Betracht gezogen, das wurde jetzt nachgeholt.

Ich vermute, dass dieser Fehler schon seit einer ganzen Weile existiert, er ist mir über ein altes Tutorial Video von vor einem Jahr aufgefallen.

Zu dem neuen Frontend: Das registriert jetzt die Skripte über eine Funktion, die nur mit dem wp_enqueue_scripts hook aufgerufen wird. Dieser Hook wird normalerweise nur im Frontend getriggert und hat deshalb auch nicht für eine Karte im Backend ausgelöst. Demnach konnte die Karte im Backend nicht initialisiert werden.

closes #1428 

Dieser Bugfix ließe sich theoretisch auch "backporten". Der commit [718f6e4](https://github.com/wielebenwir/commonsbooking/pull/1431/commits/718f6e46e9bda284a621b1f056a4800973019810) würde auch das Problem für 2.8.5 beheben. Ist jedoch nur ein kleines ästhetisches Ding ohne große Funktion.