### PR TITLE
show excerpt element in map #1300

### DIFF
--- a/assets/public/css/public.css
+++ b/assets/public/css/public.css
@@ -4232,9 +4232,6 @@
   color: #444;
   background: linear-gradient(to top left, var(--commonsbooking-color-cancel) 0%, var(--commonsbooking-color-cancel) calc(50% - 1px), #333 50%, var(--commonsbooking-color-cancel) calc(50% + 1px), var(--commonsbooking-color-cancel) 100%);
 }
-.cb-wrapper .leaflet-popup-content .cb-map-popup-item-desc {
-  display: none;
-}
 
 /* Filters */
 .cb-map-filters.cb-wrapper {

--- a/assets/public/sass/partials/_map.scss
+++ b/assets/public/sass/partials/_map.scss
@@ -139,11 +139,6 @@
 			  color: #444;
 			  background: linear-gradient(to top left, var(--commonsbooking-color-cancel) 0%, var(--commonsbooking-color-cancel) calc(50% - 1px), #333 50%, var(--commonsbooking-color-cancel) calc(50% + 1px), var(--commonsbooking-color-cancel) 100%);
 			}
-			
-			.cb-map-popup-item-desc {
-				display: none;
-			}
-				
 	}
 
 }


### PR DESCRIPTION
Ermöglicht den Text mit dem post_excerpt im Popup anzuzeigen. Das war auch ursprünglich aktiviert im CB1 Karten Plugin:
![image](https://github.com/wielebenwir/commonsbooking/assets/6433480/eb1ac076-f759-4ace-a9df-f483acc29b0d)


Die Funktion existierte also schon, wurde aber anscheinend per CSS ausgeschaltet. Gibt es dafür einen triftigen Grund? 
Das wurde damals in commit 0e90d291a6d952b269edbe7bf9d43ad4a6a13c9b deaktiviert und dann nie wieder eingeführt. 

closes #1300