### PR TITLE
Minimalstatistiken

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,7 @@ use CommonsBooking\Service\Upgrade;
 use CommonsBooking\Settings\Settings;
 use CommonsBooking\Repository\BookingCodes;
 use CommonsBooking\View\Dashboard;
+use CommonsBooking\View\Statistics;
 use CommonsBooking\Wordpress\CustomPostType\CustomPostType;
 use CommonsBooking\Wordpress\CustomPostType\Item;
 use CommonsBooking\Wordpress\CustomPostType\Location;
@@ -597,6 +598,7 @@ class Plugin {
 
 	public function registerShortcodes() {
 		add_shortcode('cb_search', array(new SearchShortcode(), 'execute'));
+		add_shortcode( 'cb_statistics', array( Statistics::class, 'shortcode' ) );
 	}
 
 	/**

--- a/src/View/Statistics.php
+++ b/src/View/Statistics.php
@@ -50,16 +50,19 @@ class Statistics extends View {
 		return count( $posts );
 	}
 
-	public static function countConfirmed( $posts ): int {
-		$bookings = array_filter( $posts, fn( $post ) => $post->post_type == 'cb_booking' );
-		return count( array_filter( $bookings, fn( $booking ) => $booking->isConfirmed() ) );
+	private static function getProperty( $post, $property ) {
+		if ( method_exists( $post, $property ) ) {
+			return $post->{$property}();
+		} else {
+			return $post->getMeta( $property );
+		}
 	}
 
 	public static function sumMeta( $posts, $metaValue ): int {
-		return array_sum( array_map( fn( $post ) => $post->getMeta( $metaValue ), $posts ) );
+		return array_sum( array_map( fn( $post ) => self::getProperty( $post, $metaValue ), $posts ) );
 	}
 
 	public static function countMeta( $posts, $metaValue ): int {
-		return count( array_filter( $posts, fn( $post ) => $post->getMeta( $metaValue ) ) );
+		return count( array_filter( $posts, fn( $post ) => self::getProperty( $post, $metaValue ) ) );
 	}
 }

--- a/src/View/Statistics.php
+++ b/src/View/Statistics.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace CommonsBooking\View;
+
+class Statistics extends View {
+
+	public static function __callStatic( $name, $arguments ) {
+		if ( strpos( $name, 'sum_' ) === 0 ) {
+			$metaValue = str_replace('sum_', '', $name);
+			return self::sumMeta($arguments[0], $metaValue);
+		}
+		elseif ( strpos( $name, 'count_' ) === 0 ) {
+			$metaValue = str_replace('count_', '', $name);
+			return self::countMeta($arguments[0], $metaValue);
+		}
+	}
+
+	public static function shortcode( $args ) {
+		$args = shortcode_atts( [
+			'do' => '',
+			'type' => '',
+		], $args, 'cb_statistics' );
+
+		$fn = $args['do'];
+		$type = $args['type'];
+
+		if ( ! $fn || ! $type ) {
+			return '';
+		}
+
+		switch ($type) {
+			case 'booking':
+				$posts = \CommonsBooking\Repository\Booking::get( [], [], null, true );
+				break;
+			case 'item':
+				$posts = \CommonsBooking\Repository\Item::get([],true);
+				break;
+			case 'location':
+				$posts = \CommonsBooking\Repository\Location::get([],true);
+				break;
+			default:
+				return '';
+		}
+
+		return self::$fn( $posts );
+
+	}
+
+	public static function count( $posts ): int {
+		return count( $posts );
+	}
+
+	public static function countConfirmed( $posts ): int {
+		$bookings = array_filter( $posts, fn( $post ) => $post->post_type == 'cb_booking' );
+		return count( array_filter( $bookings, fn( $booking ) => $booking->isConfirmed() ) );
+	}
+
+	public static function sumMeta( $posts, $metaValue ): int {
+		return array_sum( array_map( fn( $post ) => $post->getMeta( $metaValue ), $posts ) );
+	}
+
+	public static function countMeta( $posts, $metaValue ): int {
+		return count( array_filter( $posts, fn( $post ) => $post->getMeta( $metaValue ) ) );
+	}
+}

--- a/src/View/Statistics.php
+++ b/src/View/Statistics.php
@@ -13,6 +13,10 @@ class Statistics extends View {
 			$metaValue = str_replace('count_', '', $name);
 			return self::countMeta($arguments[0], $metaValue);
 		}
+		elseif ( strpos( $name, 'avg_' ) === 0 ) {
+			$metaValue = str_replace('avg_', '', $name);
+			return self::avgMeta($arguments[0], $metaValue);
+		}
 	}
 
 	public static function shortcode( $args ) {
@@ -64,5 +68,11 @@ class Statistics extends View {
 
 	public static function countMeta( $posts, $metaValue ): int {
 		return count( array_filter( $posts, fn( $post ) => self::getProperty( $post, $metaValue ) ) );
+	}
+
+	public static function avgMeta( $posts, $metaValue ): int {
+		$sum = self::sumMeta($posts, $metaValue);
+		$count = self::countMeta($posts, $metaValue);
+		return $sum / $count;
 	}
 }

--- a/src/View/Statistics.php
+++ b/src/View/Statistics.php
@@ -34,7 +34,7 @@ class Statistics extends View {
 
 		switch ($type) {
 			case 'booking':
-				$posts = \CommonsBooking\Repository\Booking::get( [], [], null, true );
+				$posts = \CommonsBooking\Repository\Booking::get( [], [], null, true, null, ['confirmed', 'unconfirmed', 'canceled', 'publish', 'inherit'] );
 				break;
 			case 'item':
 				$posts = \CommonsBooking\Repository\Item::get([],true);


### PR DESCRIPTION
Verwendung:

Im Fließtext einbauen, keinen eigenen Shortcode Block. Dann [cb_statistics do=Funktion type=item|location|booking]

Es gibt die Funktion count, die zählt alle Vorkomnisse und dann noch die mächtigen Funktionen count_xxx sum_xxx und avg_xxx , das xxx ist dabei entweder der Rückgabewert einer Funktion des jeweiligen Models oder wenn es eine solche Funktion nicht gibt der Metawert. Damit sollten sich alle möglichen Statistiken zusammenstecken lassen. Aber natürlich lässt sich damit auch Schabernack treiben, z.B. könnte jemand den Shortcode [cb_statistics do=cancel type=booking] anlegen, dann würden alle Buchungen im System storniert werden. Die Implementierung hier ist dafür aber nicht sonderlich schwierig zu implementieren und neue Möglichkeiten für Statistiken können einfach durch neue Methoden in der Model Klasse eingerichtet werden.


Beispiel:

Aktuell haben wir [cb_statistics do=count type=item] Artikel und [cb_statistics do=count type=location] Standorte. Von allen Buchungen die wir haben sind [cb_statistics do=count_isConfirmed type=booking] bestätigte Buchungen. Die durschnittliche Postleitzahl ist [cb_statistics do=avg__cb_location_postcode type=location].
