### PR TITLE
Introduce pdo driver for symfony cache

### DIFF
--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1160,6 +1160,39 @@ Return date: {{booking:returnDatetime}}
 						'id'            => 'redis_connection-status',
 						'type'          => 'text',
 						'render_row_cb' => array( \CommonsBooking\Plugin::class, 'renderREDISConnectionStatus' ),
+					),
+
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Enable PDO Caching (experimental)', 'commonsbooking' ) ),
+						'id'            => 'pdo_enabled',
+						'type'          => 'checkbox'
+					),
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'PDO DSN', 'commonsbooking' ) ),
+						'id'            => 'pdo_dsn',
+						'type'          => 'text',
+						'default'       => 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=' . DB_CHARSET
+					),
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Database Username', 'commonsbooking' ) ),
+						'id'            => 'pdo_user',
+						'type'          => 'text',
+						'default'       => DB_USER,
+					),
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Database Password', 'commonsbooking' ) ),
+						'id'            => 'pdo_pass',
+						'type'          => 'text',
+						'attributes'    => array(
+							'type' => 'password',
+						),
+						'default'       => DB_PASSWORD,
+					),
+					array(
+						'name'          => commonsbooking_sanitizeHTML( __( 'Current connection status', 'commonsbooking' ) ),
+						'id'            => 'pdo_connection-status',
+						'type'          => 'text',
+						'render_row_cb' => array( \CommonsBooking\Plugin::class, 'renderPDOConnectionStatus' ),
 					)
 				)
 			),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,10 +25,13 @@ use CommonsBooking\Wordpress\CustomPostType\Timeframe;
 use CommonsBooking\Wordpress\Options\AdminOptions;
 use CommonsBooking\Wordpress\Options\OptionsTab;
 use CommonsBooking\Wordpress\PostStatus\PostStatus;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 class Plugin {
 
 	use Cache;
+
+	private static TagAwareAdapterInterface $pdoAdapter;
 
 	/**
 	 * CB-Manager id.


### PR DESCRIPTION
This enables database based caching (mysql) via Symfony PDOAdapter for hosts where file based caching is not possible. 

When a redis connection and pdo is enabled, pdo is used for caching and redis is used for caching the tags.

TODO
- [ ] although it works. The pdoAdapter member variable which holds the adapter instance bloats the Plugin/Cache interface (bc it's private). It  should be moved in a separated holder type.