### PR TITLE
Bugfix/issue 1461 (Metaboxen Custom CB-Manager)

### DIFF
--- a/includes/Users.php
+++ b/includes/Users.php
@@ -206,7 +206,9 @@ function commonsbooking_isCurrentUserSubscriber() {
 function commonsbooking_isCurrentUserCBManager() {
 	$user = wp_get_current_user();
 
-	return apply_filters( 'commonsbooking_isCurrentUserCBManager', in_array( Plugin::$CB_MANAGER_ID, $user->roles ), $user );
+	$isManager = ! empty( array_intersect( \CommonsBooking\Repository\UserRepository::getManagerRoles(), $user->roles ) );
+
+	return apply_filters( 'commonsbooking_isCurrentUserCBManager', $isManager, $user );
 
 }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -85,6 +85,7 @@ class Plugin {
 		foreach ( $adminAllowedCPT as $customPostType ) {
 			self::addRoleCaps( $customPostType::$postType, 'administrator' );
 			//assign all capabilities of admin to CB-Manager (see comment above)
+			//We deliberately don't use the getManagerRoles from the UserRepository here, because the custom roles should be able to define their own permissions
 			self::addRoleCaps( $customPostType::$postType, self::$CB_MANAGER_ID );
 		}
 		/*
@@ -102,6 +103,7 @@ class Plugin {
 	public static function getRoleCapMapping( $roleName = null) {
 		if ( $roleName === null ) {
 			return [
+				//We deliberately don't use the getManagerRoles from the UserRepository here, because the custom roles should be able to define their own permissions
 				self::$CB_MANAGER_ID => [
 					'read'                                 => true,
 					'manage_' . COMMONSBOOKING_PLUGIN_SLUG => true,

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -14,9 +14,11 @@ class UserRepository {
 	 * @return mixed
 	 */
 	public static function getSelectableCBManagers() {
-        $managerRoles = [Plugin::$CB_MANAGER_ID];
-        $managerRoles = apply_filters("commonsbooking_manager_roles",$managerRoles);
-        return get_users( ['role__in' => $managerRoles] );
+        return get_users( ['role__in' => self::getManagerRoles()] );
+	}
+
+	public static function getManagerRoles() : array {
+		return apply_filters("commonsbooking_manager_roles",[Plugin::$CB_MANAGER_ID]);
 	}
 
 	/**


### PR DESCRIPTION
Nur minimale Änderung die vergessen wurde um das Feature konsequent durchzuziehen. Jetzt kann der Hook commonsbooking_manager_roles wie in der Dokumentation beschrieben verwendet werden. Wenn für den Custom Manager die Berechtigungen manuell genau wie die für den CB-Manager gesetzt werden, dann kann diese Rolle genau so viel wie ein CB-Manager.

closes #1461