### PR TITLE
Bugfix/issue 1463 (commonsbooking_admin_roles Hook verwirrend)

### DIFF
--- a/includes/Users.php
+++ b/includes/Users.php
@@ -138,7 +138,7 @@ function commonsbooking_custom_view_count( $views ) {
 // fixes counts for custom posts countings in admin list
 function commonsbooking_fix_view_counts( $postType, $views ) {
 	// admin is allowed to see all posts
-	if(current_user_can('administrator')) {
+	if( commonsbooking_isCurrentUserAdmin() ){
 		return $views;
 	}
 
@@ -169,9 +169,10 @@ function commonsbooking_fix_view_counts( $postType, $views ) {
 
 // Check if current user has admin role
 function commonsbooking_isCurrentUserAdmin() {
+	if (! is_user_logged_in() ) { return false; }
 	$user = wp_get_current_user();
 
-	return apply_filters( 'commonsbooking_isCurrentUserAdmin', in_array( 'administrator', $user->roles ), $user );
+	return apply_filters( 'commonsbooking_isCurrentUserAdmin', commonsbooking_isUserAdmin( $user ) );
 }
 
 /**
@@ -185,9 +186,7 @@ function commonsbooking_isCurrentUserAdmin() {
  * @return bool
  */
 function commonsbooking_isUserAdmin(\WP_User $user) {
-	$adminRoles = ['administrator'];
-	$adminRoles = apply_filters('commonsbooking_admin_roles', $adminRoles);
-	foreach ($adminRoles as $adminRole) {
+	foreach (\CommonsBooking\Repository\UserRepository::getAdminRoles() as $adminRole) {
 		if (in_array($adminRole, $user->roles)) {
 			return true;
 		}
@@ -220,7 +219,7 @@ function commonsbooking_isCurrentUserCBManager() {
 function commonsbooking_isCurrentUserAllowedToBook( $timeframeID ):bool {
 	$allowedUserRoles = get_post_meta( $timeframeID, \CommonsBooking\Model\Timeframe::META_ALLOWED_USER_ROLES, true );
 
-	if ( empty( $allowedUserRoles ) || ( current_user_can('administrator') ) ) {
+	if ( empty( $allowedUserRoles ) || ( commonsbooking_isCurrentUserAdmin() ) ) {
 		return true;
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,7 @@ use CommonsBooking\Map\LocationMapAdmin;
 use CommonsBooking\Map\SearchShortcode;
 use CommonsBooking\Model\Booking;
 use CommonsBooking\Model\BookingCode;
+use CommonsBooking\Repository\UserRepository;
 use CommonsBooking\Service\Cache;
 use CommonsBooking\Service\Scheduler;
 use CommonsBooking\Service\iCalendar;
@@ -83,7 +84,9 @@ class Plugin {
 		$CBManagerAllowedCPT = self::getCBManagerCustomPostTypes();
 		// Add capabilities for user roles
 		foreach ( $adminAllowedCPT as $customPostType ) {
-			self::addRoleCaps( $customPostType::$postType, 'administrator' );
+			foreach ( UserRepository::getAdminRoles() as $adminRole ){
+				self::addRoleCaps( $customPostType::$postType, $adminRole );
+			}
 			//assign all capabilities of admin to CB-Manager (see comment above)
 			self::addRoleCaps( $customPostType::$postType, self::$CB_MANAGER_ID );
 		}
@@ -101,17 +104,20 @@ class Plugin {
 	 */
 	public static function getRoleCapMapping( $roleName = null) {
 		if ( $roleName === null ) {
-			return [
+			$capabilities = [
 				self::$CB_MANAGER_ID => [
 					'read'                                 => true,
 					'manage_' . COMMONSBOOKING_PLUGIN_SLUG => true,
-				],
-				'administrator'      => [
+				]
+			];
+			foreach ( UserRepository::getAdminRoles() as $adminRole ) {
+				$capabilities[$adminRole] = [
 					'read'                                 => true,
 					'edit_posts'                           => true,
 					'manage_' . COMMONSBOOKING_PLUGIN_SLUG => true,
-				],
-			];
+				];
+			}
+			return $capabilities;
 		}
 		else {
 			$roleCapMapping = self::getRoleCapMapping();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,7 +9,6 @@ use CommonsBooking\Map\LocationMapAdmin;
 use CommonsBooking\Map\SearchShortcode;
 use CommonsBooking\Model\Booking;
 use CommonsBooking\Model\BookingCode;
-use CommonsBooking\Repository\UserRepository;
 use CommonsBooking\Service\Cache;
 use CommonsBooking\Service\Scheduler;
 use CommonsBooking\Service\iCalendar;
@@ -84,9 +83,7 @@ class Plugin {
 		$CBManagerAllowedCPT = self::getCBManagerCustomPostTypes();
 		// Add capabilities for user roles
 		foreach ( $adminAllowedCPT as $customPostType ) {
-			foreach ( UserRepository::getAdminRoles() as $adminRole ){
-				self::addRoleCaps( $customPostType::$postType, $adminRole );
-			}
+			self::addRoleCaps( $customPostType::$postType, 'administrator' );
 			//assign all capabilities of admin to CB-Manager (see comment above)
 			self::addRoleCaps( $customPostType::$postType, self::$CB_MANAGER_ID );
 		}
@@ -104,20 +101,17 @@ class Plugin {
 	 */
 	public static function getRoleCapMapping( $roleName = null) {
 		if ( $roleName === null ) {
-			$capabilities = [
+			return [
 				self::$CB_MANAGER_ID => [
 					'read'                                 => true,
 					'manage_' . COMMONSBOOKING_PLUGIN_SLUG => true,
-				]
-			];
-			foreach ( UserRepository::getAdminRoles() as $adminRole ) {
-				$capabilities[$adminRole] = [
+				],
+				'administrator'      => [
 					'read'                                 => true,
 					'edit_posts'                           => true,
 					'manage_' . COMMONSBOOKING_PLUGIN_SLUG => true,
-				];
-			}
-			return $capabilities;
+				],
+			];
 		}
 		else {
 			$roleCapMapping = self::getRoleCapMapping();

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -20,6 +20,14 @@ class UserRepository {
 	}
 
 	/**
+	 * Will get all roles that are considered by CommonsBooking as "Administrator" roles
+	 * @return array
+	 */
+	public static function getAdminRoles() : array {
+		return apply_filters('commonsbooking_admin_roles', ['administrator']);
+	}
+
+	/**
 	 * Returns all users with items/locations.
 	 * @return array
 	 */


### PR DESCRIPTION
Ich habe mich dagegen entschieden den von den Nutzenden erstellten Administratoren (bzw cb-admins) alle Berechtigungen auf die Instanz zu geben.
1. Der Hook wird nur bei einem Update ausgeführt, demnach sparen wir uns etwas Trickserei
2. Die Nutzenden sollen möglichst viel Kontrolle über die Fähigkeiten dieses Custom CB-Admin haben, wenn bei jedem Update die Berechtigungen zurückgesetzt werden ist das nicht so knorke. 

Und das Zuweisen neuer Berechtigungen ist mit einem Plugin wie User Role Editor ja auch keine große Sache.

closes #1463