### PR TITLE
Fix (variant 1) for special characters in e-mail subject (issue 1433)

### DIFF
--- a/includes/TemplateParser.php
+++ b/includes/TemplateParser.php
@@ -8,7 +8,7 @@ use CommonsBooking\CB\CB;
  * @param string $template
  * @param array  $objects
  *
- * @return mixed
+ * @return The parsed template as string (don't forget to sanitize)
  */
 function commonsbooking_parse_template( string $template = '', $objects = [] ) {
 	$template = preg_replace_callback(
@@ -51,14 +51,14 @@ function commonsbooking_parse_template_callback( $match, array $objects = [] ) {
 
         // extract the html before part, looking for {{[*] pattern
         if ( preg_match( '/\{\{\[([^\]]*)\]/m', $match, $html_before ) === 1 ) {
-            $html_before = commonsbooking_sanitizeHTML( preg_replace( '/(\{\{)|(\}\})|(\[)|(\])/m', '', $html_before[1] ) );
+            $html_before = preg_replace( '/(\{\{)|(\}\})|(\[)|(\])/m', '', $html_before[1] );
         } else {
             $html_before = '';
         }
 
         // extract the html after part looking for [*]}} pattern
         if ( preg_match( '/\[([^\]]*)\]\}\}/m', $match, $html_after ) === 1 ) {
-            $html_after = commonsbooking_sanitizeHTML( preg_replace( '/(\{\{)|(\}\})|(\[)|(\])/m', '', $html_after[1] ) );
+            $html_after = preg_replace( '/(\{\{)|(\}\})|(\[)|(\])/m', '', $html_after[1] );
         } else {
             $html_after = '';
         }

--- a/src/CB/CB.php
+++ b/src/CB/CB.php
@@ -26,7 +26,7 @@ class CB {
 	 * @param \WP_Post|WP_User $wpObject
 	 * @param mixed $args
 	 *
-	 * @return mixed
+	 * @return mixed (don't forget to sanitize)
 	 * @throws Exception
 	 */
 	public static function get( $key, $property, $wpObject = null, $args = null ) {
@@ -103,7 +103,7 @@ class CB {
 	 * @param $post
 	 * @param $args
 	 *
-	 * @return string|null
+	 * @return string|null (don't forget to sanitize)
 	 * @throws Exception
 	 */
 	public static function lookUp( string $key, string $property, $post, $args ): ?string {
@@ -116,11 +116,6 @@ class CB {
 			$result = self::getUserProperty( $post, $property, $args );
 		} else {
 			$result = self::getPostProperty( $post, $property, $args );
-		}
-
-		if ( $result ) {
-			// sanitize output
-			return commonsbooking_sanitizeHTML( $result );
 		}
 
 		return $result;

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -537,9 +537,8 @@ class Booking extends \CommonsBooking\Model\Timeframe {
      * @return void
      */
     public static function getFormattedUserInfo() {
-        return commonsbooking_parse_template(
-            Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_templates', 'user_details_template' )
-        );
+        $template = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_templates', 'user_details_template' );
+        return commonsbooking_sanitizeHTML ( commonsbooking_parse_template( $template ) );
     }
     
     /**

--- a/src/Model/Location.php
+++ b/src/Model/Location.php
@@ -59,12 +59,12 @@ class Location extends BookablePost {
 		if (!empty($location_street)){
 			$html_output[] = $location_street . $html_after;
 		}
-		$location_postcode = CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_postcode', $this->post );
+		$location_postcode = commonsbooking_sanitizeHTML( CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_postcode', $this->post ) );
 		if (!empty($location_postcode)){
 			$html_output[] = $location_postcode;
 		}
-		$location_city = CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_city',
-			$this->post );
+		$location_city = commonsbooking_sanitizeHTML( CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_city',
+			$this->post ) );
 		if (!empty($location_city)){
 			$html_output[] = $location_city . $html_after;
 		}
@@ -81,11 +81,11 @@ class Location extends BookablePost {
 	 * @throws \Exception
 	 */
 	public function formattedAddressOneLine(): string {
-		$location_street = CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_street', $this->post );
+		$location_street = commonsbooking_sanitizeHTML( CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_street', $this->post ) );;
 
-		$location_postcode = CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_postcode', $this->post );
+		$location_postcode = commonsbooking_sanitizeHTML( CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_postcode', $this->post ) );
 
-		$location_city = CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_city', $this->post );
+		$location_city = commonsbooking_sanitizeHTML(  CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_city', $this->post ) );
 
 		if (empty($location_street) && empty($location_postcode) && empty($location_city)){
 			return "";
@@ -123,7 +123,7 @@ class Location extends BookablePost {
 			$contact[] = "<br>"; // needed for email template
 			$contact[] = esc_html__( 'Please contact the contact persons at the location directly if you have any questions regarding collection or return:',
 				'commonsbooking' );
-			$contact[] = nl2br( CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_contact', $this->post ) );
+			$contact[] = nl2br( commonsbooking_sanitizeHTML( CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_contact', $this->post ) ) );
 		}
 
 		return implode( '<br>', $contact );
@@ -156,8 +156,9 @@ class Location extends BookablePost {
 	public function formattedPickupInstructions(): string {
 		$html_br     = '<br>';
 
-		return $html_br . $html_br . CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType,
-				COMMONSBOOKING_METABOX_PREFIX . 'location_pickupinstructions', $this->post ) . $html_br;
+		return commonsbooking_sanitizeHTML( $html_br . $html_br . CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType,
+				COMMONSBOOKING_METABOX_PREFIX . 'location_pickupinstructions', $this->post ) . $html_br
+            );
 	}
 
 	/**
@@ -170,7 +171,9 @@ class Location extends BookablePost {
 	 * @throws \Exception
 	 */
 	public function formattedPickupInstructionsOneLine() {
-		return CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_pickupinstructions', $this->post );
+		return commonsbooking_sanitizeHTML( 
+            CB::get( \CommonsBooking\Wordpress\CustomPostType\Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_pickupinstructions', $this->post )
+        );
 	}
 
 	/**


### PR DESCRIPTION
make commonsbooking_parse_template() and CB::get() NOT do any sanitation, leaving the responsibility to the calling code. The calling code can then sanitize appopiately, for example for HTML or e-mail subject output. Should fix issue 1433 for e-mail subjects with special characters like &.

I prefer this variant 1: I think it makes the code clearer when the sanitation happens closer to output generation instead of somewhere deep inside internal library functions. The down side is that one might forget to sanitize.