### PR TITLE
fix #1489 (Status / State)

### DIFF
--- a/src/Service/Holiday.php
+++ b/src/Service/Holiday.php
@@ -39,7 +39,7 @@ class Holiday {
 			</div>
 			<div class="cb_admin_holiday_table">
 				<label
-					for="<?php echo $field_type->_id( 'holiday_state' ); ?>"><?php echo esc_html__( 'State', 'commonsbooking' ); ?></label>
+					for="<?php echo $field_type->_id( 'holiday_state' ); ?>"><?php echo esc_html_x( 'State', 'territory', 'commonsbooking' ); ?></label>
 				<?php echo $field_type->select( array(
 					'name'  => $field_type->_name( '[holiday_state]' ),
 					'id'    => $field_type->_id( 'holiday_state' ),

--- a/src/Wordpress/CustomPostType/Restriction.php
+++ b/src/Wordpress/CustomPostType/Restriction.php
@@ -471,7 +471,7 @@ class Restriction extends CustomPostType {
 				'default' => wp_create_nonce( plugin_basename( __FILE__ ) )
 			),
 			array(
-				'name'             => esc_html__( "State", 'commonsbooking' ),
+				'name'             => esc_html__( "Status", 'commonsbooking' ),
 				'id'               => \CommonsBooking\Model\Restriction::META_STATE,
 				'desc'             => commonsbooking_sanitizeHTML( __( 'Choose status of this restriction. <br>
 				Set to <strong>None</strong> if you want to deactivate the restriction.<br>


### PR DESCRIPTION
Habe festgestellt, dass "Status" im Kontext von Restrictions wesentlich mehr Sinn ergibt als "State". Habe trotzdem Kontext für "State" hinzugefügt da "State" sehr viele verschiedene Bedeutungen haben kann wie z.B. Zustand, Verfassung, etc.

closes #1489