### PR TITLE
fix issue 1477 (BookingCodes können mehrfach je Datum generiert werden)

### DIFF
--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -326,8 +326,6 @@ class BookingCodes {
 			throw new BookingCodeException( __( "No booking codes could be created because the item of the timeframe could not be found.", 'commonsbooking' )  );
 		}
 
-		self::deleteOldCodes( $timeframe->ID, $location->ID, $item->ID );
-
 		$bookingCodesRandomizer = intval( $timeframe->ID );
 		$bookingCodesRandomizer += $item->ID;
 		$bookingCodesRandomizer += $location->ID;
@@ -335,6 +333,12 @@ class BookingCodes {
 		foreach ( $period as $dt ) {
 			$day = new Day( $dt->format( 'Y-m-d' ) );
 			if ( $day->isInTimeframe( $timeframe ) ) {
+
+				// Check if a code already exists, if so DO NOT generate new
+				if ( static::lookupCode($timeframe->ID, $item->ID, $location->ID, $dt->format( 'Y-m-d' )) ) {
+					continue;
+				}
+
 				$bookingCode = new BookingCode(
 					$dt->format( 'Y-m-d' ),
 					$item->ID,

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -125,7 +125,51 @@ class BookingCodes {
 	}
 
 	/**
-	 * Returns booking code by timeframe, location, item and date.
+	 * Gets a specific booking code by timeframe ID, item ID, location ID, and date.
+	 *
+	 * @param int $timeframeId - ID of the timeframe
+	 * @param int $itemId - ID of item attached to timeframe
+	 * @param int $locationId - ID of location attached to timeframe
+	 * @param string $date - Date in format Y-m-d
+	 *
+	 * @return BookingCode|null
+	 */
+	protected static function lookupCode(int $timeframeId, int $itemId, int $locationId, string $date): ?BookingCode {
+		global $wpdb;
+		$table_name = $wpdb->prefix . self::$tablename;
+
+		$sql = $wpdb->prepare(
+			"SELECT * FROM $table_name
+			WHERE 
+				timeframe = %s AND 
+				item = %s AND 
+				location = %s AND 
+				date = %s
+			ORDER BY item ASC, date ASC",
+			LIMIT 1,
+			$timeframeId,
+			$itemId,
+			$locationId,
+			$date
+		);
+
+		$bookingCodes = $wpdb->get_results($sql);
+
+		if (count($bookingCodes)) {
+			return new BookingCode(
+				$bookingCodes[0]->date,
+				$bookingCodes[0]->item,
+				$bookingCodes[0]->location,
+				$bookingCodes[0]->timeframe,
+				$bookingCodes[0]->code
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns booking code by timeframe, location, item and date. If no code exist yet and timeframe does not have end-date, generate it.
 	 *
 	 * @param Timeframe $timeframe - Timeframe object to get code for
 	 * @param int $itemId - ID of item attached to timeframe
@@ -141,25 +185,10 @@ class BookingCodes {
 		if ( $cacheItem ) {
 			return $cacheItem;
 		} else {
-			global $wpdb;
-			$table_name = $wpdb->prefix . self::$tablename;
 
-			$sql = $wpdb->prepare(
-				"SELECT * FROM $table_name
-                WHERE 
-                    timeframe = %s AND 
-                    item = %s AND 
-                    location = %s AND 
-                    date = %s
-                ORDER BY item ASC ,date ASC",
-				$timeframe->ID,
-				$itemId,
-				$locationId,
-				$date
-			);
-			$bookingCodes = $wpdb->get_results($sql);
+			$bookingCodeObject = static::lookupCode($timeframe->ID, $itemId, $locationId, $date);
 
-			if ( empty( $bookingCodes ) ) {
+			if ( ! $bookingCodeObject ) {
 				//when we have a timeframe without end-date we generate as many codes as we need
 				if (! $timeframe->getRawEndDate() && $timeframe->bookingCodesApplicable() ) {
 					$begin = $timeframe->getUTCStartDateDateTime();
@@ -168,20 +197,10 @@ class BookingCodes {
 					$interval = DateInterval::createFromDateString( '1 day' );
 					$period = new DatePeriod( $begin, $interval, $endDate );
 					static::generatePeriod($timeframe,$period);
-					$bookingCodes = $wpdb->get_results($sql);
+					$bookingCodeObject = static::lookupCode($timeframe->ID, $itemId, $locationId, $date);
 				}
 			}
 
-			$bookingCodeObject = null;
-			if ( count( $bookingCodes ) ) {
-				$bookingCodeObject = new BookingCode(
-					$bookingCodes[0]->date,
-					$bookingCodes[0]->item,
-					$bookingCodes[0]->location,
-					$bookingCodes[0]->timeframe,
-					$bookingCodes[0]->code
-				);
-			}
 			Plugin::setCacheItem( $bookingCodeObject, [$timeframe->ID] );
 
 			return $bookingCodeObject;

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -354,25 +354,6 @@ class BookingCodes {
 	}
 
 	/**
-	 * Removes all codes for the post, that don't have the current location-id or item-id.
-	 *
-	 * @param int $postId
-	 * @param int $locationId
-	 * @param int $itemId
-	 */
-	public static function deleteOldCodes( int $postId, int $locationId, int $itemId ) : void {
-		global $wpdb;
-		$table_name = $wpdb->prefix . self::$tablename;
-
-		$query = $wpdb->prepare( 'DELETE FROM ' . $table_name . ' WHERE timeframe = %d AND (location != %d OR item != %d)',
-			$postId,
-			$locationId,
-			$itemId
-		);
-		$wpdb->query( $query );
-	}
-
-	/**
 	 * @param BookingCode $bookingCode
 	 *
 	 * @return mixed


### PR DESCRIPTION
Mit dieser Änderung werden neue Codes nur generiert, wenn sie fehlen (vorher kam es in bestimmten Fällen zu Doppelungen). Außerdem werden BookingCodes in der Datenbank nie mehr gelöscht.