### PR TITLE
BookingCodes: Kleine Fixes und Verbesserung der Code-Doku

### DIFF
--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -80,7 +80,9 @@ class BookingCodes {
 			) {
 				$startGenerationPeriod = new \DateTime( self::getLastCode($timeframe)->getDate() );
 				$endGenerationPeriod = new \DateTime( $endDate );
-				$endGenerationPeriod->modify( '+' . $advanceGenerationDays . ' days' );
+				// set $endGenerationPeriod's time > 00:00:00 such that $endDate is included in DatePeriod iteration
+				// and code is generated for $endDate
+				$endGenerationPeriod->setTime(0, 0, 1);
 				static::generatePeriod( $timeframe,
 					new DatePeriod(
 						$startGenerationPeriod,
@@ -268,9 +270,8 @@ class BookingCodes {
 		if ($timeframe->getRawEndDate()){
 			$end = Wordpress::getUTCDateTime();
 			$end->setTimestamp( $timeframe->getRawEndDate() );
-			// set $end's time > 00:00:00 such that DatePeriod-iteration will include $end.
-			// TODO BETTER: $end->setTime(0,0,1) because no date overflow.
-			$end->setTimestamp( $end->getTimestamp() + 1 );
+			// set $end's time > 00:00:00 such that DatePeriod-iteration will include $end:
+			$end->setTime(0, 0, 1);
 		}
 		else {
 			$end = new \DateTime();

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -132,7 +132,7 @@ class BookingCodes {
 	 * @param int $itemId - ID of item attached to timeframe
 	 * @param int $locationId - ID of location attached to timeframe
 	 * @param string $date - Date in format Y-m-d
-	 * @param int $advanceGenerationDays - Open-ended timeframes: If 1, generate code(s) until $date. If >1 generate additional codes after $date.
+	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generates code(s) until $date. If >0 generate additional codes after $date.
 	 *
 	 * @return BookingCode|null
 	 * @throws BookingCodeException
@@ -166,6 +166,9 @@ class BookingCodes {
 					$begin = $timeframe->getUTCStartDateDateTime();
 					$endDate = new \DateTime($date);
 					$endDate->modify('+' . $advanceGenerationDays . ' days');
+					// set $endDate's time > 00:00:00 so it will included in DatePeriod iteration and a code will be
+					// generated for $endDate
+					$endDate->setTime(0, 0, 1);
 					$interval = DateInterval::createFromDateString( '1 day' );
 					$period = new DatePeriod( $begin, $interval, $endDate );
 					static::generatePeriod($timeframe,$period);
@@ -254,7 +257,7 @@ class BookingCodes {
      * Generates booking codes for timeframe.
      *
      * @param Timeframe $timeframe
-     * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generates code(s) until today. If >0 generate additional codes after today.
+     * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generate code(s) until today. If >0 generate additional codes after today.
 	 *
      * @return bool
      * @return bool

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -38,7 +38,7 @@ class BookingCodes {
 	 * @param int $timeframeId - ID of timeframe to get codes for
 	 * @param int|null $startDate - Where to get booking codes from (timestamp)
 	 * @param int|null $endDate - Where to get booking codes to (timestamp)
-	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generate code(s) until timeframe startdate. If >0 generate additional codes after timeframe startdate. (NOTE: it seems wrong to reference to timeframe startdate; maybe rather reference to today's date?)
+	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generate code(s) until today. If >0, generate additional codes after today
 	 *
 	 * @return array
 	 * @throws BookingCodeException
@@ -66,7 +66,8 @@ class BookingCodes {
 			}
 			//when we still don't have an end-date, we will just get the coming ADVANCE_GENERATION_DAYS (should default to 365 days)
 			if (! $endDate ) {
-				$endDate = strtotime( '+' . $advanceGenerationDays . ' days', $startDate );
+				$endDate = strtotime( '+' . $advanceGenerationDays . ' days', null ); // null means date and time now
+				// a code will be generated for $endDate because time generally > 00:00:00 (due to initialitaion with current date and time)
 			}
 
 			$startDate = date( 'Y-m-d', $startDate );
@@ -132,7 +133,7 @@ class BookingCodes {
 	 * @param int $itemId - ID of item attached to timeframe
 	 * @param int $locationId - ID of location attached to timeframe
 	 * @param string $date - Date in format Y-m-d
-	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generates code(s) until $date. If >0 generate additional codes after $date.
+	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generates code(s) until $date. If >0, generate additional codes after $date.
 	 *
 	 * @return BookingCode|null
 	 * @throws BookingCodeException
@@ -257,7 +258,7 @@ class BookingCodes {
      * Generates booking codes for timeframe.
      *
      * @param Timeframe $timeframe
-     * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generate code(s) until today. If >0 generate additional codes after today.
+     * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generate code(s) until today. If >0, generate additional codes after today.
 	 *
      * @return bool
      * @return bool

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -38,6 +38,7 @@ class BookingCodes {
 	 * @param int $timeframeId - ID of timeframe to get codes for
 	 * @param int|null $startDate - Where to get booking codes from (timestamp)
 	 * @param int|null $endDate - Where to get booking codes to (timestamp)
+	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generate code(s) until timeframe startdate. If >0 generate additional codes after timeframe startdate. (NOTE: it seems wrong to reference to timeframe startdate; maybe rather reference to today's date?)
 	 *
 	 * @return array
 	 * @throws BookingCodeException
@@ -129,7 +130,7 @@ class BookingCodes {
 	 * @param int $itemId - ID of item attached to timeframe
 	 * @param int $locationId - ID of location attached to timeframe
 	 * @param string $date - Date in format Y-m-d
-	 * @param int $advanceGenerationDays
+	 * @param int $advanceGenerationDays - Open-ended timeframes: If 1, generate code(s) until $date. If >1 generate additional codes after $date.
 	 *
 	 * @return BookingCode|null
 	 * @throws BookingCodeException
@@ -251,6 +252,7 @@ class BookingCodes {
      * Generates booking codes for timeframe.
      *
      * @param Timeframe $timeframe
+     * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generates code(s) until today. If >0 generate additional codes after today.
 	 *
      * @return bool
      * @return bool
@@ -266,11 +268,14 @@ class BookingCodes {
 		if ($timeframe->getRawEndDate()){
 			$end = Wordpress::getUTCDateTime();
 			$end->setTimestamp( $timeframe->getRawEndDate() );
+			// set $end's time > 00:00:00 such that DatePeriod-iteration will include $end.
+			// TODO BETTER: $end->setTime(0,0,1) because no date overflow.
 			$end->setTimestamp( $end->getTimestamp() + 1 );
 		}
 		else {
 			$end = new \DateTime();
 			$end->modify( '+' . $advanceGenerationDays . 'days');
+			// a code will be generated for the date in $end because its time generally > 00:00:00 (due to initialitaion with current date and time)
 		}
 
 		$interval = DateInterval::createFromDateString( '1 day' );

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -76,7 +76,7 @@ class BookingCodesTest extends CustomPostTypeTest
 		);
 		$this->assertNull( $code );
 
-		BookingCodes::generate( $this->timeframeWithoutEndDate );
+		BookingCodes::generate( $this->timeframeWithoutEndDate, self::ADVANCE_GENERATION_DAYS );
 		//test infinite booking days timeframes
 		$advanceDays = self::ADVANCE_GENERATION_DAYS + 1; //advance one day beyond the max generation days
 		$dayInFuture = date( 'Y-m-d',

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -172,7 +172,7 @@ class BookingCodesTest extends CustomPostTypeTest
 		BookingCodes::generate( $this->timeframeWithoutEndDate, self::ADVANCE_GENERATION_DAYS );
 		//now we should get all codes for the max generation days
 		$codeAmount = BookingCodes::ADVANCE_GENERATION_DAYS + 1;
-		$codes = BookingCodes::getCodes( $this->timeframeWithoutEndDate->ID, self::ADVANCE_GENERATION_DAYS);
+		$codes = BookingCodes::getCodes( $this->timeframeWithoutEndDate->ID );
 		$this->assertNotEmpty( $codes );
 		$this->assertCount( $codeAmount, $codes );
 		//check that the codes are in the correct order

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -170,8 +170,12 @@ class BookingCodesTest extends CustomPostTypeTest
 
 		//test infinite booking days timeframes
 		BookingCodes::generate( $this->timeframeWithoutEndDate, self::ADVANCE_GENERATION_DAYS );
-		//now we should get all codes for the max generation days
-		$codeAmount = BookingCodes::ADVANCE_GENERATION_DAYS + 1;
+
+		// codes will be generated and returned
+		// - for yesterday which is timeframe start date (1),
+		// - for today (1) and
+		// - for additional BookingCodes::ADVANCE_GENERATION_DAYS
+		$codeAmount = BookingCodes::ADVANCE_GENERATION_DAYS + 2;
 		$codes = BookingCodes::getCodes( $this->timeframeWithoutEndDate->ID );
 		$this->assertNotEmpty( $codes );
 		$this->assertCount( $codeAmount, $codes );
@@ -201,6 +205,36 @@ class BookingCodesTest extends CustomPostTypeTest
 			$lastCode = $code;
 		}
 
+	}
+
+	public function testGetCodesFuture() {
+		// test of getCodes() when today is a date in future, in particular later than timeframe start + BookingCodes::ADVANCE_GENERATION_DAYS
+		$daysInFuture = 400;
+		$futureDate = new \DateTime( self::CURRENT_DATE );
+		$futureDate->modify( "+$daysInFuture days" );
+		ClockMock::freeze( $futureDate );
+
+		//test infinite booking days timeframes: getCodes() currently only works if at least a few codes are available
+		BookingCodes::generate( $this->timeframeWithoutEndDate, self::ADVANCE_GENERATION_DAYS );
+
+		// test behavior of getCodes() without specified startDate and endDate:
+		// codes will be generated and returned
+		// - for day before self::CURRENT_DATE which is timeframe start date (1),
+		// - for $daysInFuture,
+		// - for today (1) and
+		// - for additional BookingCodes::ADVANCE_GENERATION_DAYS
+		$codeAmount = BookingCodes::ADVANCE_GENERATION_DAYS + $daysInFuture + 2;
+		$codes = BookingCodes::getCodes( $this->timeframeWithoutEndDate->ID );
+		$this->assertNotEmpty( $codes );
+		$this->assertCount( $codeAmount, $codes );
+		//check that the codes are in the correct order
+		$lastCode = null;
+		foreach ( $codes as $code ) {
+			if ( $lastCode ) {
+				$this->assertGreaterThan( $lastCode->getDate(), $code->getDate() );
+			}
+			$lastCode = $code;
+		}
 	}
 
 	public function testGetLastCode() {


### PR DESCRIPTION
Ich habe vor, wenig größere Änderungen bei den BookingCodes vorzuschlagen. In der Vorbereitung dafür sind mir kleinere Fehler und unvollständige/inkonsistente Doku aufgefallen, die mit dem eigentlichen Vorhaben nicht direkt zu tun haben. Nach dem Modell Salamitaktik ist es vielleicht vorteilhaft, kleine Schritte zu gehen, die ich als unumstritten einschätzen würde. Solche Änderungen schlage ich mit diesem PR vor.