### PR TITLE
Beständige Bookingcodes

### DIFF
--- a/src/Migration/Migration.php
+++ b/src/Migration/Migration.php
@@ -580,17 +580,13 @@ class Migration {
 	 * @return mixed
 	 */
 	public static function migrateBookingCode( $bookingCode ) {
-		$cb2LocationId  = CB1::getCB2LocationId( $bookingCode['location_id'] );
 		$cb2ItemId      = CB1::getCB2ItemId( $bookingCode['item_id'] );
-		$cb2TimeframeId = CB1::getCB2TimeframeId( $bookingCode['timeframe_id'] );
 		$date           = $bookingCode['booking_date'];
 		$code           = $bookingCode['bookingcode'];
 
 		$bookingCode = new BookingCode(
 			$date,
 			$cb2ItemId,
-			$cb2LocationId,
-			$cb2TimeframeId,
 			$code
 		);
 

--- a/src/Model/BookingCode.php
+++ b/src/Model/BookingCode.php
@@ -111,4 +111,5 @@ class BookingCode {
 		$this->code = $code;
 
 		return $this;
+    }
 }

--- a/src/Model/BookingCode.php
+++ b/src/Model/BookingCode.php
@@ -23,46 +23,30 @@ class BookingCode {
 	 * Datestring in the format Y-m-d
 	 * @var string
 	 */
-	protected $date;
+	private $date;
 
 	/**
 	 * Item ID
 	 * @var int
 	 */
-	protected $item;
-
-	/**
-	 * Location ID
-	 * @var int
-	 */
-	protected $location;
-
-	/**
-	 * Timeframe ID
-	 * @var int
-	 */
-	protected $timeframe;
+	private $item;
 
 	/**
 	 * Code string
 	 * @var string
 	 */
-	protected $code;
+	private $code;
 
 	/**
 	 * BookingCode constructor.
 	 *
 	 * @param $date
 	 * @param $item
-	 * @param $location
-	 * @param $timeframe
 	 * @param $code
 	 */
-	public function __construct( $date, $item, $location, $timeframe, $code ) {
+	public function __construct( $date, $item, $code ) {
 		$this->date      = $date;
 		$this->item      = $item;
-		$this->location  = $location;
-		$this->timeframe = $timeframe;
 		$this->code      = $code;
 	}
 
@@ -165,6 +149,4 @@ class BookingCode {
 		$this->code = $code;
 
 		return $this;
-	}
-
 }

--- a/src/Model/BookingCode.php
+++ b/src/Model/BookingCode.php
@@ -95,44 +95,6 @@ class BookingCode {
 	}
 
 	/**
-	 * @return int
-	 */
-	public function getLocation(): int {
-		return $this->location;
-	}
-
-	/**
-	 * @deprecated will be deleted in the next version. This Type should be immutable, use constructor to create a new instance
-	 * @param mixed $location
-	 *
-	 * @return BookingCode
-	 */
-	public function setLocation( $location ): BookingCode {
-		$this->location = $location;
-
-		return $this;
-	}
-
-	/**
-	 * @return int
-	 */
-	public function getTimeframe(): int {
-		return $this->timeframe;
-	}
-
-	/**
-	 * @deprecated will be deleted in the next version. This Type should be immutable, use constructor to create a new instance
-	 * @param mixed $timeframe
-	 *
-	 * @return BookingCode
-	 */
-	public function setTimeframe( $timeframe ): BookingCode {
-		$this->timeframe = $timeframe;
-
-		return $this;
-	}
-
-	/**
 	 * @return string
 	 */
 	public function getCode(): string {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -859,14 +859,12 @@ class Plugin {
 	/**
 	 * Adds bookingcode actions.
 	 * They:
-	 * 1. Delete booking codes when a booking is deleted.
-	 * 2. Hook appropriate function to button that downloads the booking codes in the backend.
+	 * - Hook appropriate function to button that downloads the booking codes in the backend.
 	 *    @see \CommonsBooking\View\BookingCodes::renderTable()
-	 * 3. Hook appropriate function to button that sends out emails with booking codes to the station.
+	 * - Hook appropriate function to button that sends out emails with booking codes to the station.
 	 *   @see \CommonsBooking\View\BookingCodes::renderDirectEmailRow()
 	 */
 	public function initBookingcodes() {
-		add_action( 'before_delete_post', array( BookingCodes::class, 'deleteBookingCodes' ), 10 );
 		add_action( 'admin_action_cb_download-bookingscodes-csv', array( View\BookingCodes::class, 'renderCSV' ), 10, 0 );
         add_action( 'admin_action_cb_email-bookingcodes', array(View\BookingCodes::class, 'emailCodes'), 10, 0);
 	}

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -362,32 +362,4 @@ class BookingCodes {
 		}, $bookingCodesArray );
 	}
 
-	/**
-	 * Deletes booking codes for current post or if posted for post with $postId.
-	 *
-	 * @param null $postId
-	 */
-	public static function deleteBookingCodes( $postId = null ) {
-		if ( $postId ) {
-			$post = get_post( $postId );
-		} else {
-			global $post;
-		}
-		if (
-			$post &&
-			$post->post_type == \CommonsBooking\Wordpress\CustomPostType\Timeframe::$postType
-		) {
-			global $wpdb;
-			$table_name = $wpdb->prefix . self::$tablename;
-
-
-			$query = $wpdb->prepare( 'SELECT timeframe FROM ' . $table_name . ' WHERE timeframe = %d', $post->ID );
-			$var   = $wpdb->get_var( $query );
-			if ( $var ) {
-				$query2 = $wpdb->prepare( 'DELETE FROM ' . $table_name . ' WHERE timeframe = %d', $post->ID );
-				$wpdb->query( $query2 );
-			}
-		}
-	}
-
 }

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -114,8 +114,6 @@ class BookingCodes {
 				$bookingCodeObject = new BookingCode(
 					$bookingCode->date,
 					$bookingCode->item,
-					$bookingCode->location,
-					$bookingCode->timeframe,
 					$bookingCode->code
 				);
 				$codes[]           = $bookingCodeObject;
@@ -156,8 +154,6 @@ class BookingCodes {
 			return new BookingCode(
 				$bookingCodes[0]->date,
 				$bookingCodes[0]->item,
-				$bookingCodes[0]->location,
-				$bookingCodes[0]->timeframe,
 				$bookingCodes[0]->code
 			);
 		}
@@ -170,7 +166,7 @@ class BookingCodes {
 	 *
 	 * @param Timeframe $timeframe - Timeframe object to get code for
 	 * @param int $itemId - ID of item attached to timeframe
-	 * @param int $locationId - ID of location attached to timeframe
+	 * @param int $locationId - ID of location attached to timeframe (DEPRECATED, has no effect)
 	 * @param string $date - Date in format Y-m-d
 	 * @param int $advanceGenerationDays - Open-ended timeframes: If 0, generates code(s) until $date. If >0, generate additional codes after $date.
 	 *
@@ -217,6 +213,7 @@ class BookingCodes {
 		$table_name      = $wpdb->prefix . self::$tablename;
 		$charset_collate = $wpdb->get_charset_collate();
 
+		// TODO To be removed later: timeframe, location (not used anymore)
 		$sql = "CREATE TABLE $table_name (
             date date DEFAULT '0000-00-00' NOT NULL,
             timeframe bigint(20) unsigned NOT NULL,
@@ -310,8 +307,6 @@ class BookingCodes {
 				$bookingCode = new BookingCode(
 					$dt->format( 'Y-m-d' ),
 					$item->ID,
-					$location->ID,
-					$timeframe->ID,
 					$bookingCodesArray[ ( (int) $dt->format( 'z' ) + $bookingCodesRandomizer ) % count( $bookingCodesArray ) ]
 				);
 				self::persist( $bookingCode );
@@ -334,9 +329,9 @@ class BookingCodes {
 		$result = $wpdb->replace(
 			$table_name,
 			array(
-				'timeframe' => $bookingCode->getTimeframe(),
+				'timeframe' => 0,
 				'date'      => $bookingCode->getDate(),
-				'location'  => $bookingCode->getLocation(),
+				'location'  => 0,
 				'item'      => $bookingCode->getItem(),
 				'code'      => $bookingCode->getCode()
 			)

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -16,7 +16,7 @@ use DatePeriod;
 
 /**
  *  This class generates booking codes for a timeframe.
- *  Currently, booking codes can only be created for timeframes with an end date and where one slot fills the whole day.
+ *  Currently, booking codes can only be created where one slot fills the whole day.
  */
 class BookingCodes {
 
@@ -277,7 +277,7 @@ class BookingCodes {
 		if (! $bookingCodesArray ){
 			throw new BookingCodeException( __( "No booking codes could be created because there were no booking codes to choose from. Please set some booking codes in the CommonsBooking settings.", 'commonsbooking' )  );
 		}
-		// Before we add new codes, we remove old ones, that are not relevant anymore
+
 		try {
 			//TODO #507
 			$location = $timeframe->getLocation();

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -98,11 +98,11 @@ class BookingCodes {
 
 			$sql = $wpdb->prepare(
 				"SELECT * FROM $table_name
-                WHERE timeframe = %d
+                WHERE item = %d
                 AND date BETWEEN %s AND %s
                 ORDER BY item ASC ,date ASC
             	",
-				$timeframeId,
+				$timeframe->getItem()->ID,
 				$startDate,
 				$endDate
 			);

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -39,8 +39,6 @@ class BookingCodesTest extends CustomPostTypeTest
 		$this->assertNotNull($code);
 		$this->assertEquals($todayDate,$code->getDate());
 		$this->assertEquals($this->itemId,$code->getItem());
-		$this->assertEquals($this->locationId,$code->getLocation());
-		$this->assertEquals($this->timeframeWithEndDate->ID,$code->getTimeframe());
 
 		//and now without end date (the fabled "infinite" timeframe)
 		BookingCodes::generate($this->timeframeWithoutEndDate,self::ADVANCE_GENERATION_DAYS);
@@ -48,8 +46,6 @@ class BookingCodesTest extends CustomPostTypeTest
 		$this->assertNotNull($code);
 		$this->assertEquals($todayDate,$code->getDate());
 		$this->assertEquals($this->itemId,$code->getItem());
-		$this->assertEquals($this->locationId,$code->getLocation());
-		$this->assertEquals($this->timeframeWithoutEndDate->ID,$code->getTimeframe());
 
 		//make sure, that the last infinite code is also generated
 	    $advanceDays = self::ADVANCE_GENERATION_DAYS - 1;
@@ -58,8 +54,6 @@ class BookingCodesTest extends CustomPostTypeTest
 		$this->assertNotNull($code);
 		$this->assertEquals($lastCodeDay,$code->getDate());
 		$this->assertEquals($this->itemId,$code->getItem());
-		$this->assertEquals($this->locationId,$code->getLocation());
-		$this->assertEquals($this->timeframeWithoutEndDate->ID,$code->getTimeframe());
     }
 
 	public function testGetCode() {
@@ -90,9 +84,7 @@ class BookingCodesTest extends CustomPostTypeTest
 			self::ADVANCE_GENERATION_DAYS
 		);
 		$this->assertNotNull( $code );
-		$this->assertEquals( $this->timeframeWithoutEndDate->ID, $code->getTimeframe() );
 		$this->assertEquals( $this->itemId, $code->getItem() );
-		$this->assertEquals( $this->locationId, $code->getLocation() );
 		$this->assertEquals( $dayInFuture, $code->getDate() );
 
 		//test that the code is persisted (i.e. it's not generated again)
@@ -116,9 +108,7 @@ class BookingCodesTest extends CustomPostTypeTest
 			$dayInFutureTwo,
 			self::ADVANCE_GENERATION_DAYS);
 		$this->assertNotNull( $futureTwoCode );
-		$this->assertEquals( $this->timeframeWithoutEndDate->ID, $futureTwoCode->getTimeframe() );
 		$this->assertEquals( $this->itemId, $futureTwoCode->getItem() );
-		$this->assertEquals( $this->locationId, $futureTwoCode->getLocation() );
 		$this->assertEquals( $dayInFutureTwo, $futureTwoCode->getDate() );
 		//now check, that the old code is still persisted
 		$stillSameCode = BookingCodes::getCode(

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -121,6 +121,89 @@ class BookingCodesTest extends CustomPostTypeTest
 		$this->assertEquals( $code->getCode(), $stillSameCode->getCode() );
 	}
 
+	public function testIfCodesAreEternal() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		// create timeframe with parameters like $timeframeWithoutEndDate
+		$timeframe_1 = new Timeframe($this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			null,
+		));
+
+		// generate some codes
+		BookingCodes::generate( $timeframe_1, self::ADVANCE_GENERATION_DAYS );
+
+		// get code for $this->itemId today
+		$todaysCode = BookingCodes::getCode( $timeframe_1,
+			$this->itemId,
+			$this->locationId,
+			date('Y-m-d', strtotime( self::CURRENT_DATE )),
+			self::ADVANCE_GENERATION_DAYS);
+
+		$this->assertNotEmpty($todaysCode->getCode());
+
+		// Check if codes are persistant/eternal:
+		// check that codes are persistant, ie when a code is once generated for a certain item and date, it should never change again
+		$countBefore = $this->countBookingCodes();
+		$this->assertGreaterThan(0, $countBefore);
+
+		// add some booking codes (like a WP Admin would do on Commonbookings admin pages)
+		$oldBookingCodes = Settings::getOption( 'commonsbooking_options_bookingcodes', 'bookingcodes' );
+		$updateSuccessful = Settings::updateOption('commonsbooking_options_bookingcodes','bookingcodes',"$oldBookingCodes,NewCode");
+		$this->assertTrue($updateSuccessful);
+
+		// repeat generate() with same parameters as above ...
+		BookingCodes::generate( $timeframe_1, self::ADVANCE_GENERATION_DAYS );
+
+		// ... it should NOT lead to any new codes, because they are already existing. Check by counting:
+		$countAfter = $this->countBookingCodes();
+		$this->assertEquals($countBefore, $countAfter);
+
+		// ... and check by comparing today's code
+		$todaysCodeAfter = BookingCodes::getCode( $timeframe_1,
+			$this->itemId,
+			$this->locationId,
+			date('Y-m-d', strtotime( self::CURRENT_DATE )),
+			self::ADVANCE_GENERATION_DAYS);
+
+		$this->assertEquals($todaysCode->getCode(), $todaysCodeAfter->getCode());
+
+		// now delete timeframe and create another timeframe with same parameters (especially same item and overlapping in time)
+		wp_delete_post( $timeframe_1->ID, true );
+
+		$timeframe_2 = new Timeframe($this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			null,
+		));
+
+		// repeat generate() with same parameters as above ...
+		BookingCodes::generate( $timeframe_2, self::ADVANCE_GENERATION_DAYS );
+
+		// ... and check by comparing today's code
+		$todaysCodeTimeframe2 = BookingCodes::getCode( $timeframe_2,
+			$this->itemId,
+			$this->locationId,
+			date('Y-m-d', strtotime( self::CURRENT_DATE )),
+			self::ADVANCE_GENERATION_DAYS);
+
+		// even if it is another timeframe, the today's code for the same item must still be the same
+		$this->assertEquals($todaysCode->getCode(), $todaysCodeTimeframe2->getCode());
+
+	}
+
+	private function countBookingCodes() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . BookingCodes::$tablename;
+
+		$sql = "SELECT COUNT(*) FROM $table_name";
+
+		return $wpdb->get_var($sql);
+	}
+
 	public function testGetCodes() {
 		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
 		//make sure that we get no codes before generation

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -227,27 +227,6 @@ class BookingCodesTest extends CustomPostTypeTest
 		}
 	}
 
-	public function testGetLastCode() {
-		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
-		BookingCodes::generate( $this->timeframeWithEndDate, self::ADVANCE_GENERATION_DAYS );
-		$lastCode = BookingCodes::getLastCode( $this->timeframeWithEndDate );
-		$this->assertNotNull( $lastCode );
-		$this->assertEquals( $this->timeframeWithEndDate->ID, $lastCode->getTimeframe() );
-		$this->assertEquals( $this->itemId, $lastCode->getItem() );
-		$this->assertEquals( $this->locationId, $lastCode->getLocation() );
-		$this->assertEquals( strtotime( '+29 day', strtotime( self::CURRENT_DATE ) ), strtotime($lastCode->getDate() ) );
-		$advanceGenerationDays = self::ADVANCE_GENERATION_DAYS;
-		BookingCodes::generate( $this->timeframeWithoutEndDate, self::ADVANCE_GENERATION_DAYS );
-		$lastCode = BookingCodes::getLastCode( $this->timeframeWithoutEndDate );
-		$this->assertNotNull( $lastCode );
-		$this->assertEquals( $this->timeframeWithoutEndDate->ID, $lastCode->getTimeframe() );
-		$this->assertEquals( $this->itemId, $lastCode->getItem() );
-		$this->assertEquals( $this->locationId, $lastCode->getLocation() );
-		//The DatePeriod does not include the endDay, so we have to subtract one day
-		$advanceGenerationDays -= 1;
-		$this->assertEquals( strtotime( '+' . $advanceGenerationDays . ' day', strtotime( self::CURRENT_DATE ) ), strtotime($lastCode->getDate() ) );
-	}
-
 	protected function setUp(): void {
 		parent::setUp();
 		$this->timeframeWithEndDate = new Timeframe($this->createTimeframe(


### PR DESCRIPTION
Mit diesem PR 
- werden generierte Codes nie gelöscht (sind Listen ausgedruckt, behalten sie ihre Gültigkeit), sondern bleiben ewig gespeichert, wenn einmal für ein Lastenrad erstellt.
- haben die Codes keinen Timeframe- oder Location-Bezug mehr (ändert ein Lastenrad z.B. aufgrund von Urlaub die Verleihstation sollen ausgedruckte Listen sowie bereits übermittelte Codes in Buchungsbestätigungen ihre Gültigkeit behalten)
- wird Bug #1477 behoben
- wird Feature #1498 umgesetzt
- wird der Code vereinfacht:
   - BookingCodes.php: 430 -> 359 Zeilen (-71)
   - BookingCode.php: 176 -> 79 Zeilen (-97)