### PR TITLE
Checkbox für Standort E-Mail BCC

### DIFF
--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -34,7 +34,8 @@ class BookingMessage extends Message {
 		// get location email adresses to send them bcc copies
 		$location = get_post($booking->getMeta('location-id'));
 		$location_emails = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email', $location ) ; /*  email addresses, comma-seperated  */
-		if ($location_emails) {
+		$location_bcc_copy = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email_bcc', $location )  == 'on' ; /*  email addresses, comma-seperated  */
+		if ($location_emails && $location_bcc_copy) {
 			$bcc_adresses = str_replace(' ','',$location_emails);
 		} else {
 			$bcc_adresses = null;

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -49,7 +49,7 @@ class Upgrade {
 		'2.9.0' => [
 			[self::class, 'setMultiSelectTimeFrameDefault']
 		],
-		'2.9.1' => [
+		'2.9.1' => [ //TODO this is anticipated
 			[self::class, 'enableLocationBookingNotification']
 		]
 	];
@@ -317,7 +317,7 @@ class Upgrade {
 	 * Previously, if a location email was set that meant that they also receive a copy of each booking / cancellation email.
 	 * Now we have a separate checkbox to enable that which should be enabled for existing locations so that they will still receive emails after upgrade.
 	 *
-	 * @since 2.9.1 (Anticipated)
+	 * @since 2.9.1 (Anticipated) //TODO
 	 * @return void
 	 */
 	public static function enableLocationBookingNotification() {

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -48,6 +48,9 @@ class Upgrade {
 		],
 		'2.9.0' => [
 			[self::class, 'setMultiSelectTimeFrameDefault']
+		],
+		'2.9.1' => [
+			[self::class, 'enableLocationBookingNotification']
 		]
 	];
 
@@ -307,6 +310,21 @@ class Upgrade {
 			if ( empty($timeframe->getMeta(\CommonsBooking\Model\Timeframe::META_LOCATION_SELECTION_TYPE ) ) ) {
 				update_post_meta($timeframe->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_SELECTION_TYPE, \CommonsBooking\Model\Timeframe::SELECTION_MANUAL_ID);
 			}
+		}
+	}
+
+	/**
+	 * Previously, if a location email was set that meant that they also receive a copy of each booking / cancellation email.
+	 * Now we have a separate checkbox to enable that which should be enabled for existing locations so that they will still receive emails after upgrade.
+	 *
+	 * @since 2.9.1 (Anticipated)
+	 * @return void
+	 */
+	public static function enableLocationBookingNotification() {
+		$locations = \CommonsBooking\Repository\Location::get();
+
+		foreach ($locations as $location) {
+			update_post_meta($location->ID, COMMONSBOOKING_METABOX_PREFIX . 'location_email_bcc', 'on');
 		}
 	}
 }

--- a/src/Wordpress/CustomPostType/Location.php
+++ b/src/Wordpress/CustomPostType/Location.php
@@ -325,7 +325,7 @@ class Location extends CustomPostType {
 		// location email
 		$cmb->add_field( array(
 			'name'       => esc_html__( 'Location email', 'commonsbooking' ),
-			'desc'       => esc_html__( 'Email addresses to which a copy of the booking confirmation / cancellation should be sent. You can enter multiple addresses separated by commas.',
+			'desc'       => esc_html__( 'Email addresses of the owner of the station. Can be reminded about bookings / cancellations and will receive the booking codes (when configured in the timeframe). You can enter multiple addresses separated by commas.',
 				'commonsbooking' ),
 			'id'         => COMMONSBOOKING_METABOX_PREFIX . 'location_email',
 			'type'       => 'text',

--- a/src/Wordpress/CustomPostType/Location.php
+++ b/src/Wordpress/CustomPostType/Location.php
@@ -336,6 +336,15 @@ class Location extends CustomPostType {
 			// 'repeatable'      => true,
 		) );
 
+		// checkbox BCC bookings / cancellations to location email
+		$cmb->add_field( array(
+			'name'       => esc_html__( 'Send copy of bookings / cancellations to location email', 'commonsbooking' ),
+			'desc'       => esc_html__( 'If enabled, the location email will receive a copy of all booking and cancellation notifications.', 'commonsbooking' ),
+			'id'         => COMMONSBOOKING_METABOX_PREFIX . 'location_email_bcc',
+			'type'       => 'checkbox',
+			'default_cb' => 'cmb2_set_checkbox_default_for_new_post'
+		) );
+
 		// pickup description
 		$cmb->add_field( array(
 			'name'       => esc_html__( 'Pickup instructions', 'commonsbooking' ),

--- a/tests/php/Service/UpgradeTest.php
+++ b/tests/php/Service/UpgradeTest.php
@@ -138,6 +138,11 @@ class UpgradeTest extends CustomPostTypeTest
 		$this->assertEquals(Timeframe::SELECTION_MANUAL_ID, get_post_meta($tf, Timeframe::META_LOCATION_SELECTION_TYPE, true));
 	}
 
+	public function testEnableLocationBookingNotification() {
+		Upgrade::enableLocationBookingNotification();
+		$this->assertEquals('on', get_post_meta($this->locationId, COMMONSBOOKING_METABOX_PREFIX . 'location_email_bcc', true) );
+	}
+
 	protected function setUp(): void {
 		parent::setUp();
 		//This replaces the original update tasks with a internal test function that just sets a variable to true


### PR DESCRIPTION
Eigentlich nur wenig Code der verändert werden müsste, aber da ich will, dass die Checkbox Default-On ist muss ich auch noch eine Migrationsfunktion schreiben um die Checkbox bei Standorten davor zu aktivieren.
closes #1512