### PR TITLE
Adds missing wp mimetype for cjs assets

### DIFF
--- a/src/Map/SearchShortcode.php
+++ b/src/Map/SearchShortcode.php
@@ -12,6 +12,14 @@ class SearchShortcode extends BaseShortcode {
 	}
 
 	protected function inject_script( $cb_map_id ) {
+
+		// Adds unknown mime types for cjs files
+		add_filter( 'mime_types', function( $wp_mime_types_for ) {
+			$file_extension = 'cjs';
+			$wp_mime_types_for[ $file_extension ] = 'application/javascript';
+			return $wp_mime_types_for;
+		});
+
 		wp_enqueue_style('cb-commons-search');
 		wp_enqueue_script('cb-commons-search');
 	}

--- a/src/Map/SearchShortcode.php
+++ b/src/Map/SearchShortcode.php
@@ -13,10 +13,10 @@ class SearchShortcode extends BaseShortcode {
 
 	protected function inject_script( $cb_map_id ) {
 
-		// Adds unknown mime types for cjs files
+		// Adds unknown mime types for cjs files (only if unknown)
 		add_filter( 'mime_types', function( $wp_mime_types_for ) {
 			$file_extension = 'cjs';
-			$wp_mime_types_for[ $file_extension ] = 'application/javascript';
+			$wp_mime_types_for[ $file_extension ] ??= 'application/javascript';
 			return $wp_mime_types_for;
 		});
 


### PR DESCRIPTION
Situation: In the new version of the map, javascript assets are included in files with `cjs` file extension. Wordpress does not know these and therefore cannot derive to it's mime type.

Problem: Some servers won't serve the mime type[1] as response header, some serve any[2]. The absence of mime types prevent execution of the served js assets in modern browsers.

Assumtion: Either the Wordpress Version or plugin constellation are the cause that the mime type is included in for example freie lasten.org[2].
For example Freie lasten[2] includes mime type `application/octet-stream`.

Solution: This pr adds the file extension and a valid mimetype `application/javascript`.

Fixes #1522

[1]: https://fjordbeweger.de/neue-karte/
[2]: https://freie-lasten.org/mobile-buchung/