### PR TITLE
Einschränkungen für ALLE deaktivieren

### DIFF
--- a/src/Wordpress/CustomPostType/Restriction.php
+++ b/src/Wordpress/CustomPostType/Restriction.php
@@ -428,14 +428,12 @@ class Restriction extends CustomPostType {
 				'name'             => esc_html__( "Location", 'commonsbooking' ),
 				'id'               => \CommonsBooking\Model\Restriction::META_LOCATION_ID,
 				'type'             => 'select',
-				'show_option_none' => esc_html__( 'All', 'commonsbooking' ),
 				'options'          => self::sanitizeOptions( \CommonsBooking\Repository\Location::getByCurrentUser() ),
 			),
 			array(
 				'name'             => esc_html__( "Item", 'commonsbooking' ),
 				'id'               => \CommonsBooking\Model\Restriction::META_ITEM_ID,
 				'type'             => 'select',
-				'show_option_none' => esc_html__( 'All', 'commonsbooking' ),
 				'options'          => self::sanitizeOptions( \CommonsBooking\Repository\Item::getByCurrentUser() ),
 			),
 			array(


### PR DESCRIPTION
Weil der Bugfix #1273 nicht so trivial ist deaktiviert dieser PR vorerst die Funktion "Alle" bei der Zuweisung von Einschränkungen zuzuweisen. 
Auf Wunsch von der Flotte, TODO für uns ist besprechen, ob wir das auch allgemein releasen wollen oder ob wir warten sollen bis wir den Bugfix für #1273 raushaben.