### PR TITLE
Fixes errors in TimeframeExport (Issue #1532)

### DIFF
--- a/src/View/TimeframeExport.php
+++ b/src/View/TimeframeExport.php
@@ -73,7 +73,6 @@ class TimeframeExport {
 
 		$timeframeDataRows = self::getTimeframeData( $timeframes );
 
-		/** @var \CommonsBooking\Model\Timeframe $timeframePost */
 		foreach ( $timeframeDataRows as $timeframeDataRow ) {
 
 			if ( ! $headline ) {
@@ -96,11 +95,15 @@ class TimeframeExport {
 			// output the column values
 			$valueColumns = array_values( $timeframeDataRow );
 
+			//TODO #507
+			/** @var \CommonsBooking\Model\Timeframe $timeframeDataPost */
+			$timeframeDataPost = new \CommonsBooking\Model\Timeframe( $timeframeDataRow['ID'] );
+
 			// Get values for user defined input fields.
 			foreach ( $inputFields as $type => $fields ) {
 				// Location fields
 				if ( $type == 'location' ) {
-					$location = $timeframePost->getLocation();
+					$location = $timeframeDataPost->getLocation();
 					foreach ( $fields as $field ) {
 						$valueColumns[] = $location->getFieldValue( $field );
 					}
@@ -108,7 +111,7 @@ class TimeframeExport {
 
 				// Item fields
 				if ( $type == 'item' ) {
-					$item = $timeframePost->getItem();
+					$item = $timeframeDataPost->getItem();
 					foreach ( $fields as $field ) {
 						$valueColumns[] = $item->getFieldValue( $field );
 					}
@@ -116,7 +119,7 @@ class TimeframeExport {
 
 				// User fields
 				if ( $type == 'user' ) {
-					$user = $timeframePost->getUserData();
+					$user = $timeframeDataPost->getUserData();
 					foreach ( $fields as $field ) {
 						$valueColumns[] = $user->get( $field );
 					}
@@ -220,7 +223,7 @@ class TimeframeExport {
 	}
 
 	/**
-	 * Takes an array of timeframes and returns an array of timeframe data for the table export
+	 * Takes an array of timeframe posts and returns an array of timeframe assoc array data for the table export
 	 *
 	 * @param \CommonsBooking\Model\Timeframe[] $timeframePosts
 	 *

--- a/tests/php/View/TimeframeExportTest.php
+++ b/tests/php/View/TimeframeExportTest.php
@@ -4,10 +4,15 @@ namespace CommonsBooking\Tests\View;
 
 use CommonsBooking\Model\Booking;
 use CommonsBooking\Model\Timeframe;
+use CommonsBooking\Settings\Settings;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use CommonsBooking\View\TimeframeExport;
+use SlopeIt\ClockMock\ClockMock;
 
 class TimeframeExportTest extends CustomPostTypeTest {
+
+	protected $fileUnderTest;
+	protected $directoryUnderTest;
 
 	public function testGetTimeframeData() {
 		$timeframeOneItemAndLocation = new Timeframe( $this->createBookableTimeFrameIncludingCurrentDay() );
@@ -41,5 +46,101 @@ class TimeframeExportTest extends CustomPostTypeTest {
 		$booking = new Booking($this->createConfirmedBookingStartingToday());
 		$dataArray = TimeframeExport::getTimeframeData( [ $booking ] );
 		$this->assertEquals( 1, count( $dataArray ) );
+	}
+
+	/**
+	 * @ignore
+	 */
+	public function testExportCsv_testsFileCreation() {
+
+		// TODO think about changing the signature of exportCSV or getExportData to include startDate and endDate, then it is less coupled to the actual usage atm
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		Settings::updateOption( 'commonsbooking_options_export', 'export-timerange', 14 );
+
+		$timeframeOneItemAndLocation = new Timeframe( $this->createBookableTimeFrameIncludingCurrentDay() );
+
+		TimeframeExport::exportCsv( $this->directoryUnderTest );
+
+		$fileName = scandir( $this->directoryUnderTest )[2];
+		$this->fileUnderTest = $this->directoryUnderTest . $fileName;
+
+		// Check basic properties
+		$this->assertTrue( file_exists( $this->fileUnderTest ) );
+		$this->assertGreaterThan( 0, filesize( $this->fileUnderTest ) );
+		ClockMock::reset();
+
+		// Parse csv contents
+		$i = 0;
+		$header = null;
+		$firstLine = null;
+		$file = fopen($this->fileUnderTest, 'r');
+		while (($line = fgetcsv($file)) !== FALSE) {
+			if ( $i == 0 ) {
+				$header = $line[0];
+			}
+			if ( $i == 1 ) {
+				$firstLine = $line[0];
+			}
+			$i += 1;
+		}
+		fclose($file);
+
+		$this->assertNotNull( $header );
+		$firstColumn = explode( ";", $header)[0];
+
+		$this->assertEquals( "ID", $firstColumn );
+		$this->assertNotNull( $firstLine );
+	}
+
+	public function testGetExportData() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		$timeframeOneItemAndLocation = new Timeframe( $this->createBookableTimeFrameIncludingCurrentDay() );
+		$dataArray = TimeframeExport::getTimeframeData( [ $timeframeOneItemAndLocation ] );
+		$this->assertEquals( 1, count( $dataArray ) );
+
+		$secondItem = $this->createItem( 'second-item' );
+		$timeframeTwoItemsOneLocation = new Timeframe (
+			$this->createTimeframe(
+				$this->locationId,
+				[ $this->itemId, $secondItem ],
+				strtotime( self::CURRENT_DATE ),
+				strtotime( '+1 week', strtotime( self::CURRENT_DATE ) )
+			)
+		);
+		$dataArray = TimeframeExport::getTimeframeData( [ $timeframeTwoItemsOneLocation ] );
+		$this->assertEquals( 2, count( $dataArray ) );
+
+		Settings::updateOption( 'commonsbooking_options_export', 'export-timerange', '14' );
+
+		$result = TimeFrameExport::getExportData( true );
+
+		$this->assertEquals( 2, count( $result ));
+		ClockMock::reset();
+	}
+
+	public function tearDown():void {
+		parent::tearDown();
+
+		if ($this->fileUnderTest)
+			wp_delete_file( $this->fileUnderTest );
+
+		rmdir( $this->directoryUnderTest );
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->directoryUnderTest = '/tmp/commonsbooking-timeframe-export-directory/';
+
+		// Deletes directory if existent
+		if ( file_exists( $this->directoryUnderTest ) ) {
+			foreach( scandir( $this->directoryUnderTest ) as $fileInDir ) {
+				wp_delete_file( $this->directoryUnderTest . $fileInDir );
+			}
+			rmdir( $this->directoryUnderTest );
+		}
+
+		// Creates new
+		mkdir( $this->directoryUnderTest );
 	}
 }


### PR DESCRIPTION
Adds the fix and additional tests to validate the fix.                                                                   
                                                                                                                         
The commit 8d98c00317e219dc0185adab8ec1e9f88ebba949 introduced this bug.                                                 
It had the purpose to allow timesframes (for holidays) to be "mutli-selected" with more than one location or item.       
This fixes the export, but won't include custom-fields of location- and item-posts, related to holiday-timeframes in the 
export file.