### PR TITLE
Fix usage of opis 2.0 interface

### DIFF
--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -92,19 +92,21 @@ class BaseRoute extends WP_REST_Controller {
 		$validator = new Validator();
 
 		try {
-			$result = $validator->schemaValidation( $data, $this->getSchemaObject() );
-			if ( $result->hasErrors() ) {
+			$result = $validator->validate( $data, $this->getSchemaObject() );
+			if ( $result->hasError() ) {
 				if ( WP_DEBUG ) {
-					var_dump( $result->getErrors() );
+					var_dump( $result->error() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
 					die;
 				}
 			}
 		} catch ( Exception $e ) {
+			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			if ( WP_DEBUG ) {
 				error_log( 'Problem while trying to access wp rest endpoint url for schema ' . $this->schemaUrl );
 				error_log( $e );
 				die;
 			}
+			// phpcs:enable
 		}
 	}
 
@@ -118,7 +120,9 @@ class BaseRoute extends WP_REST_Controller {
 		unset( $schemaObject->{'$schema'} );
 		unset( $schemaObject->{'$id'} );
 
-		return Schema::fromJsonString( wp_json_encode( $schemaObject ) );
+		$validator = new Validator();
+
+		return $validator->loader()->loadObjectSchema( $schemaObject );
 	}
 
 	/**

--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -10,6 +10,7 @@ use CommonsBooking\Repository\ApiShares;
 use CommonsBooking\Settings\Settings;
 use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
+use Opis\JsonSchema\Helper;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Server;
@@ -115,14 +116,12 @@ class BaseRoute extends WP_REST_Controller {
 	 *
 	 * @return Schema
 	 */
-	protected function getSchemaObject(): Schema {
+	protected function getSchemaObject(): object {
 		$schemaObject = json_decode( $this->getSchemaJson() );
 		unset( $schemaObject->{'$schema'} );
 		unset( $schemaObject->{'$id'} );
 
-		$validator = new Validator();
-
-		return $validator->loader()->loadObjectSchema( $schemaObject );
+		return $schemaObject;
 	}
 
 	/**


### PR DESCRIPTION
The Opis dependency was updated in 4c99c15e61fdeaeee23ae8eb9f738709e2cc10a1, but because of #1531 the code was unreachable and the bug wouldn't occur. After patching #1531, this code can be reached and a fix is necessary, because the API of OPIS JSON Parser got a majore refactoring.

See migration guide: https://opis.io/json-schema/2.x/php-validator.html#data-validation

Though it fixes partially #1466, the issue with possible missing schema files in production which should be moved from `node_modules` into the `commosnbooking` plugin dir prevails (and is fixed in #1547).