### PR TITLE
API: Adds commons-api schema files as assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,6 +141,12 @@ module.exports = function (grunt) {
 						cwd: 'node_modules/vue/dist/',
 						src: 'vue.runtime.global.prod.js',
 					},
+                    {
+                        dest: 'includes/commons-api-json-schema/',
+                        expand: true,
+                        cwd: 'node_modules/commons-api/',
+                        src: '**schema.json',
+                    }
 				],
 			},
 		},

--- a/src/API/AvailabilityRoute.php
+++ b/src/API/AvailabilityRoute.php
@@ -32,9 +32,10 @@ class AvailabilityRoute extends BaseRoute {
 
 	/**
 	 * Commons-API schema definition.
+	 *
 	 * @var string
 	 */
-	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . "node_modules/commons-api/commons-api.availability.schema.json";
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'assets/schemas/commons-api/commons-api.availability.schema.json';
 
 	/**
 	 * This retrieves bookable timeframes and the different items assigned, with their respective availability.

--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -90,12 +90,6 @@ class BaseRoute extends WP_REST_Controller {
 	 */
 	public function validateData( $data ) {
 		$validator = new Validator();
-		//the validation routes are not shipped with the built plugin
-		$isDevEnvironment = file_exists( COMMONSBOOKING_PLUGIN_DIR . 'node_modules' );
-
-		if ( ! $isDevEnvironment ) {
-			return;
-		}
 
 		try {
 			$result = $validator->schemaValidation( $data, $this->getSchemaObject() );

--- a/src/API/ItemsRoute.php
+++ b/src/API/ItemsRoute.php
@@ -28,7 +28,7 @@ class ItemsRoute extends BaseRoute {
 	 * Commons-API schema definition.
 	 * @var string
 	 */
-	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . "node_modules/commons-api/commons-api.items.schema.json";
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . "assets/schemas/commons-api/commons-api.items.schema.json";
 
 	/**
 	 * Returns raw data collection.

--- a/src/API/LocationsRoute.php
+++ b/src/API/LocationsRoute.php
@@ -30,9 +30,10 @@ class LocationsRoute extends BaseRoute {
 
 	/**
 	 * Commons-API schema definition.
+	 *
 	 * @var string
 	 */
-	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . "node_modules/commons-api/commons-api.locations.schema.json";
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'assets/schemas/commons-api/commons-api.locations.schema.json';
 
 	/**
 	 * @var Provider

--- a/src/API/OwnersRoute.php
+++ b/src/API/OwnersRoute.php
@@ -30,9 +30,10 @@ class OwnersRoute extends BaseRoute {
 
 	/**
 	 * Commons-API schema definition.
+	 *
 	 * @var string
 	 */
-	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . "node_modules/commons-api/commons-api.owners.schema.json";
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'assets/schemas/commons-api/commons-api.owners.schema.json';
 
 	/**
 	 * Returns raw data collection.

--- a/src/API/ProjectsRoute.php
+++ b/src/API/ProjectsRoute.php
@@ -24,9 +24,10 @@ class ProjectsRoute extends BaseRoute {
 
 	/**
 	 * Commons-API schema definition.
+	 *
 	 * @var string
 	 */
-	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . "node_modules/commons-api/commons-api.projects.schema.json";
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'assets/schemas/commons-api/commons-api.projects.schema.json';
 
 	/**
 	 * Get one item from the collection


### PR DESCRIPTION
This is a fix for #1466; it moves common-api schema files at grunt-build time to the assets folder and changes the relevant paths.

Fixes #1466 