### PR TITLE
GBFS/Commons-API: Add filter hook for item processing

### DIFF
--- a/src/API/GBFS/BaseRoute.php
+++ b/src/API/GBFS/BaseRoute.php
@@ -44,15 +44,39 @@ class BaseRoute extends \CommonsBooking\API\BaseRoute {
 	/**
 	 * Returns item data array.
 	 *
-	 * @param $request
+	 * @since 2.9.3 includes filter hooks for location get-args and for-each item skip.
+	 *
+	 * @param WP_REST_Request $request inbound rest request.
 	 *
 	 * @return array
 	 */
 	public function getItemData( $request ): array {
-		$data      = [];
-		$locations = Location::get();
+		$data = array();
+
+		/**
+		 * Lets you customize the args for database query. Affects all endpoints, because gbfs is based on location model.
+		 *
+		 * @param array $args request args array
+		 * @param WP_REST_Request $request
+		 */
+		$args = apply_filters( 'commonsbooking_gbfs_location_getargs', array(), $request );
+
+		/** @var \CommonsBooking\Model\Location[] $locations */
+		$locations = Location::get( $args );
 
 		foreach ( $locations as $location ) {
+			/**
+			 * You can compute if an item should be skipped or not for the api response, based on $item data.
+			 *
+			 * Example: add_filter( '...', function ( Location $location ) {
+			 *      return 'my_category' in $location->term;
+			 * })
+			 *
+			 * @param \CommonsBooking\Model\Location $location bookable post type.
+			 */
+			if ( true === apply_filters( 'commonsbooking_gbfs_location_skipitem', $location ) ) {
+				continue;
+			}
 			try {
 				$itemdata = $this->prepare_item_for_response( $location, $request );
 				$data[]   = $itemdata;

--- a/src/API/ItemsRoute.php
+++ b/src/API/ItemsRoute.php
@@ -33,7 +33,7 @@ class ItemsRoute extends BaseRoute {
 	/**
 	 * Returns raw data collection.
 	 *
-	 * @param $request
+	 * @param WP_REST_Request $request inbound request object.
 	 *
 	 * @return stdClass
 	 */
@@ -49,8 +49,34 @@ class ItemsRoute extends BaseRoute {
 			];
 		}
 
+		/**
+		 * Lets you customize the database query.
+		 *
+		 * Example: add_filter( '...', function( array $args ) {
+		 *      $args['category_slug'] = 'my_category';
+		 * })
+		 *
+		 * @param array $args from the {@see Item::get} args.
+		 */
+		$args = apply_filters( 'commonsbooking_commonsapi_itemsroute_getargs', $args );
+
+		/** @var \CommonsBooking\Model\Item[] $items */
 		$items = Item::get( $args );
 		foreach ( $items as $item ) {
+
+			/**
+			 * You can compute if an item should be skipped or not for the api response, based on $item data.
+			 *
+			 * Example: add_filter( '...', function ( Item $item ) {
+			 *      return 'my_category' in $item->term;
+			 * })
+			 *
+			 * @param \CommonsBooking\Model\Item $item bookable post type.
+			 */
+			if ( true === apply_filters( 'commonsbooking_commonsapi_itemsroute_skipitem', $item ) ) {
+				continue;
+			}
+
 			$itemdata      = $this->prepare_item_for_response( $item, $request );
 			$data->items[] = $this->prepare_response_for_collection( $itemdata );
 		}


### PR DESCRIPTION
This has the goal to enable users of the cb plugin, to alter api responses for gbfs and commons-api requests.
The motivation behind it: Item data of an instance can be many different things and endpoint response data has to be very specific. For example can an initiative lend bikes and cars, but the GBFS endpoint only should return data for bike items. 

Long term goal: Through the power of filter hooks, each initiative can implement their own filter logic, if they need it. Without touching the core implementation, this shifts work from the core-team to the users.
 
Scope of a first implentation-step would be filter hooks. Scope of potential second step would be to implement it backed by the Options array, which then can be accessed easily via web interface.

TODO and thoughts on this PR:
- [ ] discuss filter names and filter apis
- [ ] Add filter hooks for all commons-api endpoints
- [ ] Filter for gbfs item processing. But it is buried in endpoint implementation and coupled. In contrast to the gbfs location processing, which is in the base impl.