### PR TITLE
fix #1229 (Vergangene Buchungen in Buchungsübersicht)

### DIFF
--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -66,6 +66,12 @@ class Booking extends View {
 			$order = sanitize_text_field( $_POST['order'] );
 		}
 
+		// Upon initial load, start date is not configured
+		$startDateDefined = false;
+		if ( array_key_exists( 'startDate', $_POST ) ) {
+			$startDateDefined = true;
+		}
+
 		$filters = [
 			'location'  => false,
 			'item'      => false,
@@ -109,7 +115,29 @@ class Booking extends View {
 			);
 
 			if ( ! $posts ) {
-				return false;
+				// Because upon initial load the form stays empty when we just have bookings in the past
+				// With an empty form, the user can't change the start date so we look for bookings in the past
+				if ( ! $startDateDefined ) {
+					//Don't fetch all bookings so that admins are not overwhelmed with all bookings of all time
+					for ( $year = 1; $year <= 3; $year++) {
+						$currentTime = strtotime( '-' . $year . ' year' );
+						$posts     = \CommonsBooking\Repository\Booking::getForUser(
+							$user,
+							true,
+							$currentTime
+						);
+						if ( $posts ) {
+							$filters['startDate'] = $currentTime;
+							break;
+						}
+					}
+					if ( ! $posts ) {
+						return false;
+					}
+				}
+				else {
+					return false;
+				}
 			}
 
 			// Prepare Templatedata and remove invalid posts


### PR DESCRIPTION
*Was*

Die Buchungsliste zeigt mit der Initialkonfiguration nur Buchungen ab dem heutigen Tag an. Wenn vergangene Buchungen angezeigt werden sollen, muss über den Filter das Startdatum in die Vergangenheit gesetzt werden. Eben dieser Filter wird aber nicht angezeigt, wenn keine Buchungen vorhanden sind. Deshalb sorgt dieser PR dafür, dass bei nicht gesetztem Startdatum und keinen Buchungen in der Zukunft sukzessive die letzten drei Jahre durchsucht werden um Nutzenden wenigstens eine Buchung anzeigen zu können. Von da aus können Nutzende dann mit dem ihnen nun angezeigten Filter auch weiter in der Vergangenheit ihre Buchungen sehen. 

* Mögliche Probleme * 

Wenn Nutzende keine Buchungen in den letzten drei Jahren getätigt haben wird ihnen die Buchungsliste wieder nicht angezeigt. 

* Alternative *
Eine schöne Alternative wäre bestimmt auch neben dem Warnhinweis "Keine Buchungen vorhanden" einen Link zu haben "Alte Buchungen laden", der dann die entsprechende AJAX Anfrage stellt. Das würde ein Verwirren der Nutzer durch alte Buchungen vielleicht verhindern. Das war jetzt eine Lösung mit relativ geringem Aufwand.

closes #1229 