### PR TITLE
fix #1557

### DIFF
--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -82,8 +82,13 @@ class Booking extends Timeframe {
         $post = $post ?? get_post( $post_id );
         $is_trash_action = str_contains(($_REQUEST ?? array())['action'] ?? '', 'trash');
 
-        // we check if its a new created post
-        if ( ! empty( $_REQUEST ) && !$is_trash_action && $pagenow === 'post.php' && commonsbooking_isCurrentUserAdmin() ) {
+        // we check if its a new created post - TODO: This is not the case
+        if (
+			! empty( $_REQUEST ) &&
+			! $is_trash_action &&
+			$pagenow === 'post.php' &&
+			( commonsbooking_isCurrentUserAdmin() || commonsbooking_isCurrentUserCBManager() )
+		) {
             // set request variables
             $booking_user = isset( $_REQUEST['booking_user'] ) ? esc_html( $_REQUEST['booking_user'] ) : false;
 


### PR DESCRIPTION
Das sollte das Problem beheben, somit wird der Codeblock auf für CB-Manager ausgeführt. Dabei ist mir aufgefallen, dass der Kommentar "we check if its a new created post " nicht zutrifft, bei jedem neuen Speichern wird auch die Buchungsmail nochmal versendet. 

closes #1557 