### PR TITLE
Fix PHP warning in case $booking is null

### DIFF
--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -247,7 +247,7 @@ class Booking extends Timeframe {
 			);
 
 		// delete unconfirmed booking if booking process is canceled by user
-		if ( $post_status === 'delete_unconfirmed' && $booking->ID === $post_ID ) {
+		if ( $post_status === 'delete_unconfirmed' && $booking->ID && $post_ID && $booking->ID === $post_ID ) {
 			wp_delete_post( $post_ID );
 			throw new BookingDeniedException(
 				__( 'Booking canceled.', 'commonsbooking' ),


### PR DESCRIPTION
This error showed in our error log today: 

`PHP Warning:  Attempt to read property "ID" on null in wp-content/plugins/commonsbooking/src/Wordpress/CustomPostType/Booking.php on line 248`