### PR TITLE
fix #1584 (unerwartetes Verhalten durch unconfirmed booking cleanup)

### DIFF
--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -240,6 +240,13 @@ class Booking extends Timeframe {
 			throw new BookingDeniedException( __( 'Start- and/or end-date is missing.', 'commonsbooking' ) );
 		}
 
+		if ( $post_ID != null && ! get_post( $post_ID ) ) {
+			throw new BookingDeniedException(
+				__( 'Your reservation has expired, please try to book again', 'commonsbooking' ),
+				add_query_arg( 'cb-location', $locationId, get_permalink( get_post( $itemId ) ) )
+			);
+		}
+
 		/** @var \CommonsBooking\Model\Booking $booking */
 		$booking = \CommonsBooking\Repository\Booking::getByDate(
 			$repetitionStart,


### PR DESCRIPTION
Falls ein Buchungsrequest mit Referenz auf eine Post_ID abgsetzt wird (im Normalfall bedeutet das die Bestätigung einer unbestätigten Buchung oder das Stornieren einer unbestätigten Buchung) wird nochmal zusätzlich geprüft, ob dieser Post überhaupt existiert.

closes #1584 