### PR TITLE
Generate random booking codes (fix issue-1110)

### DIFF
--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -341,10 +341,6 @@ class BookingCodes {
 			throw new BookingCodeException( __( "No booking codes could be created because the item of the timeframe could not be found.", 'commonsbooking' )  );
 		}
 
-		$bookingCodesRandomizer = intval( $timeframe->ID );
-		$bookingCodesRandomizer += $item->ID;
-		$bookingCodesRandomizer += $location->ID;
-
 		foreach ( $period as $dt ) {
 			$day = new Day( $dt->format( 'Y-m-d' ) );
 			if ( $day->isInTimeframe( $timeframe ) ) {
@@ -358,7 +354,7 @@ class BookingCodes {
 				$bookingCode = new BookingCode(
 					$dt->format( 'Y-m-d' ),
 					$item->ID,
-					$bookingCodesArray[ ( (int) $dt->format( 'z' ) + $bookingCodesRandomizer ) % count( $bookingCodesArray ) ]
+					$bookingCodesArray[ random_int(0, count($bookingCodesArray) - 1) ]
 				);
 				self::persist(
 					$bookingCode,

--- a/tests/php/Repository/BookingCodesRandomnessTest.php
+++ b/tests/php/Repository/BookingCodesRandomnessTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CommonsBooking\Tests\Repository;
+
+use CommonsBooking\Repository\BookingCodes;
+use CommonsBooking\Settings\Settings;
+use SlopeIt\ClockMock\ClockMock;
+
+class BookingCodesRandomnessTest extends BookingCodesTest
+{
+	// Helper function to delete all booking codes
+	private static function deleteAllBookingCodes() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . BookingCodes::$tablename;
+		$wpdb->query("DELETE FROM {$table_name}");
+	}
+
+	// Helper function to get a booking code for today
+	private function getCodeForToday() {
+		ClockMock::freeze(new \DateTime(self::CURRENT_DATE));
+		$todayDate = date('Y-m-d', strtotime(self::CURRENT_DATE));
+		BookingCodes::generate($this->timeframeWithEndDate, 1);
+		$codeObj = BookingCodes::getCode($this->timeframeWithEndDate, $this->itemId, $this->locationId, $todayDate, 1);
+		return $codeObj->getCode();
+	}
+
+	public function testGeneratedCodesAreRandom() {
+		// Load code pool into an array and expect at least 6 codes
+		$codePoolString = Settings::getOption('commonsbooking_options_bookingcodes', 'bookingcodes');
+		$codePoolArray = explode(',', trim($codePoolString));
+		$this->assertGreaterThanOrEqual(6, count($codePoolArray));
+
+		// Prepare the Pearson chi-squared test by generating a code for today multiple times
+		// and storing the samples in an array. The number of samples should be at least
+		// 5 times the number of codes in the pool, but preferably many more
+		$tests = 100 * count($codePoolArray);
+
+		$generatedCodeForTodayArray = [];
+		for ($i = 0; $i < $tests; $i++) {
+			self::deleteAllBookingCodes();
+			$generatedCodeForTodayArray[] = $this->getCodeForToday();
+		}
+
+		// Count the occurrences of each code
+		$codeOccurrenceAssociativeArray = array_count_values($generatedCodeForTodayArray);
+		$codeOccurrenceArray = array_values($codeOccurrenceAssociativeArray);
+
+		// As the number of samples is high, we expect each pool code to be generated at least once
+		$this->assertEquals(count($codePoolArray), count($codeOccurrenceArray));
+
+		// Perform the chi-squared test on the sampled codes
+		// Null hypothesis: The codes have a uniform probability distribution
+		// Alpha = 0.001 (probability of rejecting the null hypothesis if it is true is 0.1%)
+		// If there are 6 codes in the pool, the degrees of freedom is 5 and the
+		// upper-tail critical value is 22.458
+		$chi2_critical = 22.458;
+
+		// Calculate chi-squared value from the sampled data
+		$expectedOccurrences = floatval($tests) / count($codePoolArray);
+
+		$chi2 = 0.0;
+		foreach ($codeOccurrenceArray as $occurrence) {
+			$chi2 += (($expectedOccurrences - $occurrence) ** 2) / $expectedOccurrences;
+		}
+
+		// Assert that we do not reject the null hypothesis that the code generation is random
+		$this->assertLessThan($chi2_critical, $chi2);
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+}

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -10,7 +10,7 @@ use SlopeIt\ClockMock\ClockMock;
 
 class BookingCodesTest extends CustomPostTypeTest
 {
-	private Timeframe $timeframeWithEndDate;
+	protected Timeframe $timeframeWithEndDate;
 	private Timeframe $timeframeWithoutEndDate;
 	private Timeframe $timeframeWithDisabledBookingCodesAndEndDate;
 	private Timeframe $timeframeWithDisabledBookingCodesWithoutEndDate;


### PR DESCRIPTION
Booking codes were generated deterministically with an obvious pattern. Now generate with the recommended and cryptographically secure random_int() of PHP.