### PR TITLE
fix BookingCodesMessage:sendMessage() wrong $attachment for prepareMail

### DIFF
--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -95,7 +95,7 @@ class BookingCodesMessage extends Message {
                 'item' => $timeframe->getItem(),
                 'location' => $timeframe->getLocation(),
             ],
-            [ $attachment]
+			$attachment
 		);
         
         add_action( 'commonsbooking_mail_sent',array($this,'updateEmailSent'), 5, 2 );

--- a/tests/php/Service/BookingCodesTest.php
+++ b/tests/php/Service/BookingCodesTest.php
@@ -43,6 +43,15 @@ class BookingCodesTest extends CustomPostTypeTest {
 		$this->assertMatchesRegularExpression('/' . implode('|',self::bookingCodes) . '/',$email->get_sent()->body);
 	}
 
+	/* As testSendBookingCodesMessage but cover the case when Ical is attached */
+	public function testSendBookingCodesMessageWithICal() {
+
+		// enable sending of Ical attachment
+		Settings::updateOption( 'commonsbooking_options_bookingcodes', 'mail-booking-codes-attach-ical', 'on');
+
+		$this->testSendBookingCodesMessage();
+	}
+
 	/* Tests some exceptional calculations for emailing booking codes (range and next event) */
 	public function testGetCronParams() {
 		$this->setCronParams(strtotime("2020-02-29"),strtotime("2023-01-15"));

--- a/tests/php/View/BookingCodesTest.php
+++ b/tests/php/View/BookingCodesTest.php
@@ -51,6 +51,13 @@ class BookingCodesTest extends CustomPostTypeTest {
 		$this->assertMatchesRegularExpression('/' . implode('|',self::bookingCodes) . '/',$email->get_sent()->body);
 	}
 
+	/* As above but cover the case when ical is attached */
+	public function testEmailCodesWithIcal() {
+
+		Settings::updateOption( 'commonsbooking_options_bookingcodes', 'mail-booking-codes-attach-ical', 'on');
+
+		$this->testEmailCodes();
+	}
 
 	public function testInitialCronEmailEvent() {
 		$todayDate = new \DateTime(self::CURRENT_DATE);


### PR DESCRIPTION
Mit Bezug auf #1605 , das Ziel dieser PR ist, diese Fehlermeldungen in phpunit unter "WP latest on PHP 8.2" loszuwerden. Diese Sequenz trat insgesamt zwei mal auf und wurden durch die Test-Funktionen Service::BookingCodesTest::testSendBookingCodesMessage() und View::BookingCodesTest::testSendBookingCodesMessage() ausgelöst. Siehe Commitbeschreibung für Details.

```
PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /tmp/wordpress/wp-includes/PHPMailer/PHPMailer.php on line 1880
PHP Deprecated:  is_file(): Passing null to parameter #1 ($filename) of type string is deprecated in /tmp/wordpress/wp-includes/PHPMailer/PHPMailer.php on line 1895
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /tmp/wordpress/wp-includes/PHPMailer/PHPMailer.php on line 1897
```

Mit dieser PR verschwinden die o.g. Warnungen, aber sonst ändert sich nichts.