### PR TITLE
Warnung loswerden: Creation of dynamic property ... is deprecated

### DIFF
--- a/tests/php/Repository/TimeframeTest.php
+++ b/tests/php/Repository/TimeframeTest.php
@@ -18,6 +18,9 @@ class TimeframeTest extends CustomPostTypeTest {
 	protected int $timeframeDailyRepetition;
 	protected int $timeframeWeeklyRepetition;
 	protected int $timeframeManualRepetition;
+	protected int $otherItemId;
+	protected int $otherLocationId;
+	protected int $otherTimeframeId;
 
 	/**
 	 * The tests are designed in a way, that all timeframes should lie in the CURRENT_DATE plus 10 days.
@@ -482,7 +485,7 @@ class TimeframeTest extends CustomPostTypeTest {
 	 */
 	public function testGetPostIdsByType_multiLocationMultiItem() {
 		// Timeframe with enddate and one item
-		$this->timeframeId = $this->createTimeframe(
+		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
 			$this->repetition_start,

--- a/tests/php/Service/BookingRuleAppliedTest.php
+++ b/tests/php/Service/BookingRuleAppliedTest.php
@@ -14,6 +14,8 @@ class BookingRuleAppliedTest extends CustomPostTypeTest {
 	private Booking $testBookingTomorrow;
 	private int $testBookingId;
 	protected BookingRuleApplied $appliedAlwaysAllow,$appliedAlwaysDeny;
+	protected BookingRule $alwaysallow;
+	protected BookingRule $alwaysdeny;
 
 	protected function setUpTestBooking(): void {
 		$this->testBookingId       = $this->createBooking(


### PR DESCRIPTION

Mit Bezug auf #1605 ist das Ziel dieser PR, die u.g. Warnungen loszuwerden. PHP erlaubt es (bald) nicht mehr, properties dynamisch zu deklarieren. Die Lösung ist also, die betroffenen properties in der class-Definition zu deklarieren.

> PHP Deprecated:  Creation of dynamic property CommonsBooking\Tests\Repository\TimeframeTest::$timeframeId is deprecated in /home/runner/work/commonsbooking/commonsbooking/tests/php/Repository/TimeframeTest.php on line 485
> PHP Deprecated:  Creation of dynamic property CommonsBooking\Tests\Repository\TimeframeTest::$otherItemId is deprecated in /home/runner/work/commonsbooking/commonsbooking/tests/php/Repository/TimeframeTest.php on line 41
> PHP Deprecated:  Creation of dynamic property CommonsBooking\Tests\Repository\TimeframeTest::$otherLocationId is deprecated in /home/runner/work/commonsbooking/commonsbooking/tests/php/Repository/TimeframeTest.php on line 42
> PHP Deprecated:  Creation of dynamic property CommonsBooking\Tests\Repository\TimeframeTest::$otherTimeframeId is deprecated in /home/runner/work/commonsbooking/commonsbooking/tests/php/Repository/TimeframeTest.php on line 43
> PHP Deprecated:  Creation of dynamic property CommonsBooking\Tests\Service\BookingRuleAppliedTest::$alwaysallow is deprecated in /home/runner/work/commonsbooking/commonsbooking/tests/php/Service/BookingRuleAppliedTest.php on line 161
> PHP Deprecated:  Creation of dynamic property CommonsBooking\Tests\Service\BookingRuleAppliedTest::$alwaysdeny is deprecated in /home/runner/work/commonsbooking/commonsbooking/tests/php/Service/BookingRuleAppliedTest.php on line 170
