### PR TITLE
fix testRemoveIrrelevantPostmeta

### DIFF
--- a/tests/php/Wordpress/CustomPostType/TimeframeTest.php
+++ b/tests/php/Wordpress/CustomPostType/TimeframeTest.php
@@ -228,21 +228,22 @@ class TimeframeTest extends CustomPostTypeTest {
 	 */
 	public function testRemoveIrrelevantPostmeta() {
 		$tf = new \CommonsBooking\Model\Timeframe( $this->createBookableTimeFrameIncludingCurrentDay() );
-		update_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_ITEM_ID_LIST, [ $this->itemId ] );
-		update_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_LOCATION_ID_LIST, [ $this->locationId ] );
-		update_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_LOCATION_SELECTION_TYPE, \CommonsBooking\Model\Timeframe::SELECTION_ALL_ID );
-		update_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_ITEM_SELECTION_TYPE, \CommonsBooking\Model\Timeframe::SELECTION_ALL_ID );
-		update_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_LOCATION_CATEGORY_IDS, [ '123' ] );
-		update_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_ITEM_CATEGORY_IDS, [ '123' ] );
+		update_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_ITEM_ID_LIST, [ $this->itemId ] );
+		update_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_ID_LIST, [ $this->locationId ] );
+		update_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_SELECTION_TYPE, \CommonsBooking\Model\Timeframe::SELECTION_ALL_ID );
+		update_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_ITEM_SELECTION_TYPE, \CommonsBooking\Model\Timeframe::SELECTION_ALL_ID );
+		update_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_CATEGORY_IDS, [ '123' ] );
+		update_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_ITEM_CATEGORY_IDS, [ '123' ] );
+
 		Timeframe::removeIrrelevantPostmeta( $tf );
 		//especially assert, that no item ids are assigned when updating the multi-select
 		Timeframe::manageTimeframeMeta( $tf->ID );
-		$this->assertEmpty( get_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_ITEM_ID_LIST, true ) );
-		$this->assertEmpty( get_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_LOCATION_ID_LIST, true ) );
-		$this->assertEmpty( get_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_LOCATION_SELECTION_TYPE, true ) );
-		$this->assertEmpty( get_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_ITEM_SELECTION_TYPE, true ) );
-		$this->assertEmpty( get_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_LOCATION_CATEGORY_IDS, true ) );
-		$this->assertEmpty( get_post_meta( $tf, \CommonsBooking\Model\Timeframe::META_ITEM_CATEGORY_IDS, true ) );
+		$this->assertEmpty( get_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_ITEM_ID_LIST, true ) );
+		$this->assertEmpty( get_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_ID_LIST, true ) );
+		$this->assertEmpty( get_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_SELECTION_TYPE, true ) );
+		$this->assertEmpty( get_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_ITEM_SELECTION_TYPE, true ) );
+		$this->assertEmpty( get_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_LOCATION_CATEGORY_IDS, true ) );
+		$this->assertEmpty( get_post_meta( $tf->ID, \CommonsBooking\Model\Timeframe::META_ITEM_CATEGORY_IDS, true ) );
 
 	}
 


### PR DESCRIPTION
Mit Bezug auf #1605 ist das Ziel dieser PR die u.g. Fehlermeldungen (WP latest PHP 8.2) loszuwerden. Die Warnungen wurden vom Test testRemoveIrrelevantPostmeta() ausgelöst, weil update_post_meta() fehlerhaft mit einem Objekt statt mit einer Post-ID aufgerufen wurde. Anmerkung: Der Test kann vorher nicht funktioniert haben, nach der PR ist er weiterhin erfolgreich. 

> PHP Deprecated:  Creation of dynamic property CommonsBooking\Model\Timeframe::$ID is deprecated in /tmp/wordpress/wp-includes/post.php on line 2808
> PHP Deprecated:  Creation of dynamic property CommonsBooking\Model\Timeframe::$filter is deprecated in /tmp/wordpress/wp-includes/post.php on line 2813