### PR TITLE
Change deprecated way of string interpolation

### DIFF
--- a/src/Map/SearchShortcode.php
+++ b/src/Map/SearchShortcode.php
@@ -25,22 +25,22 @@ class SearchShortcode extends BaseShortcode {
 			$data_loader               = trim("
 				const config = CommonsSearch.parseLegacyConfig(" . wp_json_encode($settings) . ");
 				const api = CommonsSearch.createAdminAjaxAPI({
-	                url: ${admin_ajax_url},
-	                nonce: ${nonce},
-	                mapId: ${cb_map_id},
+	                url: $admin_ajax_url,
+	                nonce: $nonce,
+	                mapId: $cb_map_id,
 	            }, config);
 	            if (!window.__CB_SEARCH_DATA) window.__CB_SEARCH_DATA = {};
-	            window.__CB_SEARCH_DATA[${cb_map_id}] = { config, api };
+	            window.__CB_SEARCH_DATA[$cb_map_id] = { config, api };
 			");
 			$this->processed_map_ids[] = $cb_map_id;
 		} else {
-			$data_loader = "const { config, api } = window.__CB_SEARCH_DATA[${cb_map_id}];";
+			$data_loader = "const { config, api } = window.__CB_SEARCH_DATA[$cb_map_id];";
 		}
 
 		$content = trim(strip_tags($content));
 		$content_is_config = $content && is_object(json_decode($content)) && json_last_error() == JSON_ERROR_NONE;
 		if ($content_is_config) {
-			$user_config = "const userConfig = ${content};";
+			$user_config = "const userConfig = $content;";
 		} else {
 			$user_config = "const userConfig = {};";
 		}
@@ -52,9 +52,9 @@ class SearchShortcode extends BaseShortcode {
 
 		$init_script = "(function (el) {
 			document.addEventListener('DOMContentLoaded', function() {
-	            ${data_loader}
-	            ${user_config}
-	            CommonsSearch.init(el, api, CommonsSearch.mergeConfigs(config, { layout: ${layout_config}, ...userConfig }));
+	            $data_loader
+	            $user_config
+	            CommonsSearch.init(el, api, CommonsSearch.mergeConfigs(config, { layout: $layout_config, ...userConfig }));
 			});
         })(document.currentScript.parentElement)";
 


### PR DESCRIPTION
Mit Bezug auf #1605 ist das Ziel dieser PR, u.g. Warningen unter WP latest PHP 8.2. loszuwerden. Statt ${var} habe ich mit der PR vorgeschlagen, einfach $var zu schreiben in Strings mit doppelten Anführungszeichen. Man könnte auch die moderne Variante {$var} nutzen, aber die ist nicht einfacher zu lesen.

> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 26
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 28
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 29
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 30
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 37
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 43
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 53
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 55
> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/commonsbooking/commonsbooking/src/Map/SearchShortcode.php on line 56