### PR TITLE
BookingTest_AJAX_Test: proper cleanup of created database table

### DIFF
--- a/tests/php/View/BookingTest_AJAX_Test.php
+++ b/tests/php/View/BookingTest_AJAX_Test.php
@@ -128,5 +128,14 @@ class BookingTest_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		wp_delete_post( $this->itemID, true );
 		wp_delete_post( $this->locationID, true );
 		wp_delete_post( $this->timeframeID, true );
+		$this->tearDownBookingCodesTable(); // counterpart of BookingCodes::initBookingCodesTable() in setUp()
+	}
+
+	protected function tearDownBookingCodesTable() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . \CommonsBooking\Repository\BookingCodes::$tablename;
+		$sql = "DROP TABLE $table_name";
+
+		$result = $wpdb->query($sql);
 	}
 }


### PR DESCRIPTION
Mit Bezug auf #1605 ist das Ziel dieser PR, die u.g. Warnung loszuwerden. Sie kam zu stande, weil die Tests in BookingTest_AJAX_Test die DB-Tabelle wptests_cb_bookingcodes erstellen, aber nicht wieder löschen. Die Lösung ist, die Tabelle in tearDown() ordentlich zu löschen.


> WordPress database error Table 'wptests_cb_bookingcodes' already exists for query CREATE TABLE wptests_cb_bookingcodes (
>             date date DEFAULT '0000-00-00' NOT NULL,
>             timeframe bigint(20) unsigned NOT NULL,
>             location bigint(20) unsigned NOT NULL,
>             item bigint(20) unsigned NOT NULL,
>             code varchar(100) NOT NULL,
>             PRIMARY KEY (date, timeframe, location, item, code) 
>         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci; made by PHPUnit\TextUI\Command::main, PHPUnit\TextUI\Command->run, PHPUnit\TextUI\TestRunner->run, PHPUnit\Framework\TestSuite->run, PHPUnit\Framework\TestSuite->run, PHPUnit\Framework\TestSuite->run, PHPUnit\Framework\TestCase->run, PHPUnit\Framework\TestResult->run, PHPUnit\Framework\TestCase->runBare, CommonsBooking\Tests\View\CalendarTest->setUp, CommonsBooking\Tests\Wordpress\CustomPostTypeTest->setUp, CommonsBooking\Tests\Wordpress\CustomPostTypeTest->setUpBookingCodesTable
