### PR TITLE
implement feature issue-1602: no code generation for past

### DIFF
--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -341,7 +341,12 @@ class BookingCodes {
 			throw new BookingCodeException( __( "No booking codes could be created because the item of the timeframe could not be found.", 'commonsbooking' )  );
 		}
 
+		$todayMidnight = new \DateTime('today midnight', $period->getStartDate()->getTimezone());
+
 		foreach ( $period as $dt ) {
+			// do not generate any codes for past days
+			if ($dt < $todayMidnight) continue;
+
 			$day = new Day( $dt->format( 'Y-m-d' ) );
 			if ( $day->isInTimeframe( $timeframe ) ) {
 

--- a/tests/php/Repository/BookingCodesTest.php
+++ b/tests/php/Repository/BookingCodesTest.php
@@ -128,7 +128,7 @@ class BookingCodesTest extends CustomPostTypeTest
 		$timeframe_1 = new Timeframe($this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( 'today midnight' ),
 			null,
 		));
 
@@ -176,7 +176,7 @@ class BookingCodesTest extends CustomPostTypeTest
 		$timeframe_2 = new Timeframe($this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( 'today midnight' ),
 			null,
 		));
 
@@ -221,7 +221,7 @@ class BookingCodesTest extends CustomPostTypeTest
 		//now we should get all codes
 		$codes = BookingCodes::getCodes( $this->timeframeWithEndDate->ID,self::ADVANCE_GENERATION_DAYS);
 		$this->assertNotEmpty( $codes );
-		$this->assertCount( 31, $codes );
+		$this->assertCount( 30, $codes );
 		//check that the codes are in the correct order
 		$lastCode = null;
 		foreach ( $codes as $code ) {
@@ -245,10 +245,9 @@ class BookingCodesTest extends CustomPostTypeTest
 		BookingCodes::generate( $this->timeframeWithoutEndDate, self::ADVANCE_GENERATION_DAYS );
 
 		// codes will be generated and returned
-		// - for yesterday which is timeframe start date (1),
 		// - for today (1) and
 		// - for additional BookingCodes::ADVANCE_GENERATION_DAYS
-		$codeAmount = BookingCodes::ADVANCE_GENERATION_DAYS + 2;
+		$codeAmount = 1 + BookingCodes::ADVANCE_GENERATION_DAYS ;
 		$codes = BookingCodes::getCodes( $this->timeframeWithoutEndDate->ID );
 		$this->assertNotEmpty( $codes );
 		$this->assertCount( $codeAmount, $codes );
@@ -292,14 +291,17 @@ class BookingCodesTest extends CustomPostTypeTest
 
 		// test behavior of getCodes() without specified startDate and endDate:
 		// codes will be generated and returned
-		// - for day before self::CURRENT_DATE which is timeframe start date (1),
-		// - for $daysInFuture,
-		// - for today (1) and
+		// - for the future date (1) and
 		// - for additional BookingCodes::ADVANCE_GENERATION_DAYS
-		$codeAmount = BookingCodes::ADVANCE_GENERATION_DAYS + $daysInFuture + 2;
+		$codeAmount = 1 + BookingCodes::ADVANCE_GENERATION_DAYS;
 		$codes = BookingCodes::getCodes( $this->timeframeWithoutEndDate->ID );
 		$this->assertNotEmpty( $codes );
 		$this->assertCount( $codeAmount, $codes );
+
+		// check that no codes have been generated from beginning of timeframe (in the past),
+		// by checking that first generated code is for the future date
+		$this->assertEquals( $futureDate->format( 'Y-m-d' ), $codes[0]->getDate() );
+
 		//check that the codes are in the correct order
 		$lastCode = null;
 		foreach ( $codes as $code ) {
@@ -371,20 +373,20 @@ class BookingCodesTest extends CustomPostTypeTest
 		$this->timeframeWithEndDate = new Timeframe($this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( self::CURRENT_DATE ),
 			strtotime( '+29 day', strtotime( self::CURRENT_DATE ) )
 		));
 		$this->timeframeWithoutEndDate = new Timeframe($this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( self::CURRENT_DATE ),
 			null,
 		));
 
 		$this->timeframeWithDisabledBookingCodesAndEndDate = new Timeframe($this->createTimeframe(
             $this->locationId,
             $this->itemId,
-            strtotime('-1 day', strtotime(self::CURRENT_DATE)),
+            strtotime( self::CURRENT_DATE ),
             strtotime('+30 day', strtotime(self::CURRENT_DATE)),
             \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
             "on",
@@ -408,7 +410,7 @@ class BookingCodesTest extends CustomPostTypeTest
 		$this->timeframeWithDisabledBookingCodesWithoutEndDate = new Timeframe($this->createTimeframe(
             $this->locationId,
             $this->itemId,
-            strtotime('-1 day', strtotime(self::CURRENT_DATE)),
+            strtotime( self::CURRENT_DATE ),
             null,
             \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
             "on",

--- a/tests/php/View/BookingTest_AJAX_Test.php
+++ b/tests/php/View/BookingTest_AJAX_Test.php
@@ -23,6 +23,15 @@ class BookingTest_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	];
 
 	public function testGetBookingCode_AJAX() {
+		ClockMock::freeze( new \DateTime( CustomPostTypeTest::CURRENT_DATE ));
+
+		// Save timeframe post to trigger booking code generation.
+		// It is necessary to generate here after time has been frozen to CustomPostTypeTest::CURRENT_DATE
+		// because the code generation depends on the current date and codes are not generated for the past.
+		// (CustomPostTypeTest::CURRENT_DATE is a date in the past) 
+		$timeframeCPT = new Timeframe();
+		$timeframeCPT->savePost( $this->timeframeID, get_post($this->timeframeID) );
+
 		$_POST['_wpnonce'] = wp_create_nonce( 'cb_get_booking_code' );
 		$data = [
 			'locationID' => $this->locationID,
@@ -114,11 +123,9 @@ class BookingTest_AJAX_Test extends \WP_Ajax_UnitTestCase {
 
 		$bookingCodesString = implode( ',', $this->bookingCodes );
 
-		//init booking code table and initial booking codes for timeframe
+		//init booking code table
 		Settings::updateOption('commonsbooking_options_bookingcodes','bookingcodes',$bookingCodesString);
 		\CommonsBooking\Repository\BookingCodes::initBookingCodesTable();
-		$timeframeCPT = new Timeframe();
-		$timeframeCPT->savePost( $this->timeframeID, get_post($this->timeframeID) );
 	}
 
 	public function tear_down() {


### PR DESCRIPTION
With this feature, no codes are generated for past days anymore. A test case was added and other unit tests were fixed because they actually relied on generation of codes for the past.

This implements #1602 