### PR TITLE
Cache: Warmup does not exit if an shortcode call has an exception

### DIFF
--- a/src/Map/BaseShortcode.php
+++ b/src/Map/BaseShortcode.php
@@ -2,9 +2,18 @@
 
 namespace CommonsBooking\Map;
 
+/**
+ * Map shortcode base implementation.
+ * Derive from this class to create custom map shortcode.
+ * Examples of how to implement the abstract methods called in `execute` are {@see MapShortcode} and {@see SearchShortcode}.
+ */
 abstract class BaseShortcode {
+
 	/**
-	 * the shortcode handler - load all the needed assets and render the map container
+	 * The shortcode handler - load all the needed assets and render the map container
+	 *
+	 * @param array  $atts attributes for parametrization.
+	 * @param string $content content to display, if shortcode implementation allows to.
 	 **/
 	public static function execute( array $atts, string $content ): string {
 		$instance = new static();

--- a/src/Map/BaseShortcode.php
+++ b/src/Map/BaseShortcode.php
@@ -6,8 +6,9 @@ abstract class BaseShortcode {
 	/**
 	 * the shortcode handler - load all the needed assets and render the map container
 	 **/
-	public function execute($atts, $content): string {
-		$attrs = $this->parse_attributes($atts);
+	public static function execute( array $atts, string $content ): string {
+		$instance = new static();
+		$attrs = $instance->parse_attributes($atts);
 		$options = array_filter($atts, "is_int", ARRAY_FILTER_USE_KEY);
 
 		if (! (int) $attrs['id']) {
@@ -25,10 +26,9 @@ abstract class BaseShortcode {
 		}
 
 		$cb_map_id = $post->ID;
-		$this->inject_script($cb_map_id);
-		return $this->create_container($cb_map_id, $attrs, $options, $content);
+		$instance->inject_script($cb_map_id);
+		return $instance->create_container($cb_map_id, $attrs, $options, $content);
 	}
-
 	abstract protected function parse_attributes($atts);
 	abstract protected function inject_script($cb_map_id);
 	abstract protected function create_container($cb_map_id, $attrs, $options, $content);

--- a/src/Map/MapShortcode.php
+++ b/src/Map/MapShortcode.php
@@ -2,6 +2,9 @@
 
 namespace CommonsBooking\Map;
 
+/**
+ * Shortcode for the legacy map with the old non-responsive standard leaflet style.
+ */
 class MapShortcode extends BaseShortcode {
 	protected function create_container($cb_map_id, $attrs, $options, $content) {
 		$map_height = MapAdmin::get_option( $cb_map_id, 'map_height' );

--- a/src/Map/SearchShortcode.php
+++ b/src/Map/SearchShortcode.php
@@ -1,6 +1,10 @@
 <?php
 
 namespace CommonsBooking\Map;
+
+/**
+ * Short code for a multi-widget with map, search and table capabilities.
+ */
 class SearchShortcode extends BaseShortcode {
 	protected $processed_map_ids = [];
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -652,7 +652,7 @@ class Plugin {
 	}
 
 	public function registerShortcodes() {
-		add_shortcode('cb_search', array(new SearchShortcode(), 'execute'));
+		add_shortcode( 'cb_search', array( SearchShortcode::class, 'execute' ) );
 	}
 
 	/**

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -374,19 +374,26 @@ trait Cache {
 	}
 
 	/**
-	 * Iterates through array and executes shortcodecalls.
-	 * @param $shortCodeCalls
+	 * Iterates through array and statically executes given functions.
+	 *
+	 * @param string[] $shortCodeCalls array of tuples of shortcode name strings and tuples of class + static function.
 	 *
 	 * @return void
 	 */
-	private static function runShortcodeCalls($shortCodeCalls) {
+	private static function runShortcodeCalls( array $shortCodeCalls ): void {
 		foreach($shortCodeCalls as $shortcode) {
 			$shortcodeFunction = array_keys($shortcode)[0];
 			$attributes = $shortcode[$shortcodeFunction];
 
 			if(array_key_exists($shortcodeFunction, self::$cbShortCodeFunctions)) {
 				list($class, $function) = self::$cbShortCodeFunctions[$shortcodeFunction];
-				$class::$function($attributes);
+
+				try {
+					$class::$function( $attributes );
+				} catch ( Exception $e ) {
+					// Writes error to log anyway
+					error_log( (string) $e ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				}
 			}
 		}
 	}

--- a/src/Wordpress/CustomPostType/Map.php
+++ b/src/Wordpress/CustomPostType/Map.php
@@ -35,7 +35,7 @@ class Map extends CustomPostType {
 		}
 
 		// Add shortcodes
-		add_shortcode( 'cb_map', array( new MapShortcode(), 'execute' ) );
+		add_shortcode( 'cb_map', array( MapShortcode::class, 'execute' ) );
 
 		// Add actions
 		add_action( 'save_post_' . self::$postType, array( MapAdmin::class, 'validate_options' ), 10, 3 );


### PR DESCRIPTION
Fixes #1636 

TODOs:
* [x] Quickfix: Dem MapShortcode eine statische Methode zu spendieren, welche in dem `runShortcodeCalls` aufgerufen werden kann.
* [x] Außerdem denke wäre es gut, die Methode `runShortcodeCalls` durch das Auftreten einer Exception nicht komplett abbrechen zu lassen, sondern die restlichen Einträge in `cbShortCodeFunctions` noch durchlaufen zu lassen. Also ein `try-catch` zu platzieren und etwaige Exception trotzdem zu loggen.

@hansmorb Der Aktuelle Stand, mitigiert bereits das Verhalten im Issue: Es werden alle Shortcodes ausgeführt. Aber die auftretende Exception ist noch nicht behoben.