### PR TITLE
Calendar: Fix warning about Undefined variable $firstbookableday

### DIFF
--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -352,6 +352,7 @@ class Calendar {
 		$endDate            = new Day( $endDateString );
 		$advanceBookingDays = null;
 		$lastBookableDate   = null;
+		$firstBookableDay   = null;
 		$bookableTimeframes = \CommonsBooking\Repository\Timeframe::getBookableForCurrentUser(
 			[ $location ],
 			[ $item ],
@@ -363,7 +364,7 @@ class Calendar {
 		if ( count( $bookableTimeframes ) ) {
 			$closestBookableTimeframe = self::getClosestBookableTimeFrameForToday( $bookableTimeframes );
 			$advanceBookingDays       = intval( $closestBookableTimeframe->getFieldValue( 'timeframe-advance-booking-days' ) );
-            $firstBookableDay = $closestBookableTimeframe->getFirstBookableDay();
+			$firstBookableDay         = $closestBookableTimeframe->getFirstBookableDay();
 
 			// Only if passed daterange must not be kept
 			if ( ! $keepDaterange ) {


### PR DESCRIPTION
Fixes a warning about undefined variable $firstbookableday in commonsbooking/src/View/Calendar.php (Line: 399)

```
Error code: E_WARNING
[Message]:
Undefined variable $firstbookableday
```

@hansmorb I don't really at the moment if null is a problem here for the JS client code, but it was null for calendars with no timeframes (see the if and the count in Line 363/364) in the past anyways, so I figured it should work this way.