### PR TITLE
Migration Sass 1.80

### DIFF
--- a/assets/admin/sass/admin.scss
+++ b/assets/admin/sass/admin.scss
@@ -5,30 +5,31 @@
  */
 
 /* Global styles */
-@import "../../global/sass/global";
-
-/* Lib: jQuery UI */
-.cb-admin {
-	@import "lib/_jquery-ui";
-}
+@use "../../global/sass/global";
 
 /* Dashboard */
-@import "./partials/_dashboard";
+@use "./partials/_dashboard";
 
 /* Timeframe Form */
-@import "./partials/_form-timeframe";
+@use "./partials/_form-timeframe";
 
 /** Migration Settings */
-@import "./partials/_migration";
+@use "./partials/_migration";
 
 /** Export Settings */
-@import "./partials/_form-export";
+@use "./partials/_form-export";
 
 /* Booking form  */
-@import "./partials/form-booking";
+@use "./partials/form-booking";
 
 /* Booking form  */
-@import "./partials/plugin_update";
+@use "./partials/plugin_update";
 
 /* Edit Screens Backend  */
-@import "./partials/admin-edit";
+@use "./partials/admin-edit";
+
+/* Lib: jQuery UI */
+@use "lib/_jquery-ui";
+.cb-admin {
+    @include jquery-ui.jquery-ui;
+}

--- a/assets/admin/sass/lib/_jquery-ui.scss
+++ b/assets/admin/sass/lib/_jquery-ui.scss
@@ -4,1309 +4,1662 @@
 * To view and modify this theme, visit http://jqueryui.com/themeroller/?bgShadowXPos=&bgOverlayXPos=&bgErrorXPos=&bgHighlightXPos=&bgContentXPos=&bgHeaderXPos=&bgActiveXPos=&bgHoverXPos=&bgDefaultXPos=&bgShadowYPos=&bgOverlayYPos=&bgErrorYPos=&bgHighlightYPos=&bgContentYPos=&bgHeaderYPos=&bgActiveYPos=&bgHoverYPos=&bgDefaultYPos=&bgShadowRepeat=&bgOverlayRepeat=&bgErrorRepeat=&bgHighlightRepeat=&bgContentRepeat=&bgHeaderRepeat=&bgActiveRepeat=&bgHoverRepeat=&bgDefaultRepeat=&iconsHover=url(%22images%2Fui-icons_555555_256x240.png%22)&iconsHighlight=url(%22images%2Fui-icons_777620_256x240.png%22)&iconsHeader=url(%22images%2Fui-icons_444444_256x240.png%22)&iconsError=url(%22images%2Fui-icons_cc0000_256x240.png%22)&iconsDefault=url(%22images%2Fui-icons_777777_256x240.png%22)&iconsContent=url(%22images%2Fui-icons_444444_256x240.png%22)&iconsActive=url(%22images%2Fui-icons_ffffff_256x240.png%22)&bgImgUrlShadow=&bgImgUrlOverlay=&bgImgUrlHover=&bgImgUrlHighlight=&bgImgUrlHeader=&bgImgUrlError=&bgImgUrlDefault=&bgImgUrlContent=&bgImgUrlActive=&opacityFilterShadow=Alpha(Opacity%3D30)&opacityFilterOverlay=Alpha(Opacity%3D30)&opacityShadowPerc=30&opacityOverlayPerc=30&iconColorHover=%23555555&iconColorHighlight=%23777620&iconColorHeader=%23444444&iconColorError=%23cc0000&iconColorDefault=%23777777&iconColorContent=%23444444&iconColorActive=%23ffffff&bgImgOpacityShadow=0&bgImgOpacityOverlay=0&bgImgOpacityError=95&bgImgOpacityHighlight=55&bgImgOpacityContent=75&bgImgOpacityHeader=75&bgImgOpacityActive=65&bgImgOpacityHover=75&bgImgOpacityDefault=75&bgTextureShadow=flat&bgTextureOverlay=flat&bgTextureError=flat&bgTextureHighlight=flat&bgTextureContent=flat&bgTextureHeader=flat&bgTextureActive=flat&bgTextureHover=flat&bgTextureDefault=flat&cornerRadius=3px&fwDefault=normal&ffDefault=Arial%2CHelvetica%2Csans-serif&fsDefault=1em&cornerRadiusShadow=8px&thicknessShadow=5px&offsetLeftShadow=0px&offsetTopShadow=0px&opacityShadow=.3&bgColorShadow=%23666666&opacityOverlay=.3&bgColorOverlay=%23aaaaaa&fcError=%235f3f3f&borderColorError=%23f1a899&bgColorError=%23fddfdf&fcHighlight=%23777620&borderColorHighlight=%23dad55e&bgColorHighlight=%23fffa90&fcContent=%23333333&borderColorContent=%23dddddd&bgColorContent=%23ffffff&fcHeader=%23333333&borderColorHeader=%23dddddd&bgColorHeader=%23e9e9e9&fcActive=%23ffffff&borderColorActive=%23003eff&bgColorActive=%23007fff&fcHover=%232b2b2b&borderColorHover=%23cccccc&bgColorHover=%23ededed&fcDefault=%23454545&borderColorDefault=%23c5c5c5&bgColorDefault=%23f6f6f6
 * Copyright jQuery Foundation and other contributors; Licensed MIT */
 
-/* Layout helpers
-----------------------------------*/
-.ui-helper-hidden {
-	display: none;
-}
-.ui-helper-hidden-accessible {
-	border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px;
-}
-.ui-helper-reset {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	outline: 0;
-	line-height: 1.3;
-	text-decoration: none;
-	font-size: 100%;
-	list-style: none;
-}
-.ui-helper-clearfix:before,
-.ui-helper-clearfix:after {
-	content: "";
-	display: table;
-	border-collapse: collapse;
-}
-.ui-helper-clearfix:after {
-	clear: both;
-}
-.ui-helper-zfix {
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	position: absolute;
-	opacity: 0;
-	filter:Alpha(Opacity=0); /* support: IE8 */
-}
 
-.ui-front {
-	z-index: 100;
-}
+@mixin jquery-ui {
+    /* Layout helpers
+    ----------------------------------*/
+    .ui-helper-hidden {
+        display: none;
+    }
+    .ui-helper-hidden-accessible {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+    }
+    .ui-helper-reset {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        outline: 0;
+        line-height: 1.3;
+        text-decoration: none;
+        font-size: 100%;
+        list-style: none;
+    }
+    .ui-helper-clearfix:before,
+    .ui-helper-clearfix:after {
+        content: "";
+        display: table;
+        border-collapse: collapse;
+    }
+    .ui-helper-clearfix:after {
+        clear: both;
+    }
+    .ui-helper-zfix {
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        position: absolute;
+        opacity: 0;
+        filter: Alpha(Opacity=0); /* support: IE8 */
+    }
 
-
-/* Interaction Cues
-----------------------------------*/
-.ui-state-disabled {
-	cursor: default !important;
-	pointer-events: none;
-}
+    .ui-front {
+        z-index: 100;
+    }
 
 
-/* Icons
-----------------------------------*/
-.ui-icon {
-	display: inline-block;
-	vertical-align: middle;
-	margin-top: -.25em;
-	position: relative;
-	text-indent: -99999px;
-	overflow: hidden;
-	background-repeat: no-repeat;
-}
-
-.ui-widget-icon-block {
-	left: 50%;
-	margin-left: -8px;
-	display: block;
-}
-
-/* Misc visuals
-----------------------------------*/
-
-/* Overlays */
-.ui-widget-overlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-}
-.ui-accordion .ui-accordion-header {
-	display: block;
-	cursor: pointer;
-	position: relative;
-	margin: 2px 0 0 0;
-	padding: .5em .5em .5em .7em;
-	font-size: 100%;
-}
-.ui-accordion .ui-accordion-content {
-	padding: 1em 2.2em;
-	border-top: 0;
-	overflow: auto;
-}
-.ui-autocomplete {
-	position: absolute;
-	top: 0;
-	left: 0;
-	cursor: default;
-}
-.ui-menu {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	display: block;
-	outline: 0;
-}
-.ui-menu .ui-menu {
-	position: absolute;
-}
-.ui-menu .ui-menu-item {
-	margin: 0;
-	cursor: pointer;
-	/* support: IE10, see #8844 */
-	list-style-image: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
-}
-.ui-menu .ui-menu-item-wrapper {
-	position: relative;
-	padding: 3px 1em 3px .4em;
-}
-.ui-menu .ui-menu-divider {
-	margin: 5px 0;
-	height: 0;
-	font-size: 0;
-	line-height: 0;
-	border-width: 1px 0 0 0;
-}
-.ui-menu .ui-state-focus,
-.ui-menu .ui-state-active {
-	margin: -1px;
-}
-
-/* icon support */
-.ui-menu-icons {
-	position: relative;
-}
-.ui-menu-icons .ui-menu-item-wrapper {
-	padding-left: 2em;
-}
-
-/* left-aligned */
-.ui-menu .ui-icon {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: .2em;
-	margin: auto 0;
-}
-
-/* right-aligned */
-.ui-menu .ui-menu-icon {
-	left: auto;
-	right: 0;
-}
-.ui-button {
-	padding: .4em 1em;
-	display: inline-block;
-	position: relative;
-	line-height: normal;
-	margin-right: .1em;
-	cursor: pointer;
-	vertical-align: middle;
-	text-align: center;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-
-	/* Support: IE <= 11 */
-	overflow: visible;
-}
-
-.ui-button,
-.ui-button:link,
-.ui-button:visited,
-.ui-button:hover,
-.ui-button:active {
-	text-decoration: none;
-}
-
-/* to make room for the icon, a width needs to be set here */
-.ui-button-icon-only {
-	width: 2em;
-	box-sizing: border-box;
-	text-indent: -9999px;
-	white-space: nowrap;
-}
-
-/* no icon support for input elements */
-input.ui-button.ui-button-icon-only {
-	text-indent: 0;
-}
-
-/* button icon element(s) */
-.ui-button-icon-only .ui-icon {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	margin-top: -8px;
-	margin-left: -8px;
-}
-
-.ui-button.ui-icon-notext .ui-icon {
-	padding: 0;
-	width: 2.1em;
-	height: 2.1em;
-	text-indent: -9999px;
-	white-space: nowrap;
-
-}
-
-input.ui-button.ui-icon-notext .ui-icon {
-	width: auto;
-	height: auto;
-	text-indent: 0;
-	white-space: normal;
-	padding: .4em 1em;
-}
-
-/* workarounds */
-/* Support: Firefox 5 - 40 */
-input.ui-button::-moz-focus-inner,
-button.ui-button::-moz-focus-inner {
-	border: 0;
-	padding: 0;
-}
-.ui-controlgroup {
-	vertical-align: middle;
-	display: inline-block;
-}
-.ui-controlgroup > .ui-controlgroup-item {
-	float: left;
-	margin-left: 0;
-	margin-right: 0;
-}
-.ui-controlgroup > .ui-controlgroup-item:focus,
-.ui-controlgroup > .ui-controlgroup-item.ui-visual-focus {
-	z-index: 9999;
-}
-.ui-controlgroup-vertical > .ui-controlgroup-item {
-	display: block;
-	float: none;
-	width: 100%;
-	margin-top: 0;
-	margin-bottom: 0;
-	text-align: left;
-}
-.ui-controlgroup-vertical .ui-controlgroup-item {
-	box-sizing: border-box;
-}
-.ui-controlgroup .ui-controlgroup-label {
-	padding: .4em 1em;
-}
-.ui-controlgroup .ui-controlgroup-label span {
-	font-size: 80%;
-}
-.ui-controlgroup-horizontal .ui-controlgroup-label + .ui-controlgroup-item {
-	border-left: none;
-}
-.ui-controlgroup-vertical .ui-controlgroup-label + .ui-controlgroup-item {
-	border-top: none;
-}
-.ui-controlgroup-horizontal .ui-controlgroup-label.ui-widget-content {
-	border-right: none;
-}
-.ui-controlgroup-vertical .ui-controlgroup-label.ui-widget-content {
-	border-bottom: none;
-}
-
-/* Spinner specific style fixes */
-.ui-controlgroup-vertical .ui-spinner-input {
-
-	/* Support: IE8 only, Android < 4.4 only */
-	width: 75%;
-	width: calc( 100% - 2.4em );
-}
-.ui-controlgroup-vertical .ui-spinner .ui-spinner-up {
-	border-top-style: solid;
-}
-
-.ui-checkboxradio-label .ui-icon-background {
-	box-shadow: inset 1px 1px 1px #ccc;
-	border-radius: .12em;
-	border: none;
-}
-.ui-checkboxradio-radio-label .ui-icon-background {
-	width: 16px;
-	height: 16px;
-	border-radius: 1em;
-	overflow: visible;
-	border: none;
-}
-.ui-checkboxradio-radio-label.ui-checkboxradio-checked .ui-icon,
-.ui-checkboxradio-radio-label.ui-checkboxradio-checked:hover .ui-icon {
-	background-image: none;
-	width: 8px;
-	height: 8px;
-	border-width: 4px;
-	border-style: solid;
-}
-.ui-checkboxradio-disabled {
-	pointer-events: none;
-}
-.ui-datepicker {
-	width: 17em;
-	padding: .2em .2em 0;
-	display: none;
-}
-.ui-datepicker .ui-datepicker-header {
-	position: relative;
-	padding: .2em 0;
-}
-.ui-datepicker .ui-datepicker-prev,
-.ui-datepicker .ui-datepicker-next {
-	position: absolute;
-	top: 2px;
-	width: 1.8em;
-	height: 1.8em;
-}
-.ui-datepicker .ui-datepicker-prev-hover,
-.ui-datepicker .ui-datepicker-next-hover {
-	top: 1px;
-}
-.ui-datepicker .ui-datepicker-prev {
-	left: 2px;
-}
-.ui-datepicker .ui-datepicker-next {
-	right: 2px;
-}
-.ui-datepicker .ui-datepicker-prev-hover {
-	left: 1px;
-}
-.ui-datepicker .ui-datepicker-next-hover {
-	right: 1px;
-}
-.ui-datepicker .ui-datepicker-prev span,
-.ui-datepicker .ui-datepicker-next span {
-	display: block;
-	position: absolute;
-	left: 50%;
-	margin-left: -8px;
-	top: 50%;
-	margin-top: -8px;
-}
-.ui-datepicker .ui-datepicker-title {
-	margin: 0 2.3em;
-	line-height: 1.8em;
-	text-align: center;
-}
-.ui-datepicker .ui-datepicker-title select {
-	font-size: 1em;
-	margin: 1px 0;
-}
-.ui-datepicker select.ui-datepicker-month,
-.ui-datepicker select.ui-datepicker-year {
-	width: 45%;
-}
-.ui-datepicker table {
-	width: 100%;
-	font-size: .9em;
-	border-collapse: collapse;
-	margin: 0 0 .4em;
-}
-.ui-datepicker th {
-	padding: .7em .3em;
-	text-align: center;
-	font-weight: bold;
-	border: 0;
-}
-.ui-datepicker td {
-	border: 0;
-	padding: 1px;
-}
-.ui-datepicker td span,
-.ui-datepicker td a {
-	display: block;
-	padding: .2em;
-	text-align: right;
-	text-decoration: none;
-}
-.ui-datepicker .ui-datepicker-buttonpane {
-	background-image: none;
-	margin: .7em 0 0 0;
-	padding: 0 .2em;
-	border-left: 0;
-	border-right: 0;
-	border-bottom: 0;
-}
-.ui-datepicker .ui-datepicker-buttonpane button {
-	float: right;
-	margin: .5em .2em .4em;
-	cursor: pointer;
-	padding: .2em .6em .3em .6em;
-	width: auto;
-	overflow: visible;
-}
-.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current {
-	float: left;
-}
-
-/* with multiple calendars */
-.ui-datepicker.ui-datepicker-multi {
-	width: auto;
-}
-.ui-datepicker-multi .ui-datepicker-group {
-	float: left;
-}
-.ui-datepicker-multi .ui-datepicker-group table {
-	width: 95%;
-	margin: 0 auto .4em;
-}
-.ui-datepicker-multi-2 .ui-datepicker-group {
-	width: 50%;
-}
-.ui-datepicker-multi-3 .ui-datepicker-group {
-	width: 33.3%;
-}
-.ui-datepicker-multi-4 .ui-datepicker-group {
-	width: 25%;
-}
-.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header,
-.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header {
-	border-left-width: 0;
-}
-.ui-datepicker-multi .ui-datepicker-buttonpane {
-	clear: left;
-}
-.ui-datepicker-row-break {
-	clear: both;
-	width: 100%;
-	font-size: 0;
-}
-
-/* RTL support */
-.ui-datepicker-rtl {
-	direction: rtl;
-}
-.ui-datepicker-rtl .ui-datepicker-prev {
-	right: 2px;
-	left: auto;
-}
-.ui-datepicker-rtl .ui-datepicker-next {
-	left: 2px;
-	right: auto;
-}
-.ui-datepicker-rtl .ui-datepicker-prev:hover {
-	right: 1px;
-	left: auto;
-}
-.ui-datepicker-rtl .ui-datepicker-next:hover {
-	left: 1px;
-	right: auto;
-}
-.ui-datepicker-rtl .ui-datepicker-buttonpane {
-	clear: right;
-}
-.ui-datepicker-rtl .ui-datepicker-buttonpane button {
-	float: left;
-}
-.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current,
-.ui-datepicker-rtl .ui-datepicker-group {
-	float: right;
-}
-.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header,
-.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header {
-	border-right-width: 0;
-	border-left-width: 1px;
-}
-
-/* Icons */
-.ui-datepicker .ui-icon {
-	display: block;
-	text-indent: -99999px;
-	overflow: hidden;
-	background-repeat: no-repeat;
-	left: .5em;
-	top: .3em;
-}
-.ui-dialog {
-	position: absolute;
-	top: 0;
-	left: 0;
-	padding: .2em;
-	outline: 0;
-}
-.ui-dialog .ui-dialog-titlebar {
-	padding: .4em 1em;
-	position: relative;
-}
-.ui-dialog .ui-dialog-title {
-	float: left;
-	margin: .1em 0;
-	white-space: nowrap;
-	width: 90%;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.ui-dialog .ui-dialog-titlebar-close {
-	position: absolute;
-	right: .3em;
-	top: 50%;
-	width: 20px;
-	margin: -10px 0 0 0;
-	padding: 1px;
-	height: 20px;
-}
-.ui-dialog .ui-dialog-content {
-	position: relative;
-	border: 0;
-	padding: .5em 1em;
-	background: none;
-	overflow: auto;
-}
-.ui-dialog .ui-dialog-buttonpane {
-	text-align: left;
-	border-width: 1px 0 0 0;
-	background-image: none;
-	margin-top: .5em;
-	padding: .3em 1em .5em .4em;
-}
-.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
-	float: right;
-}
-.ui-dialog .ui-dialog-buttonpane button {
-	margin: .5em .4em .5em 0;
-	cursor: pointer;
-}
-.ui-dialog .ui-resizable-n {
-	height: 2px;
-	top: 0;
-}
-.ui-dialog .ui-resizable-e {
-	width: 2px;
-	right: 0;
-}
-.ui-dialog .ui-resizable-s {
-	height: 2px;
-	bottom: 0;
-}
-.ui-dialog .ui-resizable-w {
-	width: 2px;
-	left: 0;
-}
-.ui-dialog .ui-resizable-se,
-.ui-dialog .ui-resizable-sw,
-.ui-dialog .ui-resizable-ne,
-.ui-dialog .ui-resizable-nw {
-	width: 7px;
-	height: 7px;
-}
-.ui-dialog .ui-resizable-se {
-	right: 0;
-	bottom: 0;
-}
-.ui-dialog .ui-resizable-sw {
-	left: 0;
-	bottom: 0;
-}
-.ui-dialog .ui-resizable-ne {
-	right: 0;
-	top: 0;
-}
-.ui-dialog .ui-resizable-nw {
-	left: 0;
-	top: 0;
-}
-.ui-draggable .ui-dialog-titlebar {
-	cursor: move;
-}
-.ui-draggable-handle {
-	-ms-touch-action: none;
-	touch-action: none;
-}
-.ui-resizable {
-	position: relative;
-}
-.ui-resizable-handle {
-	position: absolute;
-	font-size: 0.1px;
-	display: block;
-	-ms-touch-action: none;
-	touch-action: none;
-}
-.ui-resizable-disabled .ui-resizable-handle,
-.ui-resizable-autohide .ui-resizable-handle {
-	display: none;
-}
-.ui-resizable-n {
-	cursor: n-resize;
-	height: 7px;
-	width: 100%;
-	top: -5px;
-	left: 0;
-}
-.ui-resizable-s {
-	cursor: s-resize;
-	height: 7px;
-	width: 100%;
-	bottom: -5px;
-	left: 0;
-}
-.ui-resizable-e {
-	cursor: e-resize;
-	width: 7px;
-	right: -5px;
-	top: 0;
-	height: 100%;
-}
-.ui-resizable-w {
-	cursor: w-resize;
-	width: 7px;
-	left: -5px;
-	top: 0;
-	height: 100%;
-}
-.ui-resizable-se {
-	cursor: se-resize;
-	width: 12px;
-	height: 12px;
-	right: 1px;
-	bottom: 1px;
-}
-.ui-resizable-sw {
-	cursor: sw-resize;
-	width: 9px;
-	height: 9px;
-	left: -5px;
-	bottom: -5px;
-}
-.ui-resizable-nw {
-	cursor: nw-resize;
-	width: 9px;
-	height: 9px;
-	left: -5px;
-	top: -5px;
-}
-.ui-resizable-ne {
-	cursor: ne-resize;
-	width: 9px;
-	height: 9px;
-	right: -5px;
-	top: -5px;
-}
-.ui-progressbar {
-	height: 2em;
-	text-align: left;
-	overflow: hidden;
-}
-.ui-progressbar .ui-progressbar-value {
-	margin: -1px;
-	height: 100%;
-}
-.ui-progressbar .ui-progressbar-overlay {
-	background: url("data:image/gif;base64,R0lGODlhKAAoAIABAAAAAP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJAQABACwAAAAAKAAoAAACkYwNqXrdC52DS06a7MFZI+4FHBCKoDeWKXqymPqGqxvJrXZbMx7Ttc+w9XgU2FB3lOyQRWET2IFGiU9m1frDVpxZZc6bfHwv4c1YXP6k1Vdy292Fb6UkuvFtXpvWSzA+HycXJHUXiGYIiMg2R6W459gnWGfHNdjIqDWVqemH2ekpObkpOlppWUqZiqr6edqqWQAAIfkECQEAAQAsAAAAACgAKAAAApSMgZnGfaqcg1E2uuzDmmHUBR8Qil95hiPKqWn3aqtLsS18y7G1SzNeowWBENtQd+T1JktP05nzPTdJZlR6vUxNWWjV+vUWhWNkWFwxl9VpZRedYcflIOLafaa28XdsH/ynlcc1uPVDZxQIR0K25+cICCmoqCe5mGhZOfeYSUh5yJcJyrkZWWpaR8doJ2o4NYq62lAAACH5BAkBAAEALAAAAAAoACgAAAKVDI4Yy22ZnINRNqosw0Bv7i1gyHUkFj7oSaWlu3ovC8GxNso5fluz3qLVhBVeT/Lz7ZTHyxL5dDalQWPVOsQWtRnuwXaFTj9jVVh8pma9JjZ4zYSj5ZOyma7uuolffh+IR5aW97cHuBUXKGKXlKjn+DiHWMcYJah4N0lYCMlJOXipGRr5qdgoSTrqWSq6WFl2ypoaUAAAIfkECQEAAQAsAAAAACgAKAAAApaEb6HLgd/iO7FNWtcFWe+ufODGjRfoiJ2akShbueb0wtI50zm02pbvwfWEMWBQ1zKGlLIhskiEPm9R6vRXxV4ZzWT2yHOGpWMyorblKlNp8HmHEb/lCXjcW7bmtXP8Xt229OVWR1fod2eWqNfHuMjXCPkIGNileOiImVmCOEmoSfn3yXlJWmoHGhqp6ilYuWYpmTqKUgAAIfkECQEAAQAsAAAAACgAKAAAApiEH6kb58biQ3FNWtMFWW3eNVcojuFGfqnZqSebuS06w5V80/X02pKe8zFwP6EFWOT1lDFk8rGERh1TTNOocQ61Hm4Xm2VexUHpzjymViHrFbiELsefVrn6XKfnt2Q9G/+Xdie499XHd2g4h7ioOGhXGJboGAnXSBnoBwKYyfioubZJ2Hn0RuRZaflZOil56Zp6iioKSXpUAAAh+QQJAQABACwAAAAAKAAoAAACkoQRqRvnxuI7kU1a1UU5bd5tnSeOZXhmn5lWK3qNTWvRdQxP8qvaC+/yaYQzXO7BMvaUEmJRd3TsiMAgswmNYrSgZdYrTX6tSHGZO73ezuAw2uxuQ+BbeZfMxsexY35+/Qe4J1inV0g4x3WHuMhIl2jXOKT2Q+VU5fgoSUI52VfZyfkJGkha6jmY+aaYdirq+lQAACH5BAkBAAEALAAAAAAoACgAAAKWBIKpYe0L3YNKToqswUlvznigd4wiR4KhZrKt9Upqip61i9E3vMvxRdHlbEFiEXfk9YARYxOZZD6VQ2pUunBmtRXo1Lf8hMVVcNl8JafV38aM2/Fu5V16Bn63r6xt97j09+MXSFi4BniGFae3hzbH9+hYBzkpuUh5aZmHuanZOZgIuvbGiNeomCnaxxap2upaCZsq+1kAACH5BAkBAAEALAAAAAAoACgAAAKXjI8By5zf4kOxTVrXNVlv1X0d8IGZGKLnNpYtm8Lr9cqVeuOSvfOW79D9aDHizNhDJidFZhNydEahOaDH6nomtJjp1tutKoNWkvA6JqfRVLHU/QUfau9l2x7G54d1fl995xcIGAdXqMfBNadoYrhH+Mg2KBlpVpbluCiXmMnZ2Sh4GBqJ+ckIOqqJ6LmKSllZmsoq6wpQAAAh+QQJAQABACwAAAAAKAAoAAAClYx/oLvoxuJDkU1a1YUZbJ59nSd2ZXhWqbRa2/gF8Gu2DY3iqs7yrq+xBYEkYvFSM8aSSObE+ZgRl1BHFZNr7pRCavZ5BW2142hY3AN/zWtsmf12p9XxxFl2lpLn1rseztfXZjdIWIf2s5dItwjYKBgo9yg5pHgzJXTEeGlZuenpyPmpGQoKOWkYmSpaSnqKileI2FAAACH5BAkBAAEALAAAAAAoACgAAAKVjB+gu+jG4kORTVrVhRlsnn2dJ3ZleFaptFrb+CXmO9OozeL5VfP99HvAWhpiUdcwkpBH3825AwYdU8xTqlLGhtCosArKMpvfa1mMRae9VvWZfeB2XfPkeLmm18lUcBj+p5dnN8jXZ3YIGEhYuOUn45aoCDkp16hl5IjYJvjWKcnoGQpqyPlpOhr3aElaqrq56Bq7VAAAOw==");
-	height: 100%;
-	filter: alpha(opacity=25); /* support: IE8 */
-	opacity: 0.25;
-}
-.ui-progressbar-indeterminate .ui-progressbar-value {
-	background-image: none;
-}
-.ui-selectable {
-	-ms-touch-action: none;
-	touch-action: none;
-}
-.ui-selectable-helper {
-	position: absolute;
-	z-index: 100;
-	border: 1px dotted black;
-}
-.ui-selectmenu-menu {
-	padding: 0;
-	margin: 0;
-	position: absolute;
-	top: 0;
-	left: 0;
-	display: none;
-}
-.ui-selectmenu-menu .ui-menu {
-	overflow: auto;
-	overflow-x: hidden;
-	padding-bottom: 1px;
-}
-.ui-selectmenu-menu .ui-menu .ui-selectmenu-optgroup {
-	font-size: 1em;
-	font-weight: bold;
-	line-height: 1.5;
-	padding: 2px 0.4em;
-	margin: 0.5em 0 0 0;
-	height: auto;
-	border: 0;
-}
-.ui-selectmenu-open {
-	display: block;
-}
-.ui-selectmenu-text {
-	display: block;
-	margin-right: 20px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.ui-selectmenu-button.ui-button {
-	text-align: left;
-	white-space: nowrap;
-	width: 14em;
-}
-.ui-selectmenu-icon.ui-icon {
-	float: right;
-	margin-top: 0;
-}
-.ui-slider {
-	position: relative;
-	text-align: left;
-}
-.ui-slider .ui-slider-handle {
-	position: absolute;
-	z-index: 2;
-	width: 1.2em;
-	height: 1.2em;
-	cursor: default;
-	-ms-touch-action: none;
-	touch-action: none;
-}
-.ui-slider .ui-slider-range {
-	position: absolute;
-	z-index: 1;
-	font-size: .7em;
-	display: block;
-	border: 0;
-	background-position: 0 0;
-}
-
-/* support: IE8 - See #6727 */
-.ui-slider.ui-state-disabled .ui-slider-handle,
-.ui-slider.ui-state-disabled .ui-slider-range {
-	filter: inherit;
-}
-
-.ui-slider-horizontal {
-	height: .8em;
-}
-.ui-slider-horizontal .ui-slider-handle {
-	top: -.3em;
-	margin-left: -.6em;
-}
-.ui-slider-horizontal .ui-slider-range {
-	top: 0;
-	height: 100%;
-}
-.ui-slider-horizontal .ui-slider-range-min {
-	left: 0;
-}
-.ui-slider-horizontal .ui-slider-range-max {
-	right: 0;
-}
-
-.ui-slider-vertical {
-	width: .8em;
-	height: 100px;
-}
-.ui-slider-vertical .ui-slider-handle {
-	left: -.3em;
-	margin-left: 0;
-	margin-bottom: -.6em;
-}
-.ui-slider-vertical .ui-slider-range {
-	left: 0;
-	width: 100%;
-}
-.ui-slider-vertical .ui-slider-range-min {
-	bottom: 0;
-}
-.ui-slider-vertical .ui-slider-range-max {
-	top: 0;
-}
-.ui-sortable-handle {
-	-ms-touch-action: none;
-	touch-action: none;
-}
-.ui-spinner {
-	position: relative;
-	display: inline-block;
-	overflow: hidden;
-	padding: 0;
-	vertical-align: middle;
-}
-.ui-spinner-input {
-	border: none;
-	background: none;
-	color: inherit;
-	padding: .222em 0;
-	margin: .2em 0;
-	vertical-align: middle;
-	margin-left: .4em;
-	margin-right: 2em;
-}
-.ui-spinner-button {
-	width: 1.6em;
-	height: 50%;
-	font-size: .5em;
-	padding: 0;
-	margin: 0;
-	text-align: center;
-	position: absolute;
-	cursor: default;
-	display: block;
-	overflow: hidden;
-	right: 0;
-}
-/* more specificity required here to override default borders */
-.ui-spinner a.ui-spinner-button {
-	border-top-style: none;
-	border-bottom-style: none;
-	border-right-style: none;
-}
-.ui-spinner-up {
-	top: 0;
-}
-.ui-spinner-down {
-	bottom: 0;
-}
-.ui-tabs {
-	position: relative;/* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
-	padding: .2em;
-}
-.ui-tabs .ui-tabs-nav {
-	margin: 0;
-	padding: .2em .2em 0;
-}
-.ui-tabs .ui-tabs-nav li {
-	list-style: none;
-	float: left;
-	position: relative;
-	top: 0;
-	margin: 1px .2em 0 0;
-	border-bottom-width: 0;
-	padding: 0;
-	white-space: nowrap;
-}
-.ui-tabs .ui-tabs-nav .ui-tabs-anchor {
-	float: left;
-	padding: .5em 1em;
-	text-decoration: none;
-}
-.ui-tabs .ui-tabs-nav li.ui-tabs-active {
-	margin-bottom: -1px;
-	padding-bottom: 1px;
-}
-.ui-tabs .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor,
-.ui-tabs .ui-tabs-nav li.ui-state-disabled .ui-tabs-anchor,
-.ui-tabs .ui-tabs-nav li.ui-tabs-loading .ui-tabs-anchor {
-	cursor: text;
-}
-.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor {
-	cursor: pointer;
-}
-.ui-tabs .ui-tabs-panel {
-	display: block;
-	border-width: 0;
-	padding: 1em 1.4em;
-	background: none;
-}
-.ui-tooltip {
-	padding: 8px;
-	position: absolute;
-	z-index: 9999;
-	max-width: 300px;
-}
-body .ui-tooltip {
-	border-width: 2px;
-}
-
-/* Component containers
-----------------------------------*/
-.ui-widget {
-	font-family: Arial,Helvetica,sans-serif;
-	font-size: 1em;
-}
-.ui-widget .ui-widget {
-	font-size: 1em;
-}
-.ui-widget input,
-.ui-widget select,
-.ui-widget textarea,
-.ui-widget button {
-	font-family: Arial,Helvetica,sans-serif;
-	font-size: 1em;
-}
-.ui-widget.ui-widget-content {
-	border: 1px solid #c5c5c5;
-}
-.ui-widget-content {
-	border: 1px solid #dddddd;
-	background: #ffffff;
-	color: #333333;
-}
-.ui-widget-content a {
-	color: #333333;
-}
-.ui-widget-header {
-	border: 1px solid #dddddd;
-	background: #e9e9e9;
-	color: #333333;
-	font-weight: bold;
-}
-.ui-widget-header a {
-	color: #333333;
-}
-
-/* Interaction states
-----------------------------------*/
-.ui-state-default,
-.ui-widget-content .ui-state-default,
-.ui-widget-header .ui-state-default,
-.ui-button,
-
-/* We use html here because we need a greater specificity to make sure disabled
-works properly when clicked or hovered */
-html .ui-button.ui-state-disabled:hover,
-html .ui-button.ui-state-disabled:active {
-	border: 1px solid #c5c5c5;
-	background: #f6f6f6;
-	font-weight: normal;
-	color: #454545;
-}
-.ui-state-default a,
-.ui-state-default a:link,
-.ui-state-default a:visited,
-a.ui-button,
-a:link.ui-button,
-a:visited.ui-button,
-.ui-button {
-	color: #454545;
-	text-decoration: none;
-}
-.ui-state-hover,
-.ui-widget-content .ui-state-hover,
-.ui-widget-header .ui-state-hover,
-.ui-state-focus,
-.ui-widget-content .ui-state-focus,
-.ui-widget-header .ui-state-focus,
-.ui-button:hover,
-.ui-button:focus {
-	border: 1px solid #cccccc;
-	background: #ededed;
-	font-weight: normal;
-	color: #2b2b2b;
-}
-.ui-state-hover a,
-.ui-state-hover a:hover,
-.ui-state-hover a:link,
-.ui-state-hover a:visited,
-.ui-state-focus a,
-.ui-state-focus a:hover,
-.ui-state-focus a:link,
-.ui-state-focus a:visited,
-a.ui-button:hover,
-a.ui-button:focus {
-	color: #2b2b2b;
-	text-decoration: none;
-}
-
-.ui-visual-focus {
-	box-shadow: 0 0 3px 1px rgb(94, 158, 214);
-}
-.ui-state-active,
-.ui-widget-content .ui-state-active,
-.ui-widget-header .ui-state-active,
-a.ui-button:active,
-.ui-button:active,
-.ui-button.ui-state-active:hover {
-	border: 1px solid #003eff;
-	background: #007fff;
-	font-weight: normal;
-	color: #ffffff;
-}
-.ui-icon-background,
-.ui-state-active .ui-icon-background {
-	border: #003eff;
-	background-color: #ffffff;
-}
-.ui-state-active a,
-.ui-state-active a:link,
-.ui-state-active a:visited {
-	color: #ffffff;
-	text-decoration: none;
-}
-
-/* Interaction Cues
-----------------------------------*/
-.ui-state-highlight,
-.ui-widget-content .ui-state-highlight,
-.ui-widget-header .ui-state-highlight {
-	border: 1px solid #dad55e;
-	background: #fffa90;
-	color: #777620;
-}
-.ui-state-checked {
-	border: 1px solid #dad55e;
-	background: #fffa90;
-}
-.ui-state-highlight a,
-.ui-widget-content .ui-state-highlight a,
-.ui-widget-header .ui-state-highlight a {
-	color: #777620;
-}
-.ui-state-error,
-.ui-widget-content .ui-state-error,
-.ui-widget-header .ui-state-error {
-	border: 1px solid #f1a899;
-	background: #fddfdf;
-	color: #5f3f3f;
-}
-.ui-state-error a,
-.ui-widget-content .ui-state-error a,
-.ui-widget-header .ui-state-error a {
-	color: #5f3f3f;
-}
-.ui-state-error-text,
-.ui-widget-content .ui-state-error-text,
-.ui-widget-header .ui-state-error-text {
-	color: #5f3f3f;
-}
-.ui-priority-primary,
-.ui-widget-content .ui-priority-primary,
-.ui-widget-header .ui-priority-primary {
-	font-weight: bold;
-}
-.ui-priority-secondary,
-.ui-widget-content .ui-priority-secondary,
-.ui-widget-header .ui-priority-secondary {
-	opacity: .7;
-	filter:Alpha(Opacity=70); /* support: IE8 */
-	font-weight: normal;
-}
-.ui-state-disabled,
-.ui-widget-content .ui-state-disabled,
-.ui-widget-header .ui-state-disabled {
-	opacity: .35;
-	filter:Alpha(Opacity=35); /* support: IE8 */
-	background-image: none;
-}
-.ui-state-disabled .ui-icon {
-	filter:Alpha(Opacity=35); /* support: IE8 - See #6059 */
-}
-
-/* Icons
-----------------------------------*/
-
-/* states and images */
-.ui-icon {
-	width: 16px;
-	height: 16px;
-}
-.ui-icon,
-.ui-widget-content .ui-icon {
-	background-image: url("images/ui-icons_444444_256x240.png");
-}
-.ui-widget-header .ui-icon {
-	background-image: url("images/ui-icons_444444_256x240.png");
-}
-.ui-state-hover .ui-icon,
-.ui-state-focus .ui-icon,
-.ui-button:hover .ui-icon,
-.ui-button:focus .ui-icon {
-	background-image: url("images/ui-icons_555555_256x240.png");
-}
-.ui-state-active .ui-icon,
-.ui-button:active .ui-icon {
-	background-image: url("images/ui-icons_ffffff_256x240.png");
-}
-.ui-state-highlight .ui-icon,
-.ui-button .ui-state-highlight.ui-icon {
-	background-image: url("images/ui-icons_777620_256x240.png");
-}
-.ui-state-error .ui-icon,
-.ui-state-error-text .ui-icon {
-	background-image: url("images/ui-icons_cc0000_256x240.png");
-}
-.ui-button .ui-icon {
-	background-image: url("images/ui-icons_777777_256x240.png");
-}
-
-/* positioning */
-.ui-icon-blank { background-position: 16px 16px; }
-.ui-icon-caret-1-n { background-position: 0 0; }
-.ui-icon-caret-1-ne { background-position: -16px 0; }
-.ui-icon-caret-1-e { background-position: -32px 0; }
-.ui-icon-caret-1-se { background-position: -48px 0; }
-.ui-icon-caret-1-s { background-position: -65px 0; }
-.ui-icon-caret-1-sw { background-position: -80px 0; }
-.ui-icon-caret-1-w { background-position: -96px 0; }
-.ui-icon-caret-1-nw { background-position: -112px 0; }
-.ui-icon-caret-2-n-s { background-position: -128px 0; }
-.ui-icon-caret-2-e-w { background-position: -144px 0; }
-.ui-icon-triangle-1-n { background-position: 0 -16px; }
-.ui-icon-triangle-1-ne { background-position: -16px -16px; }
-.ui-icon-triangle-1-e { background-position: -32px -16px; }
-.ui-icon-triangle-1-se { background-position: -48px -16px; }
-.ui-icon-triangle-1-s { background-position: -65px -16px; }
-.ui-icon-triangle-1-sw { background-position: -80px -16px; }
-.ui-icon-triangle-1-w { background-position: -96px -16px; }
-.ui-icon-triangle-1-nw { background-position: -112px -16px; }
-.ui-icon-triangle-2-n-s { background-position: -128px -16px; }
-.ui-icon-triangle-2-e-w { background-position: -144px -16px; }
-.ui-icon-arrow-1-n { background-position: 0 -32px; }
-.ui-icon-arrow-1-ne { background-position: -16px -32px; }
-.ui-icon-arrow-1-e { background-position: -32px -32px; }
-.ui-icon-arrow-1-se { background-position: -48px -32px; }
-.ui-icon-arrow-1-s { background-position: -65px -32px; }
-.ui-icon-arrow-1-sw { background-position: -80px -32px; }
-.ui-icon-arrow-1-w { background-position: -96px -32px; }
-.ui-icon-arrow-1-nw { background-position: -112px -32px; }
-.ui-icon-arrow-2-n-s { background-position: -128px -32px; }
-.ui-icon-arrow-2-ne-sw { background-position: -144px -32px; }
-.ui-icon-arrow-2-e-w { background-position: -160px -32px; }
-.ui-icon-arrow-2-se-nw { background-position: -176px -32px; }
-.ui-icon-arrowstop-1-n { background-position: -192px -32px; }
-.ui-icon-arrowstop-1-e { background-position: -208px -32px; }
-.ui-icon-arrowstop-1-s { background-position: -224px -32px; }
-.ui-icon-arrowstop-1-w { background-position: -240px -32px; }
-.ui-icon-arrowthick-1-n { background-position: 1px -48px; }
-.ui-icon-arrowthick-1-ne { background-position: -16px -48px; }
-.ui-icon-arrowthick-1-e { background-position: -32px -48px; }
-.ui-icon-arrowthick-1-se { background-position: -48px -48px; }
-.ui-icon-arrowthick-1-s { background-position: -64px -48px; }
-.ui-icon-arrowthick-1-sw { background-position: -80px -48px; }
-.ui-icon-arrowthick-1-w { background-position: -96px -48px; }
-.ui-icon-arrowthick-1-nw { background-position: -112px -48px; }
-.ui-icon-arrowthick-2-n-s { background-position: -128px -48px; }
-.ui-icon-arrowthick-2-ne-sw { background-position: -144px -48px; }
-.ui-icon-arrowthick-2-e-w { background-position: -160px -48px; }
-.ui-icon-arrowthick-2-se-nw { background-position: -176px -48px; }
-.ui-icon-arrowthickstop-1-n { background-position: -192px -48px; }
-.ui-icon-arrowthickstop-1-e { background-position: -208px -48px; }
-.ui-icon-arrowthickstop-1-s { background-position: -224px -48px; }
-.ui-icon-arrowthickstop-1-w { background-position: -240px -48px; }
-.ui-icon-arrowreturnthick-1-w { background-position: 0 -64px; }
-.ui-icon-arrowreturnthick-1-n { background-position: -16px -64px; }
-.ui-icon-arrowreturnthick-1-e { background-position: -32px -64px; }
-.ui-icon-arrowreturnthick-1-s { background-position: -48px -64px; }
-.ui-icon-arrowreturn-1-w { background-position: -64px -64px; }
-.ui-icon-arrowreturn-1-n { background-position: -80px -64px; }
-.ui-icon-arrowreturn-1-e { background-position: -96px -64px; }
-.ui-icon-arrowreturn-1-s { background-position: -112px -64px; }
-.ui-icon-arrowrefresh-1-w { background-position: -128px -64px; }
-.ui-icon-arrowrefresh-1-n { background-position: -144px -64px; }
-.ui-icon-arrowrefresh-1-e { background-position: -160px -64px; }
-.ui-icon-arrowrefresh-1-s { background-position: -176px -64px; }
-.ui-icon-arrow-4 { background-position: 0 -80px; }
-.ui-icon-arrow-4-diag { background-position: -16px -80px; }
-.ui-icon-extlink { background-position: -32px -80px; }
-.ui-icon-newwin { background-position: -48px -80px; }
-.ui-icon-refresh { background-position: -64px -80px; }
-.ui-icon-shuffle { background-position: -80px -80px; }
-.ui-icon-transfer-e-w { background-position: -96px -80px; }
-.ui-icon-transferthick-e-w { background-position: -112px -80px; }
-.ui-icon-folder-collapsed { background-position: 0 -96px; }
-.ui-icon-folder-open { background-position: -16px -96px; }
-.ui-icon-document { background-position: -32px -96px; }
-.ui-icon-document-b { background-position: -48px -96px; }
-.ui-icon-note { background-position: -64px -96px; }
-.ui-icon-mail-closed { background-position: -80px -96px; }
-.ui-icon-mail-open { background-position: -96px -96px; }
-.ui-icon-suitcase { background-position: -112px -96px; }
-.ui-icon-comment { background-position: -128px -96px; }
-.ui-icon-person { background-position: -144px -96px; }
-.ui-icon-print { background-position: -160px -96px; }
-.ui-icon-trash { background-position: -176px -96px; }
-.ui-icon-locked { background-position: -192px -96px; }
-.ui-icon-unlocked { background-position: -208px -96px; }
-.ui-icon-bookmark { background-position: -224px -96px; }
-.ui-icon-tag { background-position: -240px -96px; }
-.ui-icon-home { background-position: 0 -112px; }
-.ui-icon-flag { background-position: -16px -112px; }
-.ui-icon-calendar { background-position: -32px -112px; }
-.ui-icon-cart { background-position: -48px -112px; }
-.ui-icon-pencil { background-position: -64px -112px; }
-.ui-icon-clock { background-position: -80px -112px; }
-.ui-icon-disk { background-position: -96px -112px; }
-.ui-icon-calculator { background-position: -112px -112px; }
-.ui-icon-zoomin { background-position: -128px -112px; }
-.ui-icon-zoomout { background-position: -144px -112px; }
-.ui-icon-search { background-position: -160px -112px; }
-.ui-icon-wrench { background-position: -176px -112px; }
-.ui-icon-gear { background-position: -192px -112px; }
-.ui-icon-heart { background-position: -208px -112px; }
-.ui-icon-star { background-position: -224px -112px; }
-.ui-icon-link { background-position: -240px -112px; }
-.ui-icon-cancel { background-position: 0 -128px; }
-.ui-icon-plus { background-position: -16px -128px; }
-.ui-icon-plusthick { background-position: -32px -128px; }
-.ui-icon-minus { background-position: -48px -128px; }
-.ui-icon-minusthick { background-position: -64px -128px; }
-.ui-icon-close { background-position: -80px -128px; }
-.ui-icon-closethick { background-position: -96px -128px; }
-.ui-icon-key { background-position: -112px -128px; }
-.ui-icon-lightbulb { background-position: -128px -128px; }
-.ui-icon-scissors { background-position: -144px -128px; }
-.ui-icon-clipboard { background-position: -160px -128px; }
-.ui-icon-copy { background-position: -176px -128px; }
-.ui-icon-contact { background-position: -192px -128px; }
-.ui-icon-image { background-position: -208px -128px; }
-.ui-icon-video { background-position: -224px -128px; }
-.ui-icon-script { background-position: -240px -128px; }
-.ui-icon-alert { background-position: 0 -144px; }
-.ui-icon-info { background-position: -16px -144px; }
-.ui-icon-notice { background-position: -32px -144px; }
-.ui-icon-help { background-position: -48px -144px; }
-.ui-icon-check { background-position: -64px -144px; }
-.ui-icon-bullet { background-position: -80px -144px; }
-.ui-icon-radio-on { background-position: -96px -144px; }
-.ui-icon-radio-off { background-position: -112px -144px; }
-.ui-icon-pin-w { background-position: -128px -144px; }
-.ui-icon-pin-s { background-position: -144px -144px; }
-.ui-icon-play { background-position: 0 -160px; }
-.ui-icon-pause { background-position: -16px -160px; }
-.ui-icon-seek-next { background-position: -32px -160px; }
-.ui-icon-seek-prev { background-position: -48px -160px; }
-.ui-icon-seek-end { background-position: -64px -160px; }
-.ui-icon-seek-start { background-position: -80px -160px; }
-/* ui-icon-seek-first is deprecated, use ui-icon-seek-start instead */
-.ui-icon-seek-first { background-position: -80px -160px; }
-.ui-icon-stop { background-position: -96px -160px; }
-.ui-icon-eject { background-position: -112px -160px; }
-.ui-icon-volume-off { background-position: -128px -160px; }
-.ui-icon-volume-on { background-position: -144px -160px; }
-.ui-icon-power { background-position: 0 -176px; }
-.ui-icon-signal-diag { background-position: -16px -176px; }
-.ui-icon-signal { background-position: -32px -176px; }
-.ui-icon-battery-0 { background-position: -48px -176px; }
-.ui-icon-battery-1 { background-position: -64px -176px; }
-.ui-icon-battery-2 { background-position: -80px -176px; }
-.ui-icon-battery-3 { background-position: -96px -176px; }
-.ui-icon-circle-plus { background-position: 0 -192px; }
-.ui-icon-circle-minus { background-position: -16px -192px; }
-.ui-icon-circle-close { background-position: -32px -192px; }
-.ui-icon-circle-triangle-e { background-position: -48px -192px; }
-.ui-icon-circle-triangle-s { background-position: -64px -192px; }
-.ui-icon-circle-triangle-w { background-position: -80px -192px; }
-.ui-icon-circle-triangle-n { background-position: -96px -192px; }
-.ui-icon-circle-arrow-e { background-position: -112px -192px; }
-.ui-icon-circle-arrow-s { background-position: -128px -192px; }
-.ui-icon-circle-arrow-w { background-position: -144px -192px; }
-.ui-icon-circle-arrow-n { background-position: -160px -192px; }
-.ui-icon-circle-zoomin { background-position: -176px -192px; }
-.ui-icon-circle-zoomout { background-position: -192px -192px; }
-.ui-icon-circle-check { background-position: -208px -192px; }
-.ui-icon-circlesmall-plus { background-position: 0 -208px; }
-.ui-icon-circlesmall-minus { background-position: -16px -208px; }
-.ui-icon-circlesmall-close { background-position: -32px -208px; }
-.ui-icon-squaresmall-plus { background-position: -48px -208px; }
-.ui-icon-squaresmall-minus { background-position: -64px -208px; }
-.ui-icon-squaresmall-close { background-position: -80px -208px; }
-.ui-icon-grip-dotted-vertical { background-position: 0 -224px; }
-.ui-icon-grip-dotted-horizontal { background-position: -16px -224px; }
-.ui-icon-grip-solid-vertical { background-position: -32px -224px; }
-.ui-icon-grip-solid-horizontal { background-position: -48px -224px; }
-.ui-icon-gripsmall-diagonal-se { background-position: -64px -224px; }
-.ui-icon-grip-diagonal-se { background-position: -80px -224px; }
+    /* Interaction Cues
+    ----------------------------------*/
+    .ui-state-disabled {
+        cursor: default !important;
+        pointer-events: none;
+    }
 
 
-/* Misc visuals
-----------------------------------*/
+    /* Icons
+    ----------------------------------*/
+    .ui-icon {
+        display: inline-block;
+        vertical-align: middle;
+        margin-top: -.25em;
+        position: relative;
+        text-indent: -99999px;
+        overflow: hidden;
+        background-repeat: no-repeat;
+    }
 
-/* Corner radius */
-.ui-corner-all,
-.ui-corner-top,
-.ui-corner-left,
-.ui-corner-tl {
-	border-top-left-radius: 3px;
-}
-.ui-corner-all,
-.ui-corner-top,
-.ui-corner-right,
-.ui-corner-tr {
-	border-top-right-radius: 3px;
-}
-.ui-corner-all,
-.ui-corner-bottom,
-.ui-corner-left,
-.ui-corner-bl {
-	border-bottom-left-radius: 3px;
-}
-.ui-corner-all,
-.ui-corner-bottom,
-.ui-corner-right,
-.ui-corner-br {
-	border-bottom-right-radius: 3px;
-}
+    .ui-widget-icon-block {
+        left: 50%;
+        margin-left: -8px;
+        display: block;
+    }
 
-/* Overlays */
-.ui-widget-overlay {
-	background: #aaaaaa;
-	opacity: .003;
-	filter: Alpha(Opacity=.3); /* support: IE8 */
-}
-.ui-widget-shadow {
-	-webkit-box-shadow: 0px 0px 5px #666666;
-	box-shadow: 0px 0px 5px #666666;
+    /* Misc visuals
+    ----------------------------------*/
+
+    /* Overlays */
+    .ui-widget-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+    .ui-accordion .ui-accordion-header {
+        display: block;
+        cursor: pointer;
+        position: relative;
+        margin: 2px 0 0 0;
+        padding: .5em .5em .5em .7em;
+        font-size: 100%;
+    }
+    .ui-accordion .ui-accordion-content {
+        padding: 1em 2.2em;
+        border-top: 0;
+        overflow: auto;
+    }
+    .ui-autocomplete {
+        position: absolute;
+        top: 0;
+        left: 0;
+        cursor: default;
+    }
+    .ui-menu {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: block;
+        outline: 0;
+    }
+    .ui-menu .ui-menu {
+        position: absolute;
+    }
+    .ui-menu .ui-menu-item {
+        margin: 0;
+        cursor: pointer;
+        /* support: IE10, see #8844 */
+        list-style-image: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+    }
+    .ui-menu .ui-menu-item-wrapper {
+        position: relative;
+        padding: 3px 1em 3px .4em;
+    }
+    .ui-menu .ui-menu-divider {
+        margin: 5px 0;
+        height: 0;
+        font-size: 0;
+        line-height: 0;
+        border-width: 1px 0 0 0;
+    }
+    .ui-menu .ui-state-focus,
+    .ui-menu .ui-state-active {
+        margin: -1px;
+    }
+
+    /* icon support */
+    .ui-menu-icons {
+        position: relative;
+    }
+    .ui-menu-icons .ui-menu-item-wrapper {
+        padding-left: 2em;
+    }
+
+    /* left-aligned */
+    .ui-menu .ui-icon {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: .2em;
+        margin: auto 0;
+    }
+
+    /* right-aligned */
+    .ui-menu .ui-menu-icon {
+        left: auto;
+        right: 0;
+    }
+    .ui-button {
+        padding: .4em 1em;
+        display: inline-block;
+        position: relative;
+        line-height: normal;
+        margin-right: .1em;
+        cursor: pointer;
+        vertical-align: middle;
+        text-align: center;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+
+        /* Support: IE <= 11 */
+        overflow: visible;
+    }
+
+    .ui-button,
+    .ui-button:link,
+    .ui-button:visited,
+    .ui-button:hover,
+    .ui-button:active {
+        text-decoration: none;
+    }
+
+    /* to make room for the icon, a width needs to be set here */
+    .ui-button-icon-only {
+        width: 2em;
+        box-sizing: border-box;
+        text-indent: -9999px;
+        white-space: nowrap;
+    }
+
+    /* no icon support for input elements */
+    input.ui-button.ui-button-icon-only {
+        text-indent: 0;
+    }
+
+    /* button icon element(s) */
+    .ui-button-icon-only .ui-icon {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        margin-top: -8px;
+        margin-left: -8px;
+    }
+
+    .ui-button.ui-icon-notext .ui-icon {
+        padding: 0;
+        width: 2.1em;
+        height: 2.1em;
+        text-indent: -9999px;
+        white-space: nowrap;
+
+    }
+
+    input.ui-button.ui-icon-notext .ui-icon {
+        width: auto;
+        height: auto;
+        text-indent: 0;
+        white-space: normal;
+        padding: .4em 1em;
+    }
+
+    /* workarounds */
+    /* Support: Firefox 5 - 40 */
+    input.ui-button::-moz-focus-inner,
+    button.ui-button::-moz-focus-inner {
+        border: 0;
+        padding: 0;
+    }
+    .ui-controlgroup {
+        vertical-align: middle;
+        display: inline-block;
+    }
+    .ui-controlgroup > .ui-controlgroup-item {
+        float: left;
+        margin-left: 0;
+        margin-right: 0;
+    }
+    .ui-controlgroup > .ui-controlgroup-item:focus,
+    .ui-controlgroup > .ui-controlgroup-item.ui-visual-focus {
+        z-index: 9999;
+    }
+    .ui-controlgroup-vertical > .ui-controlgroup-item {
+        display: block;
+        float: none;
+        width: 100%;
+        margin-top: 0;
+        margin-bottom: 0;
+        text-align: left;
+    }
+    .ui-controlgroup-vertical .ui-controlgroup-item {
+        box-sizing: border-box;
+    }
+    .ui-controlgroup .ui-controlgroup-label {
+        padding: .4em 1em;
+    }
+    .ui-controlgroup .ui-controlgroup-label span {
+        font-size: 80%;
+    }
+    .ui-controlgroup-horizontal .ui-controlgroup-label + .ui-controlgroup-item {
+        border-left: none;
+    }
+    .ui-controlgroup-vertical .ui-controlgroup-label + .ui-controlgroup-item {
+        border-top: none;
+    }
+    .ui-controlgroup-horizontal .ui-controlgroup-label.ui-widget-content {
+        border-right: none;
+    }
+    .ui-controlgroup-vertical .ui-controlgroup-label.ui-widget-content {
+        border-bottom: none;
+    }
+
+    /* Spinner specific style fixes */
+    .ui-controlgroup-vertical .ui-spinner-input {
+
+        /* Support: IE8 only, Android < 4.4 only */
+        width: 75%;
+        width: calc(100% - 2.4em);
+    }
+    .ui-controlgroup-vertical .ui-spinner .ui-spinner-up {
+        border-top-style: solid;
+    }
+
+    .ui-checkboxradio-label .ui-icon-background {
+        box-shadow: inset 1px 1px 1px #ccc;
+        border-radius: .12em;
+        border: none;
+    }
+    .ui-checkboxradio-radio-label .ui-icon-background {
+        width: 16px;
+        height: 16px;
+        border-radius: 1em;
+        overflow: visible;
+        border: none;
+    }
+    .ui-checkboxradio-radio-label.ui-checkboxradio-checked .ui-icon,
+    .ui-checkboxradio-radio-label.ui-checkboxradio-checked:hover .ui-icon {
+        background-image: none;
+        width: 8px;
+        height: 8px;
+        border-width: 4px;
+        border-style: solid;
+    }
+    .ui-checkboxradio-disabled {
+        pointer-events: none;
+    }
+    .ui-datepicker {
+        width: 17em;
+        padding: .2em .2em 0;
+        display: none;
+    }
+    .ui-datepicker .ui-datepicker-header {
+        position: relative;
+        padding: .2em 0;
+    }
+    .ui-datepicker .ui-datepicker-prev,
+    .ui-datepicker .ui-datepicker-next {
+        position: absolute;
+        top: 2px;
+        width: 1.8em;
+        height: 1.8em;
+    }
+    .ui-datepicker .ui-datepicker-prev-hover,
+    .ui-datepicker .ui-datepicker-next-hover {
+        top: 1px;
+    }
+    .ui-datepicker .ui-datepicker-prev {
+        left: 2px;
+    }
+    .ui-datepicker .ui-datepicker-next {
+        right: 2px;
+    }
+    .ui-datepicker .ui-datepicker-prev-hover {
+        left: 1px;
+    }
+    .ui-datepicker .ui-datepicker-next-hover {
+        right: 1px;
+    }
+    .ui-datepicker .ui-datepicker-prev span,
+    .ui-datepicker .ui-datepicker-next span {
+        display: block;
+        position: absolute;
+        left: 50%;
+        margin-left: -8px;
+        top: 50%;
+        margin-top: -8px;
+    }
+    .ui-datepicker .ui-datepicker-title {
+        margin: 0 2.3em;
+        line-height: 1.8em;
+        text-align: center;
+    }
+    .ui-datepicker .ui-datepicker-title select {
+        font-size: 1em;
+        margin: 1px 0;
+    }
+    .ui-datepicker select.ui-datepicker-month,
+    .ui-datepicker select.ui-datepicker-year {
+        width: 45%;
+    }
+    .ui-datepicker table {
+        width: 100%;
+        font-size: .9em;
+        border-collapse: collapse;
+        margin: 0 0 .4em;
+    }
+    .ui-datepicker th {
+        padding: .7em .3em;
+        text-align: center;
+        font-weight: bold;
+        border: 0;
+    }
+    .ui-datepicker td {
+        border: 0;
+        padding: 1px;
+    }
+    .ui-datepicker td span,
+    .ui-datepicker td a {
+        display: block;
+        padding: .2em;
+        text-align: right;
+        text-decoration: none;
+    }
+    .ui-datepicker .ui-datepicker-buttonpane {
+        background-image: none;
+        margin: .7em 0 0 0;
+        padding: 0 .2em;
+        border-left: 0;
+        border-right: 0;
+        border-bottom: 0;
+    }
+    .ui-datepicker .ui-datepicker-buttonpane button {
+        float: right;
+        margin: .5em .2em .4em;
+        cursor: pointer;
+        padding: .2em .6em .3em .6em;
+        width: auto;
+        overflow: visible;
+    }
+    .ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current {
+        float: left;
+    }
+
+    /* with multiple calendars */
+    .ui-datepicker.ui-datepicker-multi {
+        width: auto;
+    }
+    .ui-datepicker-multi .ui-datepicker-group {
+        float: left;
+    }
+    .ui-datepicker-multi .ui-datepicker-group table {
+        width: 95%;
+        margin: 0 auto .4em;
+    }
+    .ui-datepicker-multi-2 .ui-datepicker-group {
+        width: 50%;
+    }
+    .ui-datepicker-multi-3 .ui-datepicker-group {
+        width: 33.3%;
+    }
+    .ui-datepicker-multi-4 .ui-datepicker-group {
+        width: 25%;
+    }
+    .ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header,
+    .ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header {
+        border-left-width: 0;
+    }
+    .ui-datepicker-multi .ui-datepicker-buttonpane {
+        clear: left;
+    }
+    .ui-datepicker-row-break {
+        clear: both;
+        width: 100%;
+        font-size: 0;
+    }
+
+    /* RTL support */
+    .ui-datepicker-rtl {
+        direction: rtl;
+    }
+    .ui-datepicker-rtl .ui-datepicker-prev {
+        right: 2px;
+        left: auto;
+    }
+    .ui-datepicker-rtl .ui-datepicker-next {
+        left: 2px;
+        right: auto;
+    }
+    .ui-datepicker-rtl .ui-datepicker-prev:hover {
+        right: 1px;
+        left: auto;
+    }
+    .ui-datepicker-rtl .ui-datepicker-next:hover {
+        left: 1px;
+        right: auto;
+    }
+    .ui-datepicker-rtl .ui-datepicker-buttonpane {
+        clear: right;
+    }
+    .ui-datepicker-rtl .ui-datepicker-buttonpane button {
+        float: left;
+    }
+    .ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current,
+    .ui-datepicker-rtl .ui-datepicker-group {
+        float: right;
+    }
+    .ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header,
+    .ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header {
+        border-right-width: 0;
+        border-left-width: 1px;
+    }
+
+    /* Icons */
+    .ui-datepicker .ui-icon {
+        display: block;
+        text-indent: -99999px;
+        overflow: hidden;
+        background-repeat: no-repeat;
+        left: .5em;
+        top: .3em;
+    }
+    .ui-dialog {
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: .2em;
+        outline: 0;
+    }
+    .ui-dialog .ui-dialog-titlebar {
+        padding: .4em 1em;
+        position: relative;
+    }
+    .ui-dialog .ui-dialog-title {
+        float: left;
+        margin: .1em 0;
+        white-space: nowrap;
+        width: 90%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .ui-dialog .ui-dialog-titlebar-close {
+        position: absolute;
+        right: .3em;
+        top: 50%;
+        width: 20px;
+        margin: -10px 0 0 0;
+        padding: 1px;
+        height: 20px;
+    }
+    .ui-dialog .ui-dialog-content {
+        position: relative;
+        border: 0;
+        padding: .5em 1em;
+        background: none;
+        overflow: auto;
+    }
+    .ui-dialog .ui-dialog-buttonpane {
+        text-align: left;
+        border-width: 1px 0 0 0;
+        background-image: none;
+        margin-top: .5em;
+        padding: .3em 1em .5em .4em;
+    }
+    .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
+        float: right;
+    }
+    .ui-dialog .ui-dialog-buttonpane button {
+        margin: .5em .4em .5em 0;
+        cursor: pointer;
+    }
+    .ui-dialog .ui-resizable-n {
+        height: 2px;
+        top: 0;
+    }
+    .ui-dialog .ui-resizable-e {
+        width: 2px;
+        right: 0;
+    }
+    .ui-dialog .ui-resizable-s {
+        height: 2px;
+        bottom: 0;
+    }
+    .ui-dialog .ui-resizable-w {
+        width: 2px;
+        left: 0;
+    }
+    .ui-dialog .ui-resizable-se,
+    .ui-dialog .ui-resizable-sw,
+    .ui-dialog .ui-resizable-ne,
+    .ui-dialog .ui-resizable-nw {
+        width: 7px;
+        height: 7px;
+    }
+    .ui-dialog .ui-resizable-se {
+        right: 0;
+        bottom: 0;
+    }
+    .ui-dialog .ui-resizable-sw {
+        left: 0;
+        bottom: 0;
+    }
+    .ui-dialog .ui-resizable-ne {
+        right: 0;
+        top: 0;
+    }
+    .ui-dialog .ui-resizable-nw {
+        left: 0;
+        top: 0;
+    }
+    .ui-draggable .ui-dialog-titlebar {
+        cursor: move;
+    }
+    .ui-draggable-handle {
+        -ms-touch-action: none;
+        touch-action: none;
+    }
+    .ui-resizable {
+        position: relative;
+    }
+    .ui-resizable-handle {
+        position: absolute;
+        font-size: 0.1px;
+        display: block;
+        -ms-touch-action: none;
+        touch-action: none;
+    }
+    .ui-resizable-disabled .ui-resizable-handle,
+    .ui-resizable-autohide .ui-resizable-handle {
+        display: none;
+    }
+    .ui-resizable-n {
+        cursor: n-resize;
+        height: 7px;
+        width: 100%;
+        top: -5px;
+        left: 0;
+    }
+    .ui-resizable-s {
+        cursor: s-resize;
+        height: 7px;
+        width: 100%;
+        bottom: -5px;
+        left: 0;
+    }
+    .ui-resizable-e {
+        cursor: e-resize;
+        width: 7px;
+        right: -5px;
+        top: 0;
+        height: 100%;
+    }
+    .ui-resizable-w {
+        cursor: w-resize;
+        width: 7px;
+        left: -5px;
+        top: 0;
+        height: 100%;
+    }
+    .ui-resizable-se {
+        cursor: se-resize;
+        width: 12px;
+        height: 12px;
+        right: 1px;
+        bottom: 1px;
+    }
+    .ui-resizable-sw {
+        cursor: sw-resize;
+        width: 9px;
+        height: 9px;
+        left: -5px;
+        bottom: -5px;
+    }
+    .ui-resizable-nw {
+        cursor: nw-resize;
+        width: 9px;
+        height: 9px;
+        left: -5px;
+        top: -5px;
+    }
+    .ui-resizable-ne {
+        cursor: ne-resize;
+        width: 9px;
+        height: 9px;
+        right: -5px;
+        top: -5px;
+    }
+    .ui-progressbar {
+        height: 2em;
+        text-align: left;
+        overflow: hidden;
+    }
+    .ui-progressbar .ui-progressbar-value {
+        margin: -1px;
+        height: 100%;
+    }
+    .ui-progressbar .ui-progressbar-overlay {
+        background: url("data:image/gif;base64,R0lGODlhKAAoAIABAAAAAP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJAQABACwAAAAAKAAoAAACkYwNqXrdC52DS06a7MFZI+4FHBCKoDeWKXqymPqGqxvJrXZbMx7Ttc+w9XgU2FB3lOyQRWET2IFGiU9m1frDVpxZZc6bfHwv4c1YXP6k1Vdy292Fb6UkuvFtXpvWSzA+HycXJHUXiGYIiMg2R6W459gnWGfHNdjIqDWVqemH2ekpObkpOlppWUqZiqr6edqqWQAAIfkECQEAAQAsAAAAACgAKAAAApSMgZnGfaqcg1E2uuzDmmHUBR8Qil95hiPKqWn3aqtLsS18y7G1SzNeowWBENtQd+T1JktP05nzPTdJZlR6vUxNWWjV+vUWhWNkWFwxl9VpZRedYcflIOLafaa28XdsH/ynlcc1uPVDZxQIR0K25+cICCmoqCe5mGhZOfeYSUh5yJcJyrkZWWpaR8doJ2o4NYq62lAAACH5BAkBAAEALAAAAAAoACgAAAKVDI4Yy22ZnINRNqosw0Bv7i1gyHUkFj7oSaWlu3ovC8GxNso5fluz3qLVhBVeT/Lz7ZTHyxL5dDalQWPVOsQWtRnuwXaFTj9jVVh8pma9JjZ4zYSj5ZOyma7uuolffh+IR5aW97cHuBUXKGKXlKjn+DiHWMcYJah4N0lYCMlJOXipGRr5qdgoSTrqWSq6WFl2ypoaUAAAIfkECQEAAQAsAAAAACgAKAAAApaEb6HLgd/iO7FNWtcFWe+ufODGjRfoiJ2akShbueb0wtI50zm02pbvwfWEMWBQ1zKGlLIhskiEPm9R6vRXxV4ZzWT2yHOGpWMyorblKlNp8HmHEb/lCXjcW7bmtXP8Xt229OVWR1fod2eWqNfHuMjXCPkIGNileOiImVmCOEmoSfn3yXlJWmoHGhqp6ilYuWYpmTqKUgAAIfkECQEAAQAsAAAAACgAKAAAApiEH6kb58biQ3FNWtMFWW3eNVcojuFGfqnZqSebuS06w5V80/X02pKe8zFwP6EFWOT1lDFk8rGERh1TTNOocQ61Hm4Xm2VexUHpzjymViHrFbiELsefVrn6XKfnt2Q9G/+Xdie499XHd2g4h7ioOGhXGJboGAnXSBnoBwKYyfioubZJ2Hn0RuRZaflZOil56Zp6iioKSXpUAAAh+QQJAQABACwAAAAAKAAoAAACkoQRqRvnxuI7kU1a1UU5bd5tnSeOZXhmn5lWK3qNTWvRdQxP8qvaC+/yaYQzXO7BMvaUEmJRd3TsiMAgswmNYrSgZdYrTX6tSHGZO73ezuAw2uxuQ+BbeZfMxsexY35+/Qe4J1inV0g4x3WHuMhIl2jXOKT2Q+VU5fgoSUI52VfZyfkJGkha6jmY+aaYdirq+lQAACH5BAkBAAEALAAAAAAoACgAAAKWBIKpYe0L3YNKToqswUlvznigd4wiR4KhZrKt9Upqip61i9E3vMvxRdHlbEFiEXfk9YARYxOZZD6VQ2pUunBmtRXo1Lf8hMVVcNl8JafV38aM2/Fu5V16Bn63r6xt97j09+MXSFi4BniGFae3hzbH9+hYBzkpuUh5aZmHuanZOZgIuvbGiNeomCnaxxap2upaCZsq+1kAACH5BAkBAAEALAAAAAAoACgAAAKXjI8By5zf4kOxTVrXNVlv1X0d8IGZGKLnNpYtm8Lr9cqVeuOSvfOW79D9aDHizNhDJidFZhNydEahOaDH6nomtJjp1tutKoNWkvA6JqfRVLHU/QUfau9l2x7G54d1fl995xcIGAdXqMfBNadoYrhH+Mg2KBlpVpbluCiXmMnZ2Sh4GBqJ+ckIOqqJ6LmKSllZmsoq6wpQAAAh+QQJAQABACwAAAAAKAAoAAAClYx/oLvoxuJDkU1a1YUZbJ59nSd2ZXhWqbRa2/gF8Gu2DY3iqs7yrq+xBYEkYvFSM8aSSObE+ZgRl1BHFZNr7pRCavZ5BW2142hY3AN/zWtsmf12p9XxxFl2lpLn1rseztfXZjdIWIf2s5dItwjYKBgo9yg5pHgzJXTEeGlZuenpyPmpGQoKOWkYmSpaSnqKileI2FAAACH5BAkBAAEALAAAAAAoACgAAAKVjB+gu+jG4kORTVrVhRlsnn2dJ3ZleFaptFrb+CXmO9OozeL5VfP99HvAWhpiUdcwkpBH3825AwYdU8xTqlLGhtCosArKMpvfa1mMRae9VvWZfeB2XfPkeLmm18lUcBj+p5dnN8jXZ3YIGEhYuOUn45aoCDkp16hl5IjYJvjWKcnoGQpqyPlpOhr3aElaqrq56Bq7VAAAOw==");
+        height: 100%;
+        filter: alpha(opacity=25); /* support: IE8 */
+        opacity: 0.25;
+    }
+    .ui-progressbar-indeterminate .ui-progressbar-value {
+        background-image: none;
+    }
+    .ui-selectable {
+        -ms-touch-action: none;
+        touch-action: none;
+    }
+    .ui-selectable-helper {
+        position: absolute;
+        z-index: 100;
+        border: 1px dotted black;
+    }
+    .ui-selectmenu-menu {
+        padding: 0;
+        margin: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: none;
+    }
+    .ui-selectmenu-menu .ui-menu {
+        overflow: auto;
+        overflow-x: hidden;
+        padding-bottom: 1px;
+    }
+    .ui-selectmenu-menu .ui-menu .ui-selectmenu-optgroup {
+        font-size: 1em;
+        font-weight: bold;
+        line-height: 1.5;
+        padding: 2px 0.4em;
+        margin: 0.5em 0 0 0;
+        height: auto;
+        border: 0;
+    }
+    .ui-selectmenu-open {
+        display: block;
+    }
+    .ui-selectmenu-text {
+        display: block;
+        margin-right: 20px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .ui-selectmenu-button.ui-button {
+        text-align: left;
+        white-space: nowrap;
+        width: 14em;
+    }
+    .ui-selectmenu-icon.ui-icon {
+        float: right;
+        margin-top: 0;
+    }
+    .ui-slider {
+        position: relative;
+        text-align: left;
+    }
+    .ui-slider .ui-slider-handle {
+        position: absolute;
+        z-index: 2;
+        width: 1.2em;
+        height: 1.2em;
+        cursor: default;
+        -ms-touch-action: none;
+        touch-action: none;
+    }
+    .ui-slider .ui-slider-range {
+        position: absolute;
+        z-index: 1;
+        font-size: .7em;
+        display: block;
+        border: 0;
+        background-position: 0 0;
+    }
+
+    /* support: IE8 - See #6727 */
+    .ui-slider.ui-state-disabled .ui-slider-handle,
+    .ui-slider.ui-state-disabled .ui-slider-range {
+        filter: inherit;
+    }
+
+    .ui-slider-horizontal {
+        height: .8em;
+    }
+    .ui-slider-horizontal .ui-slider-handle {
+        top: -.3em;
+        margin-left: -.6em;
+    }
+    .ui-slider-horizontal .ui-slider-range {
+        top: 0;
+        height: 100%;
+    }
+    .ui-slider-horizontal .ui-slider-range-min {
+        left: 0;
+    }
+    .ui-slider-horizontal .ui-slider-range-max {
+        right: 0;
+    }
+
+    .ui-slider-vertical {
+        width: .8em;
+        height: 100px;
+    }
+    .ui-slider-vertical .ui-slider-handle {
+        left: -.3em;
+        margin-left: 0;
+        margin-bottom: -.6em;
+    }
+    .ui-slider-vertical .ui-slider-range {
+        left: 0;
+        width: 100%;
+    }
+    .ui-slider-vertical .ui-slider-range-min {
+        bottom: 0;
+    }
+    .ui-slider-vertical .ui-slider-range-max {
+        top: 0;
+    }
+    .ui-sortable-handle {
+        -ms-touch-action: none;
+        touch-action: none;
+    }
+    .ui-spinner {
+        position: relative;
+        display: inline-block;
+        overflow: hidden;
+        padding: 0;
+        vertical-align: middle;
+    }
+    .ui-spinner-input {
+        border: none;
+        background: none;
+        color: inherit;
+        padding: .222em 0;
+        margin: .2em 0;
+        vertical-align: middle;
+        margin-left: .4em;
+        margin-right: 2em;
+    }
+    .ui-spinner-button {
+        width: 1.6em;
+        height: 50%;
+        font-size: .5em;
+        padding: 0;
+        margin: 0;
+        text-align: center;
+        position: absolute;
+        cursor: default;
+        display: block;
+        overflow: hidden;
+        right: 0;
+    }
+    /* more specificity required here to override default borders */
+    .ui-spinner a.ui-spinner-button {
+        border-top-style: none;
+        border-bottom-style: none;
+        border-right-style: none;
+    }
+    .ui-spinner-up {
+        top: 0;
+    }
+    .ui-spinner-down {
+        bottom: 0;
+    }
+    .ui-tabs {
+        position: relative; /* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
+        padding: .2em;
+    }
+    .ui-tabs .ui-tabs-nav {
+        margin: 0;
+        padding: .2em .2em 0;
+    }
+    .ui-tabs .ui-tabs-nav li {
+        list-style: none;
+        float: left;
+        position: relative;
+        top: 0;
+        margin: 1px .2em 0 0;
+        border-bottom-width: 0;
+        padding: 0;
+        white-space: nowrap;
+    }
+    .ui-tabs .ui-tabs-nav .ui-tabs-anchor {
+        float: left;
+        padding: .5em 1em;
+        text-decoration: none;
+    }
+    .ui-tabs .ui-tabs-nav li.ui-tabs-active {
+        margin-bottom: -1px;
+        padding-bottom: 1px;
+    }
+    .ui-tabs .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor,
+    .ui-tabs .ui-tabs-nav li.ui-state-disabled .ui-tabs-anchor,
+    .ui-tabs .ui-tabs-nav li.ui-tabs-loading .ui-tabs-anchor {
+        cursor: text;
+    }
+    .ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor {
+        cursor: pointer;
+    }
+    .ui-tabs .ui-tabs-panel {
+        display: block;
+        border-width: 0;
+        padding: 1em 1.4em;
+        background: none;
+    }
+    .ui-tooltip {
+        padding: 8px;
+        position: absolute;
+        z-index: 9999;
+        max-width: 300px;
+    }
+    body .ui-tooltip {
+        border-width: 2px;
+    }
+
+    /* Component containers
+    ----------------------------------*/
+    .ui-widget {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 1em;
+    }
+    .ui-widget .ui-widget {
+        font-size: 1em;
+    }
+    .ui-widget input,
+    .ui-widget select,
+    .ui-widget textarea,
+    .ui-widget button {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 1em;
+    }
+    .ui-widget.ui-widget-content {
+        border: 1px solid #c5c5c5;
+    }
+    .ui-widget-content {
+        border: 1px solid #dddddd;
+        background: #ffffff;
+        color: #333333;
+    }
+    .ui-widget-content a {
+        color: #333333;
+    }
+    .ui-widget-header {
+        border: 1px solid #dddddd;
+        background: #e9e9e9;
+        color: #333333;
+        font-weight: bold;
+    }
+    .ui-widget-header a {
+        color: #333333;
+    }
+
+    /* Interaction states
+    ----------------------------------*/
+    .ui-state-default,
+    .ui-widget-content .ui-state-default,
+    .ui-widget-header .ui-state-default,
+    .ui-button,
+        /* We use html here because we need a greater specificity to make sure disabled
+        works properly when clicked or hovered */
+    html .ui-button.ui-state-disabled:hover,
+    html .ui-button.ui-state-disabled:active {
+        border: 1px solid #c5c5c5;
+        background: #f6f6f6;
+        font-weight: normal;
+        color: #454545;
+    }
+    .ui-state-default a,
+    .ui-state-default a:link,
+    .ui-state-default a:visited,
+    a.ui-button,
+    a:link.ui-button,
+    a:visited.ui-button,
+    .ui-button {
+        color: #454545;
+        text-decoration: none;
+    }
+    .ui-state-hover,
+    .ui-widget-content .ui-state-hover,
+    .ui-widget-header .ui-state-hover,
+    .ui-state-focus,
+    .ui-widget-content .ui-state-focus,
+    .ui-widget-header .ui-state-focus,
+    .ui-button:hover,
+    .ui-button:focus {
+        border: 1px solid #cccccc;
+        background: #ededed;
+        font-weight: normal;
+        color: #2b2b2b;
+    }
+    .ui-state-hover a,
+    .ui-state-hover a:hover,
+    .ui-state-hover a:link,
+    .ui-state-hover a:visited,
+    .ui-state-focus a,
+    .ui-state-focus a:hover,
+    .ui-state-focus a:link,
+    .ui-state-focus a:visited,
+    a.ui-button:hover,
+    a.ui-button:focus {
+        color: #2b2b2b;
+        text-decoration: none;
+    }
+
+    .ui-visual-focus {
+        box-shadow: 0 0 3px 1px rgb(94, 158, 214);
+    }
+    .ui-state-active,
+    .ui-widget-content .ui-state-active,
+    .ui-widget-header .ui-state-active,
+    a.ui-button:active,
+    .ui-button:active,
+    .ui-button.ui-state-active:hover {
+        border: 1px solid #003eff;
+        background: #007fff;
+        font-weight: normal;
+        color: #ffffff;
+    }
+    .ui-icon-background,
+    .ui-state-active .ui-icon-background {
+        border: #003eff;
+        background-color: #ffffff;
+    }
+    .ui-state-active a,
+    .ui-state-active a:link,
+    .ui-state-active a:visited {
+        color: #ffffff;
+        text-decoration: none;
+    }
+
+    /* Interaction Cues
+    ----------------------------------*/
+    .ui-state-highlight,
+    .ui-widget-content .ui-state-highlight,
+    .ui-widget-header .ui-state-highlight {
+        border: 1px solid #dad55e;
+        background: #fffa90;
+        color: #777620;
+    }
+    .ui-state-checked {
+        border: 1px solid #dad55e;
+        background: #fffa90;
+    }
+    .ui-state-highlight a,
+    .ui-widget-content .ui-state-highlight a,
+    .ui-widget-header .ui-state-highlight a {
+        color: #777620;
+    }
+    .ui-state-error,
+    .ui-widget-content .ui-state-error,
+    .ui-widget-header .ui-state-error {
+        border: 1px solid #f1a899;
+        background: #fddfdf;
+        color: #5f3f3f;
+    }
+    .ui-state-error a,
+    .ui-widget-content .ui-state-error a,
+    .ui-widget-header .ui-state-error a {
+        color: #5f3f3f;
+    }
+    .ui-state-error-text,
+    .ui-widget-content .ui-state-error-text,
+    .ui-widget-header .ui-state-error-text {
+        color: #5f3f3f;
+    }
+    .ui-priority-primary,
+    .ui-widget-content .ui-priority-primary,
+    .ui-widget-header .ui-priority-primary {
+        font-weight: bold;
+    }
+    .ui-priority-secondary,
+    .ui-widget-content .ui-priority-secondary,
+    .ui-widget-header .ui-priority-secondary {
+        opacity: .7;
+        filter: Alpha(Opacity=70); /* support: IE8 */
+        font-weight: normal;
+    }
+    .ui-state-disabled,
+    .ui-widget-content .ui-state-disabled,
+    .ui-widget-header .ui-state-disabled {
+        opacity: .35;
+        filter: Alpha(Opacity=35); /* support: IE8 */
+        background-image: none;
+    }
+    .ui-state-disabled .ui-icon {
+        filter: Alpha(Opacity=35); /* support: IE8 - See #6059 */
+    }
+
+    /* Icons
+    ----------------------------------*/
+
+    /* states and images */
+    .ui-icon {
+        width: 16px;
+        height: 16px;
+    }
+    .ui-icon,
+    .ui-widget-content .ui-icon {
+        background-image: url("images/ui-icons_444444_256x240.png");
+    }
+    .ui-widget-header .ui-icon {
+        background-image: url("images/ui-icons_444444_256x240.png");
+    }
+    .ui-state-hover .ui-icon,
+    .ui-state-focus .ui-icon,
+    .ui-button:hover .ui-icon,
+    .ui-button:focus .ui-icon {
+        background-image: url("images/ui-icons_555555_256x240.png");
+    }
+    .ui-state-active .ui-icon,
+    .ui-button:active .ui-icon {
+        background-image: url("images/ui-icons_ffffff_256x240.png");
+    }
+    .ui-state-highlight .ui-icon,
+    .ui-button .ui-state-highlight.ui-icon {
+        background-image: url("images/ui-icons_777620_256x240.png");
+    }
+    .ui-state-error .ui-icon,
+    .ui-state-error-text .ui-icon {
+        background-image: url("images/ui-icons_cc0000_256x240.png");
+    }
+    .ui-button .ui-icon {
+        background-image: url("images/ui-icons_777777_256x240.png");
+    }
+
+    /* positioning */
+    .ui-icon-blank {
+        background-position: 16px 16px;
+    }
+    .ui-icon-caret-1-n {
+        background-position: 0 0;
+    }
+    .ui-icon-caret-1-ne {
+        background-position: -16px 0;
+    }
+    .ui-icon-caret-1-e {
+        background-position: -32px 0;
+    }
+    .ui-icon-caret-1-se {
+        background-position: -48px 0;
+    }
+    .ui-icon-caret-1-s {
+        background-position: -65px 0;
+    }
+    .ui-icon-caret-1-sw {
+        background-position: -80px 0;
+    }
+    .ui-icon-caret-1-w {
+        background-position: -96px 0;
+    }
+    .ui-icon-caret-1-nw {
+        background-position: -112px 0;
+    }
+    .ui-icon-caret-2-n-s {
+        background-position: -128px 0;
+    }
+    .ui-icon-caret-2-e-w {
+        background-position: -144px 0;
+    }
+    .ui-icon-triangle-1-n {
+        background-position: 0 -16px;
+    }
+    .ui-icon-triangle-1-ne {
+        background-position: -16px -16px;
+    }
+    .ui-icon-triangle-1-e {
+        background-position: -32px -16px;
+    }
+    .ui-icon-triangle-1-se {
+        background-position: -48px -16px;
+    }
+    .ui-icon-triangle-1-s {
+        background-position: -65px -16px;
+    }
+    .ui-icon-triangle-1-sw {
+        background-position: -80px -16px;
+    }
+    .ui-icon-triangle-1-w {
+        background-position: -96px -16px;
+    }
+    .ui-icon-triangle-1-nw {
+        background-position: -112px -16px;
+    }
+    .ui-icon-triangle-2-n-s {
+        background-position: -128px -16px;
+    }
+    .ui-icon-triangle-2-e-w {
+        background-position: -144px -16px;
+    }
+    .ui-icon-arrow-1-n {
+        background-position: 0 -32px;
+    }
+    .ui-icon-arrow-1-ne {
+        background-position: -16px -32px;
+    }
+    .ui-icon-arrow-1-e {
+        background-position: -32px -32px;
+    }
+    .ui-icon-arrow-1-se {
+        background-position: -48px -32px;
+    }
+    .ui-icon-arrow-1-s {
+        background-position: -65px -32px;
+    }
+    .ui-icon-arrow-1-sw {
+        background-position: -80px -32px;
+    }
+    .ui-icon-arrow-1-w {
+        background-position: -96px -32px;
+    }
+    .ui-icon-arrow-1-nw {
+        background-position: -112px -32px;
+    }
+    .ui-icon-arrow-2-n-s {
+        background-position: -128px -32px;
+    }
+    .ui-icon-arrow-2-ne-sw {
+        background-position: -144px -32px;
+    }
+    .ui-icon-arrow-2-e-w {
+        background-position: -160px -32px;
+    }
+    .ui-icon-arrow-2-se-nw {
+        background-position: -176px -32px;
+    }
+    .ui-icon-arrowstop-1-n {
+        background-position: -192px -32px;
+    }
+    .ui-icon-arrowstop-1-e {
+        background-position: -208px -32px;
+    }
+    .ui-icon-arrowstop-1-s {
+        background-position: -224px -32px;
+    }
+    .ui-icon-arrowstop-1-w {
+        background-position: -240px -32px;
+    }
+    .ui-icon-arrowthick-1-n {
+        background-position: 1px -48px;
+    }
+    .ui-icon-arrowthick-1-ne {
+        background-position: -16px -48px;
+    }
+    .ui-icon-arrowthick-1-e {
+        background-position: -32px -48px;
+    }
+    .ui-icon-arrowthick-1-se {
+        background-position: -48px -48px;
+    }
+    .ui-icon-arrowthick-1-s {
+        background-position: -64px -48px;
+    }
+    .ui-icon-arrowthick-1-sw {
+        background-position: -80px -48px;
+    }
+    .ui-icon-arrowthick-1-w {
+        background-position: -96px -48px;
+    }
+    .ui-icon-arrowthick-1-nw {
+        background-position: -112px -48px;
+    }
+    .ui-icon-arrowthick-2-n-s {
+        background-position: -128px -48px;
+    }
+    .ui-icon-arrowthick-2-ne-sw {
+        background-position: -144px -48px;
+    }
+    .ui-icon-arrowthick-2-e-w {
+        background-position: -160px -48px;
+    }
+    .ui-icon-arrowthick-2-se-nw {
+        background-position: -176px -48px;
+    }
+    .ui-icon-arrowthickstop-1-n {
+        background-position: -192px -48px;
+    }
+    .ui-icon-arrowthickstop-1-e {
+        background-position: -208px -48px;
+    }
+    .ui-icon-arrowthickstop-1-s {
+        background-position: -224px -48px;
+    }
+    .ui-icon-arrowthickstop-1-w {
+        background-position: -240px -48px;
+    }
+    .ui-icon-arrowreturnthick-1-w {
+        background-position: 0 -64px;
+    }
+    .ui-icon-arrowreturnthick-1-n {
+        background-position: -16px -64px;
+    }
+    .ui-icon-arrowreturnthick-1-e {
+        background-position: -32px -64px;
+    }
+    .ui-icon-arrowreturnthick-1-s {
+        background-position: -48px -64px;
+    }
+    .ui-icon-arrowreturn-1-w {
+        background-position: -64px -64px;
+    }
+    .ui-icon-arrowreturn-1-n {
+        background-position: -80px -64px;
+    }
+    .ui-icon-arrowreturn-1-e {
+        background-position: -96px -64px;
+    }
+    .ui-icon-arrowreturn-1-s {
+        background-position: -112px -64px;
+    }
+    .ui-icon-arrowrefresh-1-w {
+        background-position: -128px -64px;
+    }
+    .ui-icon-arrowrefresh-1-n {
+        background-position: -144px -64px;
+    }
+    .ui-icon-arrowrefresh-1-e {
+        background-position: -160px -64px;
+    }
+    .ui-icon-arrowrefresh-1-s {
+        background-position: -176px -64px;
+    }
+    .ui-icon-arrow-4 {
+        background-position: 0 -80px;
+    }
+    .ui-icon-arrow-4-diag {
+        background-position: -16px -80px;
+    }
+    .ui-icon-extlink {
+        background-position: -32px -80px;
+    }
+    .ui-icon-newwin {
+        background-position: -48px -80px;
+    }
+    .ui-icon-refresh {
+        background-position: -64px -80px;
+    }
+    .ui-icon-shuffle {
+        background-position: -80px -80px;
+    }
+    .ui-icon-transfer-e-w {
+        background-position: -96px -80px;
+    }
+    .ui-icon-transferthick-e-w {
+        background-position: -112px -80px;
+    }
+    .ui-icon-folder-collapsed {
+        background-position: 0 -96px;
+    }
+    .ui-icon-folder-open {
+        background-position: -16px -96px;
+    }
+    .ui-icon-document {
+        background-position: -32px -96px;
+    }
+    .ui-icon-document-b {
+        background-position: -48px -96px;
+    }
+    .ui-icon-note {
+        background-position: -64px -96px;
+    }
+    .ui-icon-mail-closed {
+        background-position: -80px -96px;
+    }
+    .ui-icon-mail-open {
+        background-position: -96px -96px;
+    }
+    .ui-icon-suitcase {
+        background-position: -112px -96px;
+    }
+    .ui-icon-comment {
+        background-position: -128px -96px;
+    }
+    .ui-icon-person {
+        background-position: -144px -96px;
+    }
+    .ui-icon-print {
+        background-position: -160px -96px;
+    }
+    .ui-icon-trash {
+        background-position: -176px -96px;
+    }
+    .ui-icon-locked {
+        background-position: -192px -96px;
+    }
+    .ui-icon-unlocked {
+        background-position: -208px -96px;
+    }
+    .ui-icon-bookmark {
+        background-position: -224px -96px;
+    }
+    .ui-icon-tag {
+        background-position: -240px -96px;
+    }
+    .ui-icon-home {
+        background-position: 0 -112px;
+    }
+    .ui-icon-flag {
+        background-position: -16px -112px;
+    }
+    .ui-icon-calendar {
+        background-position: -32px -112px;
+    }
+    .ui-icon-cart {
+        background-position: -48px -112px;
+    }
+    .ui-icon-pencil {
+        background-position: -64px -112px;
+    }
+    .ui-icon-clock {
+        background-position: -80px -112px;
+    }
+    .ui-icon-disk {
+        background-position: -96px -112px;
+    }
+    .ui-icon-calculator {
+        background-position: -112px -112px;
+    }
+    .ui-icon-zoomin {
+        background-position: -128px -112px;
+    }
+    .ui-icon-zoomout {
+        background-position: -144px -112px;
+    }
+    .ui-icon-search {
+        background-position: -160px -112px;
+    }
+    .ui-icon-wrench {
+        background-position: -176px -112px;
+    }
+    .ui-icon-gear {
+        background-position: -192px -112px;
+    }
+    .ui-icon-heart {
+        background-position: -208px -112px;
+    }
+    .ui-icon-star {
+        background-position: -224px -112px;
+    }
+    .ui-icon-link {
+        background-position: -240px -112px;
+    }
+    .ui-icon-cancel {
+        background-position: 0 -128px;
+    }
+    .ui-icon-plus {
+        background-position: -16px -128px;
+    }
+    .ui-icon-plusthick {
+        background-position: -32px -128px;
+    }
+    .ui-icon-minus {
+        background-position: -48px -128px;
+    }
+    .ui-icon-minusthick {
+        background-position: -64px -128px;
+    }
+    .ui-icon-close {
+        background-position: -80px -128px;
+    }
+    .ui-icon-closethick {
+        background-position: -96px -128px;
+    }
+    .ui-icon-key {
+        background-position: -112px -128px;
+    }
+    .ui-icon-lightbulb {
+        background-position: -128px -128px;
+    }
+    .ui-icon-scissors {
+        background-position: -144px -128px;
+    }
+    .ui-icon-clipboard {
+        background-position: -160px -128px;
+    }
+    .ui-icon-copy {
+        background-position: -176px -128px;
+    }
+    .ui-icon-contact {
+        background-position: -192px -128px;
+    }
+    .ui-icon-image {
+        background-position: -208px -128px;
+    }
+    .ui-icon-video {
+        background-position: -224px -128px;
+    }
+    .ui-icon-script {
+        background-position: -240px -128px;
+    }
+    .ui-icon-alert {
+        background-position: 0 -144px;
+    }
+    .ui-icon-info {
+        background-position: -16px -144px;
+    }
+    .ui-icon-notice {
+        background-position: -32px -144px;
+    }
+    .ui-icon-help {
+        background-position: -48px -144px;
+    }
+    .ui-icon-check {
+        background-position: -64px -144px;
+    }
+    .ui-icon-bullet {
+        background-position: -80px -144px;
+    }
+    .ui-icon-radio-on {
+        background-position: -96px -144px;
+    }
+    .ui-icon-radio-off {
+        background-position: -112px -144px;
+    }
+    .ui-icon-pin-w {
+        background-position: -128px -144px;
+    }
+    .ui-icon-pin-s {
+        background-position: -144px -144px;
+    }
+    .ui-icon-play {
+        background-position: 0 -160px;
+    }
+    .ui-icon-pause {
+        background-position: -16px -160px;
+    }
+    .ui-icon-seek-next {
+        background-position: -32px -160px;
+    }
+    .ui-icon-seek-prev {
+        background-position: -48px -160px;
+    }
+    .ui-icon-seek-end {
+        background-position: -64px -160px;
+    }
+    .ui-icon-seek-start {
+        background-position: -80px -160px;
+    }
+    /* ui-icon-seek-first is deprecated, use ui-icon-seek-start instead */
+    .ui-icon-seek-first {
+        background-position: -80px -160px;
+    }
+    .ui-icon-stop {
+        background-position: -96px -160px;
+    }
+    .ui-icon-eject {
+        background-position: -112px -160px;
+    }
+    .ui-icon-volume-off {
+        background-position: -128px -160px;
+    }
+    .ui-icon-volume-on {
+        background-position: -144px -160px;
+    }
+    .ui-icon-power {
+        background-position: 0 -176px;
+    }
+    .ui-icon-signal-diag {
+        background-position: -16px -176px;
+    }
+    .ui-icon-signal {
+        background-position: -32px -176px;
+    }
+    .ui-icon-battery-0 {
+        background-position: -48px -176px;
+    }
+    .ui-icon-battery-1 {
+        background-position: -64px -176px;
+    }
+    .ui-icon-battery-2 {
+        background-position: -80px -176px;
+    }
+    .ui-icon-battery-3 {
+        background-position: -96px -176px;
+    }
+    .ui-icon-circle-plus {
+        background-position: 0 -192px;
+    }
+    .ui-icon-circle-minus {
+        background-position: -16px -192px;
+    }
+    .ui-icon-circle-close {
+        background-position: -32px -192px;
+    }
+    .ui-icon-circle-triangle-e {
+        background-position: -48px -192px;
+    }
+    .ui-icon-circle-triangle-s {
+        background-position: -64px -192px;
+    }
+    .ui-icon-circle-triangle-w {
+        background-position: -80px -192px;
+    }
+    .ui-icon-circle-triangle-n {
+        background-position: -96px -192px;
+    }
+    .ui-icon-circle-arrow-e {
+        background-position: -112px -192px;
+    }
+    .ui-icon-circle-arrow-s {
+        background-position: -128px -192px;
+    }
+    .ui-icon-circle-arrow-w {
+        background-position: -144px -192px;
+    }
+    .ui-icon-circle-arrow-n {
+        background-position: -160px -192px;
+    }
+    .ui-icon-circle-zoomin {
+        background-position: -176px -192px;
+    }
+    .ui-icon-circle-zoomout {
+        background-position: -192px -192px;
+    }
+    .ui-icon-circle-check {
+        background-position: -208px -192px;
+    }
+    .ui-icon-circlesmall-plus {
+        background-position: 0 -208px;
+    }
+    .ui-icon-circlesmall-minus {
+        background-position: -16px -208px;
+    }
+    .ui-icon-circlesmall-close {
+        background-position: -32px -208px;
+    }
+    .ui-icon-squaresmall-plus {
+        background-position: -48px -208px;
+    }
+    .ui-icon-squaresmall-minus {
+        background-position: -64px -208px;
+    }
+    .ui-icon-squaresmall-close {
+        background-position: -80px -208px;
+    }
+    .ui-icon-grip-dotted-vertical {
+        background-position: 0 -224px;
+    }
+    .ui-icon-grip-dotted-horizontal {
+        background-position: -16px -224px;
+    }
+    .ui-icon-grip-solid-vertical {
+        background-position: -32px -224px;
+    }
+    .ui-icon-grip-solid-horizontal {
+        background-position: -48px -224px;
+    }
+    .ui-icon-gripsmall-diagonal-se {
+        background-position: -64px -224px;
+    }
+    .ui-icon-grip-diagonal-se {
+        background-position: -80px -224px;
+    }
+
+
+    /* Misc visuals
+    ----------------------------------*/
+
+    /* Corner radius */
+    .ui-corner-all,
+    .ui-corner-top,
+    .ui-corner-left,
+    .ui-corner-tl {
+        border-top-left-radius: 3px;
+    }
+    .ui-corner-all,
+    .ui-corner-top,
+    .ui-corner-right,
+    .ui-corner-tr {
+        border-top-right-radius: 3px;
+    }
+    .ui-corner-all,
+    .ui-corner-bottom,
+    .ui-corner-left,
+    .ui-corner-bl {
+        border-bottom-left-radius: 3px;
+    }
+    .ui-corner-all,
+    .ui-corner-bottom,
+    .ui-corner-right,
+    .ui-corner-br {
+        border-bottom-right-radius: 3px;
+    }
+
+    /* Overlays */
+    .ui-widget-overlay {
+        background: #aaaaaa;
+        opacity: .003;
+        filter: Alpha(Opacity=.3); /* support: IE8 */
+    }
+    .ui-widget-shadow {
+        -webkit-box-shadow: 0px 0px 5px #666666;
+        box-shadow: 0px 0px 5px #666666;
+    }
+
 }

--- a/assets/admin/sass/partials/_dashboard.scss
+++ b/assets/admin/sass/partials/_dashboard.scss
@@ -18,7 +18,7 @@
 		ul {
 				li {
 					margin-top: 15px;
-					@extend .cb-box;
+					@extend .cb-box !optional;
 					.cb-summmary-item {
 						font-weight: bold;
 					}

--- a/assets/global/sass/global.scss
+++ b/assets/global/sass/global.scss
@@ -5,19 +5,19 @@
  */
 
 /* Lib: reset.css */
-@import "lib/_reset";
+@use "lib/_reset";
 
 /* Lib: animate.css */
-@import "lib/_animate";
+@use "lib/_animate";
 
 /* Variables: colors, widths, padding */
-@import "partials/_variables";
+@use "partials/_variables";
 
 /* Mixins */
-@import "partials/_mixins";
+@use "partials/_mixins";
 
 /* Extends */
-@import "partials/_extends";
+@use "partials/_extends";
 
 /* Utilites */
-@import "partials/_utilities";
+@use "partials/_utilities";

--- a/assets/global/sass/partials/_extends.scss
+++ b/assets/global/sass/partials/_extends.scss
@@ -11,29 +11,31 @@
  */
 
 /* -------------------- Boxes -------------------- */
+@use "mixins";
+@use "variables";
 
 .cb-box {
 	background: var(--commonsbooking-color-gray-background);
-	
+
+    overflow: hidden;
+    border-radius: var(--commonsbooking-radius);
+    margin-bottom: var(--commonsbooking-spacer);
+
 	padding: var(--commonsbooking-spacer-small) / 2 var(--commonsbooking-spacer-small);
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		padding: var(--commonsbooking-spacer) var(--commonsbooking-spacer-big);
 	}
-	
-	overflow: hidden;
-	border-radius: var(--commonsbooking-radius);
-	margin-bottom: var(--commonsbooking-spacer);
 }
 
 .cb-box-inner {
-	background: $color-white;
+	background: variables.$color-white;
+
+    border-radius: var(--commonsbooking-radius);
 
 	padding: var(--commonsbooking-spacer-small);
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		padding: var(--commonsbooking-spacer);
 	}
-	
-	border-radius: var(--commonsbooking-radius);
 }
 
 /* -------------------- Typography -------------------- */
@@ -55,7 +57,7 @@
 
 .cb-hover {
 	@extend .shadow-small;
-	border: 1px solid $color-blue-dark;
+	border: 1px solid variables.$color-blue-dark;
 	border-radius: var(--commonsbooking-radius);
 }
 
@@ -74,7 +76,7 @@
 	text-decoration: none !important;
 	word-break: normal !important; /* TwentyTwenty theme fix */
 	white-space: nowrap;
-	color: $color-white;
+	color: variables.$color-white;
 	padding: var(--commonsbooking-spacer) var(--commonsbooking-spacer-big);
 	font-weight: bold;
 
@@ -86,11 +88,11 @@
 	&:hover {
 		@extend .shadow-small;
 		background: var(--commonsbooking-color-secondary);
-		color: $color-white; /* Various themes fix */
+		color: variables.$color-white; /* Various themes fix */
 	}
 
 	&:visited {
-		color: $color-white;
+		color: variables.$color-white;
 	}
 
 	&.big {
@@ -99,7 +101,7 @@
 		line-height: var(--commonsbooking-font-size-big);
 	}
 	&.secondary {
-		background-color: $color-white;
+		background-color: variables.$color-white;
 		color: var(--commonsbooking-color-error);
 	}
 
@@ -138,7 +140,7 @@
 	margin: 0;
 	a {
 		text-decoration: none;
-		color: $color-white;
+		color: variables.$color-white;
 		padding: var(--commonsbooking-spacer-small) var(--commonsbooking-spacer);
 	}
 }

--- a/assets/public/sass/partials/_bookings.scss
+++ b/assets/public/sass/partials/_bookings.scss
@@ -5,6 +5,8 @@
 *
 */
 
+@use "../../../global/sass/partials/variables";
+
 #ui-datepicker-div {
     display: none;
     background-color: white;
@@ -54,7 +56,7 @@
         }
 
         .filter-wrapper {
-            @include font-default;
+            @include variables.font-default;
             margin-top: 10px;
             flex-basis: 220px;
 
@@ -102,7 +104,7 @@
     }
 
     #booking-list--results {
-        @include font-default;
+        @include variables.font-default;
         width: 100%;
 
         @media (min-width: 400px) {
@@ -113,12 +115,13 @@
             background-color: white;
 
             .content-wrapper {
+                margin-bottom: 5px;
+                font-size: 0.9em;
+
                 display: flex;
                 @media only screen and (max-width: 600px) {
                     display: block;
                 }
-                margin-bottom: 5px;
-                font-size: 0.9em;
 
                 & > p,
                 & > div {
@@ -267,7 +270,7 @@
     }
 
     #booking-list--pagination {
-        @include font-default;
+        @include variables.font-default;
 
         ul {
             display: flex;

--- a/assets/public/sass/partials/_calendar.scss
+++ b/assets/public/sass/partials/_calendar.scss
@@ -4,7 +4,7 @@
  * Styles for the litepicker javascript
  *
  */
- 
+@use "../mixins/calendar";
 
 :root {
 	--litepickerBgColor: transparent;
@@ -72,7 +72,7 @@
 			
 		}
 		&__months {
-			@extend .cb-box-inner;
+			@extend .cb-box-inner !optional;
 
 			background: transparent; 
 			box-shadow: none;
@@ -236,7 +236,7 @@
 			}
 
 			.day-item {
-                @include day-item;
+                @include calendar.day-item;
 			}
 
 			.week-number {

--- a/assets/public/sass/partials/_forms.scss
+++ b/assets/public/sass/partials/_forms.scss
@@ -10,6 +10,8 @@
  * @copyright 2015 wielebenwir
  */
 
+@use "../../../global/sass/partials/variables";
+
 .cb-wrapper {
 
 
@@ -32,11 +34,11 @@
     textarea {
         -webkit-appearance: none;
         -moz-appearance: none;
-        background: $color-white;
+        background: variables.$color-white;
         border-radius: var(--commonsbooking-radius);
         border-style: solid;
         border-width: 0.1rem;
-        border-color: $color-black;
+        border-color: variables.$color-black;
         box-shadow: none;
         display: block;
         margin: 0;
@@ -55,12 +57,12 @@
     }
 
     .cb-action {
-        @extend .cb-box;
+        @extend .cb-box !optional;
 
         text-align: right;
 
         input {
-            @extend .cb-button;
+            @extend .cb-button !optional;
             float: right;
         }
 
@@ -113,7 +115,7 @@
         width: 100%; /* do not extend litepicker width */
         color: var(--commonsbooking-textcolor-dark);
         input {
-            @extend .cb-button;
+            @extend .cb-button !optional;
             float: right;
         }
 
@@ -129,7 +131,7 @@
                 display: flex;
                 align-items: center;
 
-                @extend .cb-box-inner;
+                @extend .cb-box-inner !optional;
                 margin-bottom: var(--commonsbooking-spacer);
                 text-align: left;
                 overflow: hidden;
@@ -167,7 +169,7 @@
     }
 
     .cb-notice {
-        @extend .cb-box;
+        @extend .cb-box !optional;
         margin-bottom: var(--commonsbooking-spacer-big);
         font-size: var(--commonsbooking-font-size-big);
         vertical-align: middle;

--- a/assets/public/sass/partials/_layouts.scss
+++ b/assets/public/sass/partials/_layouts.scss
@@ -5,6 +5,7 @@
  *
  */
 
+@use "../../../global/sass/partials/mixins";
 
 /* -------------------- Tables -------------------- */
 
@@ -15,7 +16,7 @@
 		font-weight: bold;
 	}
 	
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		display: flex;
 		flex-direction: row;
 	    flex-wrap: wrap;
@@ -31,7 +32,7 @@
 }
 /* 50-50 */
 .cb-col-50-50 {
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		display: flex;
 		> :nth-child(odd) {
 			width: 50%;
@@ -62,7 +63,7 @@
 		}
 	}
 
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		
 		display: flex;
 		justify-content: space-between;
@@ -96,7 +97,7 @@
 		text-align: right;
 	}
 	
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		display: flex;
 		flex-direction: row;
 	    justify-content: space-between;
@@ -130,7 +131,7 @@
 }
 
 .cb-col-20-50-30 {
-	@include breakpoint(phablet) {
+	@include mixins.breakpoint(phablet) {
 		display: flex;
 		flex-direction: row;
 	    justify-content: space-between;

--- a/assets/public/sass/partials/_lists.scss
+++ b/assets/public/sass/partials/_lists.scss
@@ -19,7 +19,7 @@
 	display: block;
 	margin-top: var(--commonsbooking-spacer-big);
     color: var(--commonsbooking-textcolor-dark);
-	@extend .cb-box;
+	@extend .cb-box !optional;;
 	
 	.cb-list-content.cb-pickupinstructions div {
 		white-space: pre-wrap; // enable line break in content from meta textfields 
@@ -56,7 +56,7 @@
 	/* sub lists wrapper */
 	> .cb-wrapper {
 		overflow: hidden;
-		@extend .cb-box-inner;
+		@extend .cb-box-inner !optional;;
 	
 		
 		> div { /* sub list items */
@@ -71,10 +71,10 @@
 	.template-timeframe-withlocation,
 	.template-item-withlocation
 	 {
-		@extend .cb-col-auto;
+		@extend .cb-col-auto !optional;;
 	}
 	.cb-list-header {
-		@extend .cb-col-auto;
+		@extend .cb-col-auto !optional;;
 	}
 	.cb-list-header img{
 		

--- a/assets/public/sass/partials/_map.scss
+++ b/assets/public/sass/partials/_map.scss
@@ -12,6 +12,8 @@
 * @copyright 2020 wielebenwir
 */
 
+@use "../../../global/sass/partials/variables";
+
 .cb-wrapper {	
 	
 	/* Leaflet Map */
@@ -147,7 +149,7 @@
 .cb-map-filters.cb-wrapper {
 	
 	margin-top: var(--commonsbooking-spacer);
-	@extend .cb-box;
+	@extend .cb-box !optional;
 	
 	input[type="checkbox"] {
 		margin: 0 var(--commonsbooking-spacer-small) 0 0;
@@ -173,12 +175,12 @@
 		> div {
 			margin-bottom: var(--commonsbooking-spacer);
 			padding-bottom: var(--commonsbooking-spacer);
-			border-bottom: 1px solid $color-gray-dark;
+			border-bottom: 1px solid variables.$color-gray-dark;
 		}
 	}
 
 	.cb-map-filter-group-label {
-		@extend .cb-big;
+		@extend .cb-big !optional;
 		color: var(--commonsbooking-color-primary);
 		margin-bottom: var(--commonsbooking-spacer-small);
 	}
@@ -188,7 +190,7 @@
 	.cb-map-availability-filter,
 	.cb-map-distance-filter {
 		.cb-map-filter-group {
-			@extend .cb-col-50-50-filter;
+			@extend .cb-col-50-50-filter !optional;
 			}
 	}
 	
@@ -205,7 +207,7 @@
 			}
 			button.undo-geo-search, button.geo-search {
 				background: transparent;
-				color: $color-white;
+				color: variables.$color-white;
 			}
 		}
 	}
@@ -245,7 +247,7 @@
 	.cb-map-button-wrapper {
 		text-align: right;
 		button {
-			@extend .cb-button;
+			@extend .cb-button !optional;
 		}
 	}
 }

--- a/assets/public/sass/partials/_notice.scss
+++ b/assets/public/sass/partials/_notice.scss
@@ -8,7 +8,7 @@
 
 .cb-wrapper {	
 	.cb-notice {
-		@extend .cb-box;
+		@extend .cb-box !optional;
 		margin-bottom: var(--commonsbooking-spacer-big);
 		font-size: var(--commonsbooking-font-size-big);
 		vertical-align: middle;

--- a/assets/public/sass/partials/_shortcodeItemsTable.scss
+++ b/assets/public/sass/partials/_shortcodeItemsTable.scss
@@ -12,13 +12,16 @@
 * @copyright 2020 wielebenwir
 */
 
+@use "../../../global/sass/partials/variables";
+@use "../../../public/sass/mixins/calendar";
+
 .cb-table-scroll {
 	position: relative;
 	overflow: scroll;
 }
 
 .cb-items-table {
-	@extend .cb-box;
+	@extend .cb-box !optional;
 	overflow: auto; /* overwriting cb-box standard behaviour */
 	padding: 0; /* overwriting cb-box standard behaviour */
 	width: 100%;
@@ -68,7 +71,7 @@
 		width: 100px;
 		min-width: 100px;
 		max-width: 100px;
-		background: $color-white;
+		background: variables.$color-white;
 	}
 	/* place first col */
 	thead tr:nth-child(2) th:first-child,
@@ -128,25 +131,25 @@
             background-color: var(--litepickerDayColorBg);
 
             &.is-holiday {
-                @include day-is-holiday;
+                @include calendar.day-is-holiday;
             }
             &.is-booked {
-                @include day-is-booked;
+                @include calendar.day-is-booked;
             }
 
             &.is-partially-booked {
-                @include day-is-partially-booked;
+                @include calendar.day-is-partially-booked;
             }
 
             &.is-partially-booked-start {
-                @include day-is-partially-booked-start;
+                @include calendar.day-is-partially-booked-start;
             }
             &.is-partially-booked-end {
-                @include day-is-partially-booked-end;
+                @include calendar.day-is-partially-booked-end;
             }
 
             &.is-locked {
-                @include day-is-locked;
+                @include calendar.day-is-locked;
             }
 		}
 	}

--- a/assets/public/sass/partials/_single.scss
+++ b/assets/public/sass/partials/_single.scss
@@ -11,7 +11,7 @@
     background: transparent;
     padding: 0;
     > div:not(.cb-notice) { 
-      @extend .cb-box;
+      @extend .cb-box !optional;
       > div { /* sub list items */
         &:last-of-type {
           border-bottom: 0;

--- a/assets/public/sass/public.scss
+++ b/assets/public/sass/public.scss
@@ -3,37 +3,37 @@
  */
 
 /* Mixins */
-@import "mixins/_calendar";
+@use "mixins/_calendar" as calendarmixins;
 
 /* Global styles */
-@import "../../global/sass/global";
+@use "../../global/sass/global";
 
 /* Multi-column layouts */
-@import "partials/_layouts";
+@use "partials/_layouts";
 
 /* List styles */
-@import "partials/_lists";
+@use "partials/_lists";
 
 /* List styles */
-@import "partials/_single";
+@use "partials/_single";
 
 /* Form styles */
-@import "partials/_forms";
+@use "partials/_forms";
 
 /* Calendar styles */
-@import "partials/_calendar";
+@use "partials/_calendar";
 
 /* Map styles */
-@import "partials/_map";
+@use "partials/_map";
 
 /* Booking list styles */
-@import "partials/_bookings";
+@use "partials/_bookings";
 
 /* Notices and restrictions styles */
-@import "partials/_notice";
+@use "partials/_notice";
 
 /* Styles for items table */
-@import "partials/_shortcodeItemsTable";
+@use "partials/_shortcodeItemsTable";
 
 /* Fixes for specific WP Themes */
-@import "partials/_themeoptimization";
+@use "partials/_themeoptimization";

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"grunt-contrib-watch": "^1.1.0",
 				"grunt-dart-sass": "^2.0.1",
 				"matchdep": "^2.0.0",
-				"sass": "^1.66.1"
+				"sass": "^1.80.6"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1896,6 +1896,302 @@
 			"resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
 			"integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
 			"dev": true
+		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
+			"integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^1.0.3",
+				"is-glob": "^4.0.3",
+				"micromatch": "^4.0.5",
+				"node-addon-api": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.5.0",
+				"@parcel/watcher-darwin-arm64": "2.5.0",
+				"@parcel/watcher-darwin-x64": "2.5.0",
+				"@parcel/watcher-freebsd-x64": "2.5.0",
+				"@parcel/watcher-linux-arm-glibc": "2.5.0",
+				"@parcel/watcher-linux-arm-musl": "2.5.0",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.0",
+				"@parcel/watcher-linux-arm64-musl": "2.5.0",
+				"@parcel/watcher-linux-x64-glibc": "2.5.0",
+				"@parcel/watcher-linux-x64-musl": "2.5.0",
+				"@parcel/watcher-win32-arm64": "2.5.0",
+				"@parcel/watcher-win32-ia32": "2.5.0",
+				"@parcel/watcher-win32-x64": "2.5.0"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
+			"integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
+			"integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
+			"integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
+			"integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
+			"integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
+			"integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
+			"integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
+			"integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
+			"integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
+			"integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
+			"integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
+			"integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
+			"integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
 		},
 		"node_modules/@rokoli/vue-tiny-i18n": {
 			"version": "0.3.0",
@@ -3831,6 +4127,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"dev": true,
+			"optional": true,
+			"bin": {
+				"detect-libc": "bin/detect-libc.js"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/diff": {
@@ -7713,6 +8022,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"optional": true
+		},
 		"node_modules/node-preload": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -8928,12 +9244,12 @@
 			"dev": true
 		},
 		"node_modules/sass": {
-			"version": "1.69.5",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-			"integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+			"version": "1.80.6",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.80.6.tgz",
+			"integrity": "sha512-ccZgdHNiBF1NHBsWvacvT5rju3y1d/Eu+8Ex6c21nHp2lZGLBEtuwc415QfiI1PJa1TpCo3iXwwSRjRpn2Ckjg==",
 			"dev": true,
 			"dependencies": {
-				"chokidar": ">=3.0.0 <4.0.0",
+				"chokidar": "^4.0.0",
 				"immutable": "^4.0.0",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
@@ -8942,6 +9258,37 @@
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher": "^2.4.1"
+			}
+		},
+		"node_modules/sass/node_modules/chokidar": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+			"dev": true,
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/sass/node_modules/readdirp": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+			"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"grunt-contrib-watch": "^1.1.0",
 		"grunt-dart-sass": "^2.0.1",
 		"matchdep": "^2.0.0",
-		"sass": "^1.66.1"
+		"sass": "^1.80.6"
 	},
 	"scripts": {
 		"start": "composer install --ignore-platform-reqs && npm install && npm run dist",


### PR DESCRIPTION
@hansmorb 

### Sass Code

Ich habe den Sass Code soweit angepasst das Warnings/Errors nicht mehr auftauchen, also der `npm run dist` jetzt erfolgreich durchläuft. Der erzeugte CSS Code unterscheidet sich aber. Ob das ein Problem ist weiß ich noch nicht, da ich das Aussehen des Plugins mit dem neuen CSS Code noch nicht getetst habe.

Ich habe die Änderungen in der Commit Nachricht beschrieben. Der Branch geht nicht vom Master ab sondern vom Dependabot Pull.

### JS API

Es tauchen jetzt nur die Deprecations für die Verwendung der Legacy-JS API im [`grunt-dart-sass`](https://www.npmjs.com/package/grunt-dart-sass) Plugin auf. Ich glaube wir können auch das `grunt-sass` Plugin für `dart-sass` nutzen. Die Konfiguration im `Gruntfile` sieht auf den ersten Blick ähnlich aus. Da bin ich aber noch nicht im Detail drin. Die Deprecation wurde hier auch nur [per Repo-fremden Patch gelöst,](https://github.com/sindresorhus/grunt-sass/issues/311) und ist noch nicht gemerged.

Das von uns verwendete grunt-dart-sass Plugin ist vor [3 Jahren zuletzt geändert worden](https://github.com/laurenhamel/grunt-dart-sass) (Auf Issues aus der Zeit wurde auch nicht geantwortet, scheint also inaktiv. Den Patch von oben könnten wir hier sicher auch selber anwenden.
