### PR TITLE
Disable map styles that seem inactive

### DIFF
--- a/templates/map-admin-page-template.php
+++ b/templates/map-admin-page-template.php
@@ -31,8 +31,9 @@ use CommonsBooking\Wordpress\CustomPostType\Map;
                         <select name="cb_map_options[base_map]">
                             <option value="1" <?php echo  $selected_base_map == 1 ? 'selected' : '' ?>><?php echo commonsbooking_sanitizeHTML( __( 'OSM - mapnik' ,'commonsbooking')); ?></option>
                             <option value="2" <?php echo  $selected_base_map == 2 ? 'selected' : '' ?>><?php echo commonsbooking_sanitizeHTML( __( 'OSM - german style' ,'commonsbooking')); ?></option>
-                            <option value="3" <?php echo  $selected_base_map == 3 ? 'selected' : '' ?>><?php echo commonsbooking_sanitizeHTML( __( 'OSM - hike and bike' ,'commonsbooking')); ?></option>
-                            <option value="4" <?php echo  $selected_base_map == 4 ? 'selected' : '' ?>><?php echo commonsbooking_sanitizeHTML( __( 'OSM - lokaler (min. zoom: 9)' ,'commonsbooking')); ?></option>
+							<!-- Reenable the map styles if needed -->
+                            <!--<option value="3" <?php /* echo  $selected_base_map == 3 ? 'selected' : '' */ ?>><?php /* echo commonsbooking_sanitizeHTML( __( 'OSM - hike and bike' ,'commonsbooking')); */ ?></option>-->
+                            <!--<option value="4" <?php /* echo  $selected_base_map == 4 ? 'selected' : '' */ ?>><?php /* echo commonsbooking_sanitizeHTML( __( 'OSM - lokaler (min. zoom: 9)' ,'commonsbooking')); */ ?></option>-->
                         </select>
                     </td>
                 </tr>


### PR DESCRIPTION
Der Code für die unterschiedlichen Map style Feature der Karten ist leider etwas über verschiedene PHP/JS Files verteilt.

1. Die Anpassungen im Template habe ich hier im Pull commitet.
2. Die URLs der Styles sind hier im JS hinterlegt: https://github.com/wielebenwir/commonsbooking/blob/22ef5c84c210387240efe1f563672f4980f7efac/assets/map/js/cb-map-shortcode.js#L11
3. Die Validierung der int codes hier:
https://github.com/wielebenwir/commonsbooking/blob/22ef5c84c210387240efe1f563672f4980f7efac/src/Map/MapAdmin.php#L216

(2) und (3) habe ich vorerst mal drin gelassen, da aktuell glaube nicht klar ist ob die wieder rein kommen oder? Aber ich hätte auch nichts dagegen alles sauber umzusetzen. Was denkst du @hansmorb ?

Aber ansonsten wären die Code-Stellen (1), (2) und (3) auch relevant für die ausstehende Umsetzung von https://github.com/wielebenwir/commonsbooking/issues/1658