### PR TITLE
Add polyfill for PHP 8.0's `str_contains()` function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "scssphp/scssphp": "^1.11.1",
     "ext-json": "*",
     "symfony/cache": "^5.4.30",
+    "symfony/polyfill-php80": "^1.31",
     "symfony/service-contracts": "^v2.5.2",
     "eluceo/ical": "~2.14.0",
     "phpmailer/phpmailer": "^6.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cef4a58c672b31917fae588e87f7e67",
+    "content-hash": "aaa2b2b358360f59f165d28362c6d9e0",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -4780,13 +4780,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.3",
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Currently the PHP minimum requirement is 7.3+, but the function `str_contains` is used in the code.