### PR TITLE
Documents commonsbooking filter hooks

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -228,6 +228,16 @@ function commonsbooking_filter_from_cmb2( $field_args ) {
 	} else {
 		$filterName    = sprintf( 'commonsbooking_defaults_%s', $field_args['id'] );
 		$default_value = array_key_exists( 'default_value', $field_args ) ? $field_args['default_value'] : '';
+
+		/**
+		 * Default value for cmb2 fields.
+		 *
+		 * The last part of the filter is the cmb2 field id.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param mixed $default_value default value for the field.
+		 */
 		return apply_filters( $filterName, $default_value );
 	}
 }

--- a/includes/Template.php
+++ b/includes/Template.php
@@ -50,12 +50,12 @@ if ( ! function_exists( 'commonsbooking_get_template_part' ) ) {
 		/**
 		 * Allow 3rd party plugin filter template file from their plugin
 		 *
-		 * @param string template path
-		 * @param string slug
-		 * @param string name
-		 * @param string plugin slug
-		 *
 		 * @since 2.2.4
+		 *
+		 * @param string $template template path
+		 * @param string $slug slug
+		 * @param string $name name
+		 * @param string $plugin_slug plugin slug
 		 */
 		$template = apply_filters( 'commonsbooking_get_template_part', $template, $slug, $name, $plugin_slug );
 

--- a/includes/Template.php
+++ b/includes/Template.php
@@ -47,7 +47,16 @@ if ( ! function_exists( 'commonsbooking_get_template_part' ) ) {
 			$template = locate_template( array( "{$slug}.php", $plugin_slug . "{$slug}.php" ) );
 		}
 
-		// Allow 3rd party plugin filter template file from their plugin
+		/**
+		 * Allow 3rd party plugin filter template file from their plugin
+		 *
+		 * @param string template path
+		 * @param string slug
+		 * @param string name
+		 * @param string plugin slug
+		 *
+		 * @since 2.2.4
+		 */
 		$template = apply_filters( 'commonsbooking_get_template_part', $template, $slug, $name, $plugin_slug );
 
 		$has_post_thumbnail = ( has_post_thumbnail() ) ? 'has-post-thumbnail' : 'no-post-thumbnail'; // @TODO this feils because we have no global post anymore

--- a/includes/TemplateParser.php
+++ b/includes/TemplateParser.php
@@ -20,9 +20,20 @@ function commonsbooking_parse_template( string $template = '', $objects = [], $s
 		$template
 	);
 
-	// template is checked recursively to support templates tags within custom fields that are for example added to items or locations
-	// why? users can add e.g. inidvidual booking-mail texts per location by adding a custom field like 'custom_booking_message' and use all avaiable template tags within this custom field
+	// template is checked recursively to support templates tags within custom fields that are for example added
+	//  to items or locations
+	//
+	// why? users can add e.g. individual booking-mail texts per location by adding a custom field like
+	//  'custom_booking_message' and use all avaiable template tags within this custom field
 	if ( preg_match_all( '/{{.*?}}/', $template ) === 0 ) {
+		/**
+		 * Default template content
+		 *
+		 * @param string $template content of template after tag replacement
+		 *
+		 * @since 2.7.3 with commonsbooking prefix
+		 * @since 2.1.1
+		 */
 		return apply_filters( 'commonsbooking_template_tag', $template );
 	} else {
 		return commonsbooking_parse_template( $template, $objects, $sanitizeFunction );

--- a/includes/TemplateParser.php
+++ b/includes/TemplateParser.php
@@ -21,19 +21,19 @@ function commonsbooking_parse_template( string $template = '', $objects = [], $s
 	);
 
 	// template is checked recursively to support templates tags within custom fields that are for example added
-	//  to items or locations
+	// to items or locations
 	//
 	// why? users can add e.g. individual booking-mail texts per location by adding a custom field like
-	//  'custom_booking_message' and use all avaiable template tags within this custom field
+	// 'custom_booking_message' and use all avaiable template tags within this custom field
 	if ( preg_match_all( '/{{.*?}}/', $template ) === 0 ) {
 		/**
-		 * Default template content
-		 *
-		 * @param string $template content of template after tag replacement
-		 *
-		 * @since 2.7.3 with commonsbooking prefix
-		 * @since 2.1.1
-		 */
+		* Default template content
+		*
+		* @since 2.7.3 with commonsbooking prefix
+		* @since 2.1.1
+		*
+		* @param string $template content of template after tag replacement
+		*/
 		return apply_filters( 'commonsbooking_template_tag', $template );
 	} else {
 		return commonsbooking_parse_template( $template, $objects, $sanitizeFunction );

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -215,24 +215,42 @@ function commonsbooking_isUserAdmin( \WP_User $user ) {
  * @return bool
  */
 function commonsbooking_isUserCBManager( \WP_User $user ): bool {
-	return apply_filters( 'commonsbooking_isCurrentUserCBManager', in_array( Plugin::$CB_MANAGER_ID, $user->roles ), $user );
+	$isManager = ! empty( array_intersect( \CommonsBooking\Repository\UserRepository::getManagerRoles(), $user->roles ) );
+
+	/**
+	 * Default value if current user is cb manager.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param bool    $isManager true or false, if current user is cb manager
+	 * @param WP_User $user current user
+	 */
+	return apply_filters( 'commonsbooking_isCurrentUserCBManager', $isManager, $user );
 }
 
 // Check if current user has subscriber role
 function commonsbooking_isCurrentUserSubscriber() {
 	$user = wp_get_current_user();
 
-	return apply_filters( 'commonsbooking_isCurrentUserSubscriber', in_array( 'subscriber', $user->roles ), $user );
+	$isSubscriber = in_array( 'subscriber', $user->roles );
+	/**
+	 * Default value if current user is subscriber.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param bool    $isSubscriber true or false, if current user is subscriber
+	 * @param WP_User $user current user
+	 */
+	return apply_filters( 'commonsbooking_isCurrentUserSubscriber', $isSubscriber, $user );
 }
 
-// check if current user has CBManager role
+/**
+ * check if current user has CBManager role
+ *
+ * @return bool if is allowed
+ */
 function commonsbooking_isCurrentUserCBManager() {
-
-	$user = wp_get_current_user();
-
-	$isManager = ! empty( array_intersect( \CommonsBooking\Repository\UserRepository::getManagerRoles(), $user->roles ) );
-
-	return apply_filters( 'commonsbooking_isCurrentUserCBManager', $isManager, $user );
+	return commonsbooking_isUserCBManager( wp_get_current_user() );
 }
 
 /**

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -174,7 +174,17 @@ function commonsbooking_isCurrentUserAdmin() {
 		return false; }
 	$user = wp_get_current_user();
 
-	return apply_filters( 'commonsbooking_isCurrentUserAdmin', commonsbooking_isUserAdmin( $user ) );
+	$isAdmin = commonsbooking_isUserAdmin( $user );
+	/**
+	 * Default value if current user is admin.
+	 *
+	 * @since 2.10.0 add $user param
+	 * @since 2.4.3
+	 *
+	 * @param bool         $isAdmin true or false, if current user is admin
+	 * @param null|WP_User $user current user
+	 */
+	return apply_filters( 'commonsbooking_isCurrentUserAdmin', $isAdmin, $user );
 }
 
 /**

--- a/src/CB/CB.php
+++ b/src/CB/CB.php
@@ -50,10 +50,20 @@ class CB {
 		// If possible cast to CB Custom Post Type Model to get additional functions
 		$wpObject = Helper::castToCBCustomType( $wpObject, $key );
 
-		$result     = self::lookUp( $key, $property, $wpObject, $args, $sanitizeFunction );  // Find matching methods, properties or metadata
-		$filterName = sprintf( 'commonsbooking_tag_%s_%s', $key, $property );
+		// Find matching methods, properties or metadata
+		$result = self::lookUp( $key, $property, $wpObject, $args, $sanitizeFunction );
 
-		return apply_filters( $filterName, $result );
+		/**
+         * Default value for post type properties.
+		 * 
+         *`The dynamic part of the hook $key is the name of the post type and the $property is the name of the meta field.
+		 * 
+         * @since 2.7.1 refactored filter name from cb_tag_* to its current form
+		 * @since 2.1.1
+		 *
+		 * @param string|null
+		 */
+		return apply_filters( "commonsbooking_tag_{$key}_{$property}", $result );
 	}
 
 	/**

--- a/src/CB/CB.php
+++ b/src/CB/CB.php
@@ -27,7 +27,7 @@ class CB {
 	 * @param mixed            $args
 	 * @param callable         $sanitizeFunction The callable used to remove unwanted tags/characters (use default 'commonsbooking_sanitizeHTML' or 'sanitize_text_field')
 	 *
-	 * @return Property of (custom) post (sanitized) or null if not found
+	 * @return string|null property of (custom) post (sanitized) or null if not found
 	 * @throws Exception
 	 */
 	public static function get( $key, $property, $wpObject = null, $args = null, $sanitizeFunction = 'commonsbooking_sanitizeHTML' ) {
@@ -54,14 +54,15 @@ class CB {
 		$result = self::lookUp( $key, $property, $wpObject, $args, $sanitizeFunction );
 
 		/**
-         * Default value for post type properties.
-		 * 
-         *`The dynamic part of the hook $key is the name of the post type and the $property is the name of the meta field.
-		 * 
-         * @since 2.7.1 refactored filter name from cb_tag_* to its current form
+		 * Default value for post type properties.
+		 *
+		 * The dynamic part of the hook $key is the name of the post type and the $property is the name of the meta
+		 * field.
+		 *
+		 * @since 2.7.1 refactored filter name from cb_tag_* to its current form
 		 * @since 2.1.1
 		 *
-		 * @param string|null
+		 * @param string|null $result from property lookup
 		 */
 		return apply_filters( "commonsbooking_tag_{$key}_{$property}", $result );
 	}

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -56,7 +56,11 @@ class BookingCodesMessage extends Message {
 		if ( empty( $bookingCodes ) ) {
 			return $this->raiseError( __( 'Could not find booking codes for this timeframe/period', 'commonsbooking' ) );
 		}
-
+		/**
+		 * TODO
+		 *
+		 * @since 2.9.0
+		 */
 		$bookingTable = apply_filters(
 			'commonsbooking_emailcodes_rendertable',
 			\CommonsBooking\View\BookingCodes::renderBookingCodesTable( $bookingCodes ),
@@ -64,6 +68,11 @@ class BookingCodesMessage extends Message {
 			'email'
 		);
 
+		/**
+		 * TODO
+		 *
+		 * @since 2.9.0
+		 */
 		$bAddIcal   = apply_filters(
 			'commonsbooking_emailcodes_addical',
 			Settings::getOption( 'commonsbooking_options_bookingcodes', 'mail-booking-' . $this->action . '-attach-ical' ),

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -59,26 +59,18 @@ class BookingCodesMessage extends Message {
 
 		$bookingTable = \CommonsBooking\View\BookingCodes::renderTableFor( 'email', $bookingCodes );
 
+		$cb_settings_option = Settings::getOption( 'commonsbooking_options_bookingcodes', 'mail-booking-' . $this->action . '-attach-ical' );
 		/**
-		 * TODO
+		 * Default value (from option settings) whether adding the ical attachment to booking codes email.
 		 *
 		 * @since 2.9.0
-		 */
-		$bookingTable = apply_filters(
-			'commonsbooking_emailcodes_rendertable',
-			\CommonsBooking\View\BookingCodes::renderBookingCodesTable( $bookingCodes ),
-			$bookingCodes,
-			'email'
-		);
-
-		/**
-		 * TODO
 		 *
-		 * @since 2.9.0
+		 * @param bool $cb_settings_option
+		 * @param \CommonsBooking\Model\Timeframe $timeframe for which the booking codes are sent
 		 */
 		$bAddIcal   = apply_filters(
 			'commonsbooking_emailcodes_addical',
-			Settings::getOption( 'commonsbooking_options_bookingcodes', 'mail-booking-' . $this->action . '-attach-ical' ),
+			$cb_settings_option,
 			$timeframe
 		);
 		$attachment = $bAddIcal ? $this->getIcalAttachment( $bookingCodes ) : null;

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -207,31 +207,33 @@ class BookingCodesMessage extends Message {
 		$calendar = new iCalendar();
 
 		foreach ( $bookingCodes as $bookingCode ) {
+			$unfilteredTitle = $bookingCode->getItemName() . ' (' . $bookingCode->getCode() . ')';
 			/**
 			 * Default title of booking codes ical event
 			 *
-			 * @param string default title
-			 * @param BookingCode object
-			 *
 			 * @since 2.9.0
+			 *
+			 * @param string      $unfilteredTitle default title
+			 * @param BookingCode $bookingCode object
 			 */
-			$title = apply_filters(
-				'commonsbooking_emailcodes_icalevent_title',
-				$bookingCode->getItemName() . ' (' . $bookingCode->getCode() . ')',
-				$bookingCode
-			);
+			$title = apply_filters( 'commonsbooking_emailcodes_icalevent_title', $unfilteredTitle, $bookingCode );
 
+			$unfilteredDesc = sprintf(
+				__( 'booking code for item "%1$s": %2$s', 'commonsbooking' ),
+				$bookingCode->getItemName(),
+				$bookingCode->getCode()
+			);
 			/**
 			 * Default description of booking codes ical event
 			 *
-			 * @param string default description
-			 * @param BookingCode object
-			 *
 			 * @since 2.9.0
-			 */
+			 *
+			 * @param string      $unfilteredDesc default description
+			 * @param BookingCode $bookingCode object
+			*/
 			$desc = apply_filters(
 				'commonsbooking_emailcodes_icalevent_desc',
-				sprintf( __( 'booking code for item "%1$s": %2$s', 'commonsbooking' ), $bookingCode->getItemName(), $bookingCode->getCode() ),
+				$unfilteredDesc,
 				$bookingCode
 			);
 

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -198,12 +198,29 @@ class BookingCodesMessage extends Message {
 		$calendar = new iCalendar();
 
 		foreach ( $bookingCodes as $bookingCode ) {
+			/**
+			 * Default title of booking codes ical event
+			 *
+			 * @param string default title
+			 * @param BookingCode object
+			 *
+			 * @since 2.9.0
+			 */
 			$title = apply_filters(
 				'commonsbooking_emailcodes_icalevent_title',
 				$bookingCode->getItemName() . ' (' . $bookingCode->getCode() . ')',
 				$bookingCode
 			);
-			$desc  = apply_filters(
+
+			/**
+			 * Default description of booking codes ical event
+			 *
+			 * @param string default description
+			 * @param BookingCode object
+			 *
+			 * @since 2.9.0
+			 */
+			$desc = apply_filters(
 				'commonsbooking_emailcodes_icalevent_desc',
 				sprintf( __( 'booking code for item "%1$s": %2$s', 'commonsbooking' ), $bookingCode->getItemName(), $bookingCode->getCode() ),
 				$bookingCode

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -56,6 +56,9 @@ class BookingCodesMessage extends Message {
 		if ( empty( $bookingCodes ) ) {
 			return $this->raiseError( __( 'Could not find booking codes for this timeframe/period', 'commonsbooking' ) );
 		}
+
+		$bookingTable = \CommonsBooking\View\BookingCodes::renderTableFor( 'email', $bookingCodes );
+
 		/**
 		 * TODO
 		 *

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -59,18 +59,18 @@ class BookingCodesMessage extends Message {
 
 		$bookingTable = \CommonsBooking\View\BookingCodes::renderTableFor( 'email', $bookingCodes );
 
-		$cb_settings_option = Settings::getOption( 'commonsbooking_options_bookingcodes', 'mail-booking-' . $this->action . '-attach-ical' );
+		$cbSettingsOption = Settings::getOption( 'commonsbooking_options_bookingcodes', 'mail-booking-' . $this->action . '-attach-ical' );
 		/**
 		 * Default value (from option settings) whether adding the ical attachment to booking codes email.
 		 *
 		 * @since 2.9.0
 		 *
-		 * @param bool $cb_settings_option
+		 * @param bool $cbSettingsOption
 		 * @param \CommonsBooking\Model\Timeframe $timeframe for which the booking codes are sent
 		 */
 		$bAddIcal   = apply_filters(
 			'commonsbooking_emailcodes_addical',
-			$cb_settings_option,
+			$cbSettingsOption,
 			$timeframe
 		);
 		$attachment = $bAddIcal ? $this->getIcalAttachment( $bookingCodes ) : null;

--- a/src/Messages/LocationBookingReminderMessage.php
+++ b/src/Messages/LocationBookingReminderMessage.php
@@ -78,6 +78,15 @@ class LocationBookingReminderMessage extends Message {
 			]
 		);
 
+		/**
+		 * Default location booking reminder message
+		 *
+		 * @param LocationBookingReminderMessage object to be send.
+		 *
+		 * @return * TODO should return bool or object?
+		 *
+		 * @since 2.9.2
+		 */
 		$sendMessage = apply_filters( 'commonsbooking_before_send_location_reminder_mail', $this );
 		if ( $sendMessage ) {
 			$this->sendNotificationMail();

--- a/src/Messages/LocationBookingReminderMessage.php
+++ b/src/Messages/LocationBookingReminderMessage.php
@@ -78,16 +78,15 @@ class LocationBookingReminderMessage extends Message {
 			]
 		);
 
+		$sendMessageToBeFiltered = $this;
 		/**
 		 * Default location booking reminder message
 		 *
-		 * @param LocationBookingReminderMessage object to be send.
-		 *
-		 * @return * TODO should return bool or object?
-		 *
 		 * @since 2.9.2
+		 *
+		 * @param LocationBookingReminderMessage $sendMessageToBeFiltered object to be sent.
 		 */
-		$sendMessage = apply_filters( 'commonsbooking_before_send_location_reminder_mail', $this );
+		$sendMessage = apply_filters( 'commonsbooking_before_send_location_reminder_mail', $sendMessageToBeFiltered );
 		if ( $sendMessage ) {
 			$this->sendNotificationMail();
 		}

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -91,6 +91,15 @@ abstract class Message {
 	}
 
 	public function getTo() {
+		/**
+         * E-Mail message recipient
+		 *
+         * @since 2.7.3 refactored filter name from cb_mail_to
+		 * @since 2.1.1
+         * 
+		 * @param string email address recipient
+         * @param string email action (see valid actions of the implementing message class)
+		 */
 		return apply_filters( 'commonsbooking_mail_to', $this->to, $this->getAction() );
 	}
 
@@ -99,14 +108,40 @@ abstract class Message {
 	}
 
 	public function getSubject() {
+		/**
+         * E-Mail message subject
+		 *
+         * @since 2.7.3 refactored filter name from cb_mail_subject
+		 * @since 2.1.1
+         * 
+		 * @param string email subject
+         * @param string email action (see valid actions of the implementing message class)
+		 */
 		return apply_filters( 'commonsbooking_mail_subject', $this->subject, $this->getAction() );
 	}
 
 	public function getBody() {
+		/**
+         * E-Mail message body
+		 *
+         * @since 2.7.3 refactored filter name from cb_mail_body
+		 * @since 2.1.1
+         * 
+		 * @param string email body
+         * @param string email action (see valid actions of the implementing message class)
+		 */
 		return apply_filters( 'commonsbooking_mail_body', $this->body, $this->getAction() );
 	}
 
 	public function getAttachment(): array {
+		/**
+         * E-Mail attachment
+		 *
+         * @since 2.7.3
+         * 
+		 * @param array|null attachment
+         * @param string email action (see valid actions of the implementing message class)
+		 */
 		return apply_filters( 'commonsbooking_mail_attachment', $this->attachment, $this->getAction() );
 	}
 

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -90,59 +90,87 @@ abstract class Message {
 		return $this->action;
 	}
 
+	/**
+	 * Returns recipient address of the message.
+	 *
+	 * @return string|null
+	 */
 	public function getTo() {
+		$recipient     = $this->to;
+		$messageAction = $this->getAction();
 		/**
-         * E-Mail message recipient
-		 *
-         * @since 2.7.3 refactored filter name from cb_mail_to
-		 * @since 2.1.1
-         * 
-		 * @param string email address recipient
-         * @param string email action (see valid actions of the implementing message class)
-		 */
-		return apply_filters( 'commonsbooking_mail_to', $this->to, $this->getAction() );
+		* E-Mail message recipient
+		*
+		* @since 2.7.3 refactored filter name from cb_mail_to
+		* @since 2.1.1
+		*
+		* @param string $recipient email address recipient
+		* @param string $messageAction email action (see valid actions of the implementing message class)
+		*/
+		return apply_filters( 'commonsbooking_mail_to', $recipient, $messageAction );
 	}
 
 	public function getHeaders() {
 		return $this->headers;
 	}
 
+	/**
+	 * Subject of the email message.
+	 *
+	 * @return string|null
+	 */
 	public function getSubject() {
+		$subject       = $this->subject;
+		$messageAction = $this->getAction();
 		/**
-         * E-Mail message subject
+		 * E-Mail message subject
 		 *
-         * @since 2.7.3 refactored filter name from cb_mail_subject
+		 * @since 2.7.3 refactored filter name from cb_mail_subject
 		 * @since 2.1.1
-         * 
-		 * @param string email subject
-         * @param string email action (see valid actions of the implementing message class)
+		 *
+		 * @param string $subject email subject
+		 * @param string $messageAction email action (see valid actions of the implementing message class)
 		 */
-		return apply_filters( 'commonsbooking_mail_subject', $this->subject, $this->getAction() );
+		return apply_filters( 'commonsbooking_mail_subject', $subject, $messageAction );
 	}
 
+	/**
+	 * Return message body.
+	 *
+	 * @return string|null
+	 */
 	public function getBody() {
+		$body          = $this->body;
+		$messageAction = $this->getAction();
 		/**
-         * E-Mail message body
+		 * E-Mail message body
 		 *
-         * @since 2.7.3 refactored filter name from cb_mail_body
+		 * @since 2.7.3 refactored filter name from cb_mail_body
 		 * @since 2.1.1
-         * 
-		 * @param string email body
-         * @param string email action (see valid actions of the implementing message class)
+		 *
+		 * @param string $body email body
+		 * @param string $messageAction email action (see valid actions of the implementing message class)
 		 */
-		return apply_filters( 'commonsbooking_mail_body', $this->body, $this->getAction() );
+		return apply_filters( 'commonsbooking_mail_body', $body, $messageAction );
 	}
 
+	/**
+	 * Return array of attachment
+	 *
+	 * @return array
+	 */
 	public function getAttachment(): array {
+		$attachment    = $this->attachment;
+		$messageAction = $this->getAction();
 		/**
-         * E-Mail attachment
+		 * E-Mail attachment
 		 *
-         * @since 2.7.3
-         * 
-		 * @param array|null attachment
-         * @param string email action (see valid actions of the implementing message class)
+		 * @since 2.7.3
+		 *
+		 * @param array|null $attachment
+		 * @param string $messageAction email action (see valid actions of the implementing message class)
 		 */
-		return apply_filters( 'commonsbooking_mail_attachment', $this->attachment, $this->getAction() );
+		return apply_filters( 'commonsbooking_mail_attachment', $attachment, $messageAction );
 	}
 
 	/**

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -203,9 +203,9 @@ class Timeframe extends CustomPost {
 		/**
 		 * Default list of privilege roles
 		 *
-		 * @param string[] $privilegedRolesDefaults list of roles as strings that are privileged roles
-		 *
 		 * @since 2.9.0
+		 *
+		 * @param string[] $privilegedRolesDefaults list of roles as strings that are privileged roles
 		 */
 		$privilegedRoles = apply_filters( 'commonsbooking_privileged_roles', $privilegedRolesDefaults );
 		if ( ! empty( array_intersect( $privilegedRoles, $user->roles ) ) ) {

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -196,9 +196,18 @@ class Timeframe extends CustomPost {
 			return false;
 		}
 
+
+
 		// these roles are always allowed to book
-		$privilegedRoles = [ 'administrator' ];
-		apply_filters( 'commonsbooking_privileged_roles', $privilegedRoles );
+		$privilegedRolesDefaults = [ 'administrator' ];
+		/**
+		 * Default list of privilege roles
+		 *
+		 * @param string[] $privilegedRolesDefaults list of roles as strings that are privileged roles
+		 *
+		 * @since 2.9.0
+		 */
+		$privilegedRoles = apply_filters( 'commonsbooking_privileged_roles', $privilegedRolesDefaults );
 		if ( ! empty( array_intersect( $privilegedRoles, $user->roles ) ) ) {
 			return true;
 		}

--- a/src/Repository/Restriction.php
+++ b/src/Repository/Restriction.php
@@ -12,6 +12,13 @@ class Restriction extends PostRepository {
 	/**
 	 * Returns active restrictions.
 	 *
+	 * @param array       $locations one or more location ids to filter
+	 * @param array       $items     one or more item ids to filter
+	 * @param string|null $date if provided, filters restrictions to be valid on the given date
+	 * @param bool        $returnAsModel returns array of models instead of ids, default false (returns ids)
+	 * @param int         $minTimestamp if provided, returns restrictions where rep-end > min-timestamp. default null
+	 * @param string[]    $postStatus filters for given list of status, defaults to all WordPress post status enums
+	 *
 	 * @return \CommonsBooking\Model\Restriction[]
 	 * @throws Exception
 	 */
@@ -35,7 +42,7 @@ class Restriction extends PostRepository {
 				$posts = Wordpress::flattenWpdbResult( $posts );
 
 				// If there are locations or items to be filtered, we iterate through
-				// query result because wp_query is to slow for meta-querying them.
+				// query result because wp_query is too slow for meta-querying them.
 				if ( count( $locations ) || count( $items ) ) {
 					$posts = self::filterPosts( $posts, $locations, $items );
 				}
@@ -54,10 +61,11 @@ class Restriction extends PostRepository {
 	}
 
 	/**
-	 * Queries posts from db.
+	 * Queries restriction posts from db.
+	 * Only queries active restrictions.
 	 *
 	 * @param $date
-	 * @param $minTimestamp
+	 * @param $minTimestamp int checks if rep-end > minTimestamp (0:00)
 	 * @param $postStatus
 	 *
 	 * @return array|object|null

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -17,27 +17,38 @@ class UserRepository {
 		return get_users( [ 'role__in' => self::getManagerRoles() ] );
 	}
 
+	/**
+	 * Returns all valid roles that are considered by CommonsBooking as "Manager" roles.
+	 *
+	 * @return string[]
+	 */
 	public static function getManagerRoles(): array {
+		$manager_roles = [ Plugin::$CB_MANAGER_ID ];
 		/**
 		 * Default list of manager roles
 		 *
-		 * @since 2.8.3
+		 * @since 2.9.0
+		 *
+		 * @param string[] $manager_roles list of allowed manager roles that is returned by {@see UserRepository::getManagerRoles()}
 		 */
-		return apply_filters( 'commonsbooking_manager_roles', [ Plugin::$CB_MANAGER_ID ] );
+		return apply_filters( 'commonsbooking_manager_roles', $manager_roles );
 	}
 
 	/**
-	 * Will get all roles that are considered by CommonsBooking as "Administrator" roles
+	 * Returns all roles that are considered by CommonsBooking as "Administrator" roles.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function getAdminRoles(): array {
+		$admin_roles = [ 'administrator' ];
 		/**
 		 * Default list of admin roles
 		 *
 		 * @since 2.8.3
+		 *
+		 * @param string[] $admin_roles list of allowed admin roles that are returned by {@see UserRepository::getAdminRoles()}
 		 */
-		return apply_filters( 'commonsbooking_admin_roles', [ 'administrator' ] );
+		return apply_filters( 'commonsbooking_admin_roles', $admin_roles );
 	}
 
 	/**

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -23,15 +23,15 @@ class UserRepository {
 	 * @return string[]
 	 */
 	public static function getManagerRoles(): array {
-		$manager_roles = [ Plugin::$CB_MANAGER_ID ];
+		$managerRoles = [ Plugin::$CB_MANAGER_ID ];
 		/**
 		 * Default list of manager roles
 		 *
 		 * @since 2.9.0
 		 *
-		 * @param string[] $manager_roles list of allowed manager roles that is returned by {@see UserRepository::getManagerRoles()}
+		 * @param string[] $managerRoles list of allowed manager roles that is returned by {@see UserRepository::getManagerRoles()}
 		 */
-		return apply_filters( 'commonsbooking_manager_roles', $manager_roles );
+		return apply_filters( 'commonsbooking_manager_roles', $managerRoles );
 	}
 
 	/**
@@ -40,15 +40,15 @@ class UserRepository {
 	 * @return string[]
 	 */
 	public static function getAdminRoles(): array {
-		$admin_roles = [ 'administrator' ];
+		$adminRoles = [ 'administrator' ];
 		/**
 		 * Default list of admin roles
 		 *
 		 * @since 2.8.3
 		 *
-		 * @param string[] $admin_roles list of allowed admin roles that are returned by {@see UserRepository::getAdminRoles()}
+		 * @param string[] $adminRoles list of allowed admin roles that are returned by {@see UserRepository::getAdminRoles()}
 		 */
-		return apply_filters( 'commonsbooking_admin_roles', $admin_roles );
+		return apply_filters( 'commonsbooking_admin_roles', $adminRoles );
 	}
 
 	/**

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -18,6 +18,11 @@ class UserRepository {
 	}
 
 	public static function getManagerRoles(): array {
+		/**
+		 * Default list of manager roles
+		 *
+		 * @since 2.8.3
+		 */
 		return apply_filters( 'commonsbooking_manager_roles', [ Plugin::$CB_MANAGER_ID ] );
 	}
 
@@ -27,6 +32,11 @@ class UserRepository {
 	 * @return array
 	 */
 	public static function getAdminRoles(): array {
+		/**
+		 * Default list of admin roles
+		 *
+		 * @since 2.8.3
+		 */
 		return apply_filters( 'commonsbooking_admin_roles', [ 'administrator' ] );
 	}
 

--- a/src/Service/BookingRule.php
+++ b/src/Service/BookingRule.php
@@ -331,7 +331,7 @@ class BookingRule {
 		/**
 		 * Default list of booking rules that get applied before booking confirmation
 		 *
-		 * @param BookingRule[] list of booking rule objects
+		 * @param BookingRule[] $defaultRuleSet list of booking rule objects
 		 *
 		 * @since 2.9 bigger refactoring # TODO
 		 * @since 2.7.4

--- a/src/Service/BookingRule.php
+++ b/src/Service/BookingRule.php
@@ -328,6 +328,14 @@ class BookingRule {
 			),
 		];
 
+		/**
+		 * Default list of booking rules that get applied before booking confirmation
+		 *
+		 * @param BookingRule[] list of booking rule objects
+		 *
+		 * @since 2.9 bigger refactoring # TODO
+		 * @since 2.7.4
+		 */
 		return apply_filters( COMMONSBOOKING_PLUGIN_SLUG . '_booking-rules', $defaultRuleSet );
 	}
 

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -169,7 +169,7 @@ class Booking extends View {
 				$locationTitle = $location ? $booking->getLocation()->post_title : commonsbooking_sanitizeHTML( __( 'Not available', 'commonsbooking' ) );
 
 				// Prepare row data
-				// FIXME does this follow any common schema, which we already use when exposing this data?
+				// FIXME This untyped structure is exposed via the filter commonsbooking_booking_filter below, but the set of keys of the assoc array must not be changed. This is not ideal and should be either replace by a dedicated object type or removed entirely.
 				// If not, why not expose this as own type?
 				$rowData = [
 					'postID'             => $booking->ID,
@@ -237,6 +237,8 @@ class Booking extends View {
 					/**
 					 * Default assoc array of row data and the booking object, which gets added to the booking list data result.
 					 *
+					 * NOTE: Upon using this filter hook, the schema of associative array keys needs to be adhered to in order to not break the booking list.
+					 *
 					 * @since 2.7.3
 					 *
 					 * @param array                         $rowData assoc array of one row booking data
@@ -253,7 +255,7 @@ class Booking extends View {
 				$bookingDataArray['menu'] = ' <div class="cb-dropdown" style="float:right;"> <div id="cb-bookingdropbtn" class="cb-dropbtn"></div> <div class="cb-dropdown-content">' . $menuitems . '</div> </div>';
 			}
 
-			// TODO does this account for empty entries in data, when apply filters return empty booking object??? what purpose has the booking_filter?
+			// TODO remove null values from $bookingDataArray['data'] to not break pagination logic
 			if ( array_key_exists( 'data', $bookingDataArray ) && count( $bookingDataArray['data'] ) ) {
 				$totalCount                      = count( $bookingDataArray['data'] );
 				$bookingDataArray['total']       = $totalCount;

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -169,6 +169,7 @@ class Booking extends View {
 				$locationTitle = $location ? $booking->getLocation()->post_title : commonsbooking_sanitizeHTML( __( 'Not available', 'commonsbooking' ) );
 
 				// Prepare row data
+				// FIXME does this follow any schema?
 				$rowData = [
 					'postID'             => $booking->ID,
 					'startDate'          => $booking->getStartDate(),
@@ -251,6 +252,7 @@ class Booking extends View {
 				$bookingDataArray['menu'] = ' <div class="cb-dropdown" style="float:right;"> <div id="cb-bookingdropbtn" class="cb-dropbtn"></div> <div class="cb-dropdown-content">' . $menuitems . '</div> </div>';
 			}
 
+			// TODO does this account for empty entries in data, when apply filters return empty booking object??? what purpose has the booking_filter?
 			if ( array_key_exists( 'data', $bookingDataArray ) && count( $bookingDataArray['data'] ) ) {
 				$totalCount                      = count( $bookingDataArray['data'] );
 				$bookingDataArray['total']       = $totalCount;

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -169,7 +169,8 @@ class Booking extends View {
 				$locationTitle = $location ? $booking->getLocation()->post_title : commonsbooking_sanitizeHTML( __( 'Not available', 'commonsbooking' ) );
 
 				// Prepare row data
-				// FIXME does this follow any schema?
+				// FIXME does this follow any common schema, which we already use when exposing this data?
+				// If not, why not expose this as own type?
 				$rowData = [
 					'postID'             => $booking->ID,
 					'startDate'          => $booking->getStartDate(),
@@ -236,10 +237,10 @@ class Booking extends View {
 					/**
 					 * Default assoc array of row data and the booking object, which gets added to the booking list data result.
 					 *
-					 * @param array $rowData
-					 * @param \CommonsBooking\Model\Booking $booking
-					 *
 					 * @since 2.7.3
+					 *
+					 * @param array                         $rowData assoc array of one row booking data
+					 * @param \CommonsBooking\Model\Booking $booking booking model of one row booking data
 					 */
 					$bookingDataArray['data'][] = apply_filters( 'commonsbooking_booking_filter', $rowData, $booking );
 				}

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -231,6 +231,15 @@ class Booking extends View {
 				// If search term was submitted, filter for it.
 				if ( ! $search || count( preg_grep( '/.*' . $search . '.*/i', $rowData ) ) > 0 ) {
 					$rowData['actions']         = $actions;
+
+					/**
+					 * Default assoc array of row data and the booking object, which gets added to the booking list data result.
+					 *
+					 * @param array $rowData
+					 * @param \CommonsBooking\Model\Booking $booking
+					 *
+					 * @since 2.7.3
+					 */
 					$bookingDataArray['data'][] = apply_filters( 'commonsbooking_booking_filter', $rowData, $booking );
 				}
 			}

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -441,7 +441,7 @@ HTML;
 	/**
 	 * Renders HTML table of bookingCodes List.
 	 *
-	 * @param $bookingCodes array : CommonsBooking\Model\BookingCode
+	 * @param CommonsBooking\Model\BookingCode[] $bookingCodes list of booking codes
 	 *
 	 * @return string HTML table
 	 */

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -408,21 +408,8 @@ HTML;
                 </div>
                 <div class="cmb-td">';
 			if ( $timeframe->hasBookingCodes() ) {
-				/**
-				 * Default rendering of the booking code table.
-				 *
-				 * @param string rendering of booking codes list as html string
-				 * @param array $bookingCodes list of booking codes
-				 * @param string ?
-				 *
-				 * @since 2.9.0
-				 */
-				echo apply_filters(
-					'commonsbooking_emailcodes_rendertable',
-					self::renderBookingCodesTable( $bookingCodes ),
-					$bookingCodes,
-					'timeframe_form'
-				);
+				echo self::renderTableFor( 'timeframe_form', $bookingCodes );
+
 				echo '<br>';
 				echo '<p  class="cmb2-metabox-description">';
 					printf( __( 'Only showing booking codes for the next %s days.', 'commonsbooking' ), $bcToShow );
@@ -564,6 +551,31 @@ HTML;
 			commonsbooking_sanitizeHTML( __( 'An unknown error occured', 'commonsbooking' ) ),
 			commonsbooking_sanitizeHTML( __( 'Email booking codes', 'commonsbooking' ) ),
 			[ 'back_link' => true ]
+		);
+	}
+
+	/**
+	 * @param string                             $renderTarget code where email is rendered (email|timeframe_form)
+	 * @param CommonsBooking\Model\BookingCode[] $bookingCodes array of string booking codes
+	 *
+	 * @return string|null
+	 */
+	public static function renderTableFor( $renderTarget, $bookingCodes ) {
+		$renderedTable = self::renderBookingCodesTable( $bookingCodes );
+		/**
+		 * Default rendering of the booking code table in the specified target.
+		 *
+		 * @since 2.9.0
+		 *
+		 * @param string                             $renderedTable rendering of booking codes list as html string
+		 * @param CommonsBooking\Model\BookingCode[] $bookingCodes list of booking codes
+		 * @param string                             $renderTarget where email is rendered (email|timeframe_form)
+		 */
+		return apply_filters(
+			'commonsbooking_emailcodes_rendertable',
+			$renderedTable,
+			$bookingCodes,
+			$renderTarget
 		);
 	}
 }

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -408,6 +408,15 @@ HTML;
                 </div>
                 <div class="cmb-td">';
 			if ( $timeframe->hasBookingCodes() ) {
+				/**
+				 * Default rendering of the booking code table.
+				 *
+				 * @param string rendering of booking codes list as html string
+				 * @param array $bookingCodes list of booking codes
+				 * @param string ?
+				 *
+				 * @since 2.9.0
+				 */
 				echo apply_filters(
 					'commonsbooking_emailcodes_rendertable',
 					self::renderBookingCodesTable( $bookingCodes ),

--- a/src/Wordpress/CustomPostType/CustomPostType.php
+++ b/src/Wordpress/CustomPostType/CustomPostType.php
@@ -123,9 +123,9 @@ abstract class CustomPostType {
 		/**
 		 * Default list of cmb2 meta boxes definitions.
 		 *
-		 * @param array $metaDataFields of arrays with [id, name, type, desc] keys.
-		 *
 		 * @since 2.9.2
+		 *
+		 * @param array $metaDataFields of arrays with [id, name, type, desc] keys.
 		 */
 		$metaDataFields = apply_filters( 'commonsbooking_custom_metadata', $metaDataFields );
 

--- a/src/Wordpress/CustomPostType/CustomPostType.php
+++ b/src/Wordpress/CustomPostType/CustomPostType.php
@@ -120,7 +120,13 @@ abstract class CustomPostType {
 			}
 		}
 
-		// allows to programmatically add custom metaboxes
+		/**
+		 * Default list of cmb2 meta boxes definitions.
+		 *
+		 * @param array $metaDataFields of arrays with [id, name, type, desc] keys.
+		 *
+		 * @since 2.9.2
+		 */
 		$metaDataFields = apply_filters( 'commonsbooking_custom_metadata', $metaDataFields );
 
 		if ( array_key_exists( $type, $metaDataFields ) ) {

--- a/src/Wordpress/Widget/UserWidget.php
+++ b/src/Wordpress/Widget/UserWidget.php
@@ -38,15 +38,16 @@ class UserWidget extends WP_Widget {
 		echo commonsbooking_sanitizeHTML( $args['before_widget'] );
 
 		if ( ! empty( $instance['title'] ) ) {
+			$unfilteredTitle = $instance['title'];
 			/**
 			 * Default widget title
 			 *
-			 * @param string widget title
-			 *
 			 * @since 2.10.0 uses commonsbooking prefix
 			 * @since 2.4.0
+			 *
+			 * @param string $unfilteredTitle of the widget
 			 */
-			$title = apply_filters( 'commonsbooking_widget_title', $instance['title'] );
+			$title = apply_filters( 'commonsbooking_widget_title', $unfilteredTitle );
 			echo commonsbooking_sanitizeHTML( $args['before_title'] . $title . $args['after_title'] );
 		}
 

--- a/src/Wordpress/Widget/UserWidget.php
+++ b/src/Wordpress/Widget/UserWidget.php
@@ -38,7 +38,16 @@ class UserWidget extends WP_Widget {
 		echo commonsbooking_sanitizeHTML( $args['before_widget'] );
 
 		if ( ! empty( $instance['title'] ) ) {
-			echo commonsbooking_sanitizeHTML( $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'] );
+			/**
+			 * Default widget title
+			 *
+			 * @param string widget title
+			 *
+			 * @since 2.10.0 uses commonsbooking prefix
+			 * @since 2.4.0
+			 */
+			$title = apply_filters( 'commonsbooking_widget_title', $instance['title'] );
+			echo commonsbooking_sanitizeHTML( $args['before_title'] . $title . $args['after_title'] );
 		}
 
 		echo '<div class="textwidget">';


### PR DESCRIPTION
Since we now can support [checking the phpdocs for `apply_filters`.](https://github.com/szepeviktor/phpstan-wordpress?tab=readme-ov-file#usage-of-an-apply_filters-docblock).

This pull requests aims to add phpdoc for all filters provided by the commonsbooking plugin.
So we can benefit from statically type checking their interfaces.

These filters are missing phpdoc at the moment. And there are some TODOs left.
```
./includes/Users.php:41020:	return apply_filters( 'commonsbooking_isCurrentUserAdmin', commonsbooking_isUserAdmin( $user ) );
./includes/Users.php:41051:	return apply_filters( 'commonsbooking_isCurrentUserCBManager', in_array( Plugin::$CB_MANAGER_ID, $user->roles ), $user );
./includes/Users.php:41058:	return apply_filters( 'commonsbooking_isCurrentUserSubscriber', in_array( 'subscriber', $user->roles ), $user );
./includes/Users.php:41068:	return apply_filters( 'commonsbooking_isCurrentUserCBManager', $isManager, $user );
./includes/Admin.php:41422:		return apply_filters( $filterName, $default_value );
```