### PR TITLE
Plugin: Fix wp translation access

### DIFF
--- a/includes/Users.php
+++ b/includes/Users.php
@@ -127,7 +127,7 @@ add_filter(
 
 // Add filter to change post counts in admin lists for custom post types.
 foreach ( Plugin::getCustomPostTypes() as $custom_post_type ) {
-	add_filter( 'views_edit-' . $custom_post_type::getPostType(), 'commonsbooking_custom_view_count', 10, 1 );
+	add_filter( 'views_edit-' . $custom_post_type, 'commonsbooking_custom_view_count', 10, 1 );
 }
 
 // Filter function for fix of counts in admin lists for custom post types.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -91,14 +91,14 @@ class Plugin {
 		$CBManagerAllowedCPT = self::getCBManagerCustomPostTypes();
 		// Add capabilities for user roles
 		foreach ( $adminAllowedCPT as $customPostType ) {
-			self::addRoleCaps( $customPostType::$postType, 'administrator' );
+			self::addRoleCaps( $customPostType, 'administrator' );
 			// assign all capabilities of admin to CB-Manager (see comment above)
 			// We deliberately don't use the getManagerRoles from the UserRepository here, because the custom roles should be able to define their own permissions
-			self::addRoleCaps( $customPostType::$postType, self::$CB_MANAGER_ID );
+			self::addRoleCaps( $customPostType, self::$CB_MANAGER_ID );
 		}
 		/*
 		foreach ( $CBManagerAllowedCPT as $customPostType ) {
-			self::addRoleCaps( $customPostType::$postType, self::$CB_MANAGER_ID );
+			self::addRoleCaps( $customPostType, self::$CB_MANAGER_ID );
 		}
 		*/
 	}
@@ -157,17 +157,75 @@ class Plugin {
 	 * When defining a CustomPostType, you must also define a model for it, which extends the CustomPost class.
 	 * The existence of a model is checked in the @see PluginTest::testGetCustomPostTypes() test.
 	 *
-	 * @return CustomPostType[]
+	 * @see Plugin::getCustomPostTypeClasses()
+	 *
+	 * @since 2.10.3 only returns custom post type enum string
+	 *
+	 * @return string[] enum array
 	 */
 	public static function getCustomPostTypes(): array {
+
+		return array_map(
+			function ( $type ) {
+				return ( $type )::getPostType();
+			},
+			self::getCustomPostTypeClasses()
+		);
+	}
+
+	/**
+	 * @return class-string<CustomPostType>[] class array
+	 */
+	private static function getCustomPostTypeClasses() {
 		return [
-			new Item(),
-			new Location(),
-			new Timeframe(),
-			new Map(),
-			new \CommonsBooking\Wordpress\CustomPostType\Booking(),
-			new Restriction(),
+			\CommonsBooking\Wordpress\CustomPostType\Item::class,
+			\CommonsBooking\Wordpress\CustomPostType\Location::class,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::class,
+			\CommonsBooking\Wordpress\CustomPostType\Map::class,
+			\CommonsBooking\Wordpress\CustomPostType\Booking::class,
+			\CommonsBooking\Wordpress\CustomPostType\Restriction::class,
 		];
+	}
+
+	/**
+	 * @return CustomPostType[] instantiated objects
+	 */
+	public static function getCustomPostTypeObjects() {
+		return array_map(
+			function ( $type ) {
+				return new $type();
+			},
+			self::getCustomPostTypeClasses()
+		);
+	}
+
+
+	/**
+	 * Same as {@see Plugin::getCustomPostTypes()}
+	 *
+	 * @return string[] enum array
+	 */
+	public static function getCBManagerCustomPostTypes() {
+		return array_map(
+			function ( $type ) {
+				return $type::getPostType();
+			},
+			self::getCBManagerCustomPostTypeClasses()
+		);
+	}
+
+	/**
+	 * Instantiated custom post type objects
+	 *
+	 * @return CustomPostType[]
+	 */
+	public static function getCBManagerCustomPostTypesObjects() {
+		return array_map(
+			function ( $type ) {
+				return new $type();
+			},
+			self::getCBManagerCustomPostTypeClasses()
+		);
 	}
 
 	/**
@@ -193,15 +251,15 @@ class Plugin {
 	/**
 	 * Returns only custom post types, which are allowed for cb manager
 	 *
-	 * @return array
+	 * @return class-string<CustomPostType>[] array of classes
 	 */
-	public static function getCBManagerCustomPostTypes(): array {
+	private static function getCBManagerCustomPostTypeClasses(): array {
 		return [
-			new Item(),
-			new Location(),
-			new Timeframe(),
-			new \CommonsBooking\Wordpress\CustomPostType\Booking(),
-			new Restriction(),
+			\CommonsBooking\Wordpress\CustomPostType\Item::class,
+			\CommonsBooking\Wordpress\CustomPostType\Location::class,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::class,
+			\CommonsBooking\Wordpress\CustomPostType\Booking::class,
+			\CommonsBooking\Wordpress\CustomPostType\Restriction::class,
 		];
 	}
 
@@ -289,7 +347,7 @@ class Plugin {
 		);
 
 		// Custom post types
-		$customPostTypes = commonsbooking_isCurrentUserAdmin() ? self::getCustomPostTypes() : self::getCBManagerCustomPostTypes();
+		$customPostTypes = commonsbooking_isCurrentUserAdmin() ? self::getCustomPostTypeObjects() : self::getCBManagerCustomPostTypesObjects();
 		foreach ( $customPostTypes as $cbCustomPostType ) {
 			$params = $cbCustomPostType->getMenuParams();
 			add_submenu_page(
@@ -398,7 +456,7 @@ class Plugin {
 	 * Registers custom post types.
 	 */
 	public static function registerCustomPostTypes() {
-		foreach ( self::getCustomPostTypes() as $customPostType ) {
+		foreach ( self::getCustomPostTypeObjects() as $customPostType ) {
 			$cptArgs = $customPostType->getArgs();
 			// make export possible when using WP_DEBUG, this allows us to use the export feature for creating new E2E tests
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -948,7 +1006,7 @@ class Plugin {
 		// Set 'cb-dashboard' as parent for cb post types
 		if ( in_array( $current_screen->base, array( 'post', 'edit' ) ) ) {
 			foreach ( self::getCustomPostTypes() as $customPostType ) {
-				if ( $customPostType::getPostType() === $current_screen->post_type ) {
+				if ( $customPostType === $current_screen->post_type ) {
 					return 'cb-dashboard';
 				}
 			}
@@ -983,7 +1041,7 @@ class Plugin {
 		// Check if we're inside the main loop in a single post page.
 		if ( is_single() && in_the_loop() && is_main_query() ) {
 			global $post;
-			foreach ( self::getCustomPostTypes() as $customPostType ) {
+			foreach ( self::getCustomPostTypeClasses() as $customPostType ) {
 				if ( $customPostType::getPostType() === $post->post_type ) {
 					return $content . $customPostType::getView()::content( $post );
 				}

--- a/tests/php/PluginTest.php
+++ b/tests/php/PluginTest.php
@@ -18,8 +18,8 @@ class PluginTest extends CustomPostTypeTest {
 			// first, create a post of this type
 			$post = wp_insert_post(
 				[
-					'post_type' => $customPostType::getPostType(),
-					'post_title' => 'Test ' . $customPostType::getPostType(),
+					'post_type' => $customPostType,
+					'post_title' => 'Test ' . $customPostType,
 					'post_status' => 'publish',
 				]
 			);


### PR DESCRIPTION
Closes #1710 

Before, it unnecessarily initialized all CustomPostType classes, even when static access was sufficient.

Now uses static access on $postType variable

* Refactors methods to use class-string based lists instead of objects of custom post types.