### PR TITLE
fix crash in warmupCache() when processing (fixes #1723)

### DIFF
--- a/src/Map/BaseShortcode.php
+++ b/src/Map/BaseShortcode.php
@@ -17,7 +17,7 @@ abstract class BaseShortcode {
 	 * @param array  $atts attributes for parametrization.
 	 * @param string $content content to display, if shortcode implementation allows to.
 	 **/
-	public static function execute( array $atts, string $content ): string {
+	public static function execute( array $atts, string $content = "" ): string {
 		$instance = new static();
 		$attrs = $instance->parse_attributes($atts);
 		$options = array_filter($atts, "is_int", ARRAY_FILTER_USE_KEY);


### PR DESCRIPTION
warmupCache() calls BaseShortcode::execute() when processing a cb_map shortcode, but passes just one parameter even if BaseShortcode::execute() needed two. Added empty default value to second parameter ($content is irrelevant for cb_map) so execute() can be called with just one parameter.