### PR TITLE
Workaround for #1724: Prevent admin.js from executing on invalid end pages

### DIFF
--- a/assets/admin/js/admin.js
+++ b/assets/admin/js/admin.js
@@ -5,6 +5,21 @@
         let startTimeInput = $("#repetition-start_time");
         let endTimeInput = $("#repetition-end_time");
         let preserveManualCode = false;
+        let itemInput = $("#item-id");
+        let locationInput = $("#location-id");
+        let startDateInput = $("#repetition-start_date");
+        let bookingCodeInput = $("#_cb_bookingcode");
+
+        // check if this is loaded on right kind of backend page
+        let allExist = [
+                fullDayCheckbox, startTimeInput, endTimeInput, itemInput, locationInput, startDateInput, bookingCodeInput
+        ].every(domElement => domElement.length === 1);
+
+        if (!allExist) {
+            // return early to prevent ajax calls with incorrect parameters
+            return;
+        }
+
         fullDayCheckbox.on("change", function(event) {
             if (fullDayCheckbox.is(":checked")) {
                 startTimeInput.val("00:00");
@@ -17,10 +32,6 @@
             }
         });
         fullDayCheckbox.trigger("change");
-        let itemInput = $("#item-id");
-        let locationInput = $("#location-id");
-        let startDateInput = $("#repetition-start_date");
-        let bookingCodeInput = $("#_cb_bookingcode");
         itemInput.on("change", function(event) {
             let data = {
                 itemID: itemInput.val()

--- a/assets/admin/js/src/booking.js
+++ b/assets/admin/js/src/booking.js
@@ -5,6 +5,21 @@
         let startTimeInput = $('#repetition-start_time');
         let endTimeInput = $('#repetition-end_time');
         let preserveManualCode = false;
+        let itemInput = $('#item-id');
+        let locationInput = $('#location-id');
+        let startDateInput = $('#repetition-start_date');
+        let bookingCodeInput = $('#_cb_bookingcode');
+
+        // check if this is loaded on right kind of backend page
+        let allExist = [
+                fullDayCheckbox, startTimeInput, endTimeInput, itemInput, locationInput, startDateInput, bookingCodeInput
+        ].every(domElement => domElement.length === 1);
+
+        if (!allExist) {
+            // return early to prevent ajax calls with incorrect parameters
+            return;
+        }
+
         fullDayCheckbox.on('change', function (event) {
             if (fullDayCheckbox.is(':checked')) {
                 startTimeInput.val('00:00');
@@ -17,12 +32,6 @@
             }
         });
         fullDayCheckbox.trigger('change');
-
-
-        let itemInput = $('#item-id');
-        let locationInput = $('#location-id');
-        let startDateInput = $('#repetition-start_date');
-        let bookingCodeInput = $('#_cb_bookingcode');
 
         itemInput.on('change', function (event) {
             let data = {


### PR DESCRIPTION
This prevents malformed AJAX calls and avoids weird errors in the php log.
Instead, an "early return" and a javascript console warning are implemented. The solution is not 100% satisfactory. An ultimate solution would make sure that only relevant admin.js code is enqueued for a certain backend admin page and that would make this early return unnecessary.
We can discuss a better solution. I would be open to implement that as well.