### PR TITLE
Add phpcbf check workflow

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,6 @@
 
 # Apply phpcbf to commonsbooking.php
 f8bdfd6d5d595f22d7c0345a2eb35571343ed134
+
+# Apply last time before automatic action
+102673ed5e3e2969090ce754aa97dde88bc7377d

--- a/.github/workflows/phpcbf-check.yml
+++ b/.github/workflows/phpcbf-check.yml
@@ -1,0 +1,41 @@
+name: PHP Code Beautifier Check
+
+on:
+  push:
+    paths:
+      - '**/*.php'
+  pull_request:
+    paths:
+      - '**/*.php'
+  workflow_dispatch:
+
+
+jobs:
+  phpcbf-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'  # Adjust this to your PHP version
+          extensions: uopz
+
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
+
+      - name: Run phpcbf
+        run: ./vendor/bin/phpcbf -q --parallel=1 src templates includes tests commonsbooking.php
+
+      - name: Verify code style is unchanged
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "ERROR: phpcbf made changes. Please run phpcbf locally and commit the fixes."
+            exit 1
+          else
+            echo "Code style is compliant."
+          fi

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -1,5 +1,14 @@
 ### Formatter
 
+We adhere to [PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer) rules defined in the [phpcs.xml](https://github.com/wielebenwir/commonsbooking/blob/master/.phpcs.xml.dist) rules file, as  it is a mature tool and well established in the Wordpress-Plugin development scene.
+A program to apply auto-formattable rules of PHPCS is `phpcbf` and we encourage everyone
+to configure this tool in their IDE so that contribution commits consist of properly formatted code.
+Both are already in the dev dependencies of the repository code.
+
+We have an automatic check [as Github Action](https://github.com/wielebenwir/commonsbooking/tree/master/.github/workflows/phpcbf-check.yml) in our CI/CD-Pipeline, which prevents code contributions that not adhere to the rules.
+
+#### Ignore formatter revisions
+
 We use .git-blame-ignore-revs to track repo-wide cosmetic refactorings by auto format tools like prettier/phpcbf.
 See [Github Documentation](https://docs.github.com/de/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view)
 

--- a/src/Map/BaseShortcode.php
+++ b/src/Map/BaseShortcode.php
@@ -17,7 +17,7 @@ abstract class BaseShortcode {
 	 * @param array  $atts attributes for parametrization.
 	 * @param string $content content to display, if shortcode implementation allows to.
 	 **/
-	public static function execute( array $atts, string $content = "" ): string {
+	public static function execute( array $atts, string $content = '' ): string {
 		$instance = new static();
 		$attrs    = $instance->parse_attributes( $atts );
 		$options  = array_filter( $atts, 'is_int', ARRAY_FILTER_USE_KEY );

--- a/src/Map/MapFilter.php
+++ b/src/Map/MapFilter.php
@@ -2,7 +2,6 @@
 
 namespace CommonsBooking\Map;
 
-
 class MapFilter {
 
 	protected static function check_item_terms_against_categories( $item_terms, $category_groups ): bool {

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -325,7 +325,7 @@ abstract class Message {
 		if ( ! empty( $atts['attachments'] ) ) {
 			$attachments = $atts['attachments'];
 			if ( is_array( $attachments ) ) {
-				// Is the $attachments array a single array of attachment data, or an array containing multiple arrays of 
+				// Is the $attachments array a single array of attachment data, or an array containing multiple arrays of
 				// attachment data? (note that the array may also be a one-dimensional array of file paths, as-per default usage).
 				$is_multidimensional_array = count( $attachments ) == count( $attachments, COUNT_RECURSIVE ) ? false : true;
 				if ( ! $is_multidimensional_array ) {

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -196,8 +196,6 @@ class Timeframe extends CustomPost {
 			return false;
 		}
 
-
-
 		// these roles are always allowed to book
 		$privilegedRolesDefaults = [ 'administrator' ];
 		/**

--- a/src/Service/MassOperations.php
+++ b/src/Service/MassOperations.php
@@ -30,7 +30,7 @@ class MassOperations {
 		} else {
 			$result = array(
 				'success' => false,
-				'message' => empty( $errorMessage ) ?? __( 'An error occurred while moving bookings.', 'commonsbooking' )
+				'message' => empty( $errorMessage ) ?? __( 'An error occurred while moving bookings.', 'commonsbooking' ),
 			);
 		}
 

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -232,7 +232,7 @@ class Booking extends View {
 
 				// If search term was submitted, filter for it.
 				if ( ! $search || count( preg_grep( '/.*' . $search . '.*/i', $rowData ) ) > 0 ) {
-					$rowData['actions']         = $actions;
+					$rowData['actions'] = $actions;
 
 					/**
 					 * Default assoc array of row data and the booking object, which gets added to the booking list data result.

--- a/tests/php/Wordpress/CustomPostType/TimeframeTest.php
+++ b/tests/php/Wordpress/CustomPostType/TimeframeTest.php
@@ -47,9 +47,9 @@ class TimeframeTest extends CustomPostTypeTest {
 		$this->createCBManager();
 		$this->createAdministrator();
 		wp_set_current_user( $this->adminUserID );
-		$this->assertCount(3,  Timeframe::getSelectionOptions() );
+		$this->assertCount( 3, Timeframe::getSelectionOptions() );
 		wp_set_current_user( $this->cbManagerUserID );
-		$this->assertCount(1,  Timeframe::getSelectionOptions() );
+		$this->assertCount( 1, Timeframe::getSelectionOptions() );
 	}
 
 	public function testGetGridOptions() {


### PR DESCRIPTION
After running phpcbf on our codebase (#1730), this adds an automatic check, if we have any code format violations in future prs and suggests running phpcbf by the user.

Additionally I think it would be more comfortable for contributors to have an pre-commit hook, that checks if phpcbf should be run.

TODO
* [ ] We should document our formatting practices in the README/TECHNICAL readme.