### PR TITLE
View/Booking: Adds an null/assoc check for results of the commonsbooking_booking_filter

### DIFF
--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -244,14 +244,14 @@ class Booking extends View {
 					 * NOTE: Upon using this filter hook, the schema of associative array keys needs to be adhered to in order to not break the booking list.
 					 * See $rowData in this function, for the valid keys.
 					 *
-					 * @since 2.7.3
-					 *
-					 * @param array                         $rowData assoc array of one row booking data
+					 * @param array|mixed|null              $rowData assoc array of one row booking data
 					 * @param \CommonsBooking\Model\Booking $booking booking model of one row booking data
+					 *
+					 *@since 2.7.3
 					 */
 					$filteredRowData = apply_filters( 'commonsbooking_booking_filter', $rowData, $booking );
 
-					// Only includes valid row data objects
+					// Only includes non-null array row data objects
 					if ( isset( $filteredRowData ) && is_array( $filteredRowData ) ) {
 						if ( WP_DEBUG ) {
 							// Logs absent keys, relative to the original row data keys, could cause problems

--- a/tests/php/View/BookingTest.php
+++ b/tests/php/View/BookingTest.php
@@ -67,7 +67,8 @@ final class BookingTest extends CustomPostTypeTest {
 		remove_filter( 'commonsbooking_booking_filter', $simpleFilter );
 	}
 
-	/* TODO implement more complex test (to test keys of rowData as input/filter and as output via getBookingListData
+	/*
+	TODO implement more complex test (to test keys of rowData as input/filter and as output via getBookingListData
 	public function testGetBookingListData_withComplexRowDataFilter() {
 
 	}


### PR DESCRIPTION
This adds an null/assoc-array check for the result of the commonsbooking_booking_filter.

It also adds WP_DEBUG logging entry in case there are absent keys (relative to the original rowData array keys).
