### PR TITLE
fix cb-manager can't access blocked timeframes (#1784)

### DIFF
--- a/src/Wordpress/CustomPostType/Timeframe.php
+++ b/src/Wordpress/CustomPostType/Timeframe.php
@@ -415,38 +415,6 @@ class Timeframe extends CustomPostType {
 					'compare' => '<=',
 				);
 			}
-
-			// Check if current user is allowed to see posts
-			if ( ! commonsbooking_isCurrentUserAdmin() ) {
-				$locations = \CommonsBooking\Repository\Location::getByCurrentUser();
-				array_walk(
-					$locations,
-					function ( &$item, $key ) {
-						$item = $item->ID;
-					}
-				);
-				$items = \CommonsBooking\Repository\Item::getByCurrentUser();
-				array_walk(
-					$items,
-					function ( &$item, $key ) {
-						$item = $item->ID;
-					}
-				);
-
-				$query->query_vars['meta_query'][] = array(
-					'relation' => 'OR',
-					array(
-						'key'     => \CommonsBooking\Model\Timeframe::META_LOCATION_ID,
-						'value'   => $locations,
-						'compare' => 'IN',
-					),
-					array(
-						'key'     => \CommonsBooking\Model\Timeframe::META_ITEM_ID,
-						'value'   => $items,
-						'compare' => 'IN',
-					),
-				);
-			}
 		}
 	}
 


### PR DESCRIPTION
The cause of the issue is, that "Blocked" timeframes save the affected items / locations in the item-id-list and location-id-list meta key, which contain a serialized array. This means, that this query to filter who is eligible:

https://github.com/wielebenwir/commonsbooking/blob/aac5d15e28bbab6594f500701eccc3e0ac674a96/src/Wordpress/CustomPostType/Timeframe.php#L436-L448

won't work anymore. This query uses the pre_get_posts filter to manipulate the WP_Query object before the posts are fetched. We could now add our queries for the ****-id-list meta fields onto the WP_Query. But unfortunately, using WP_Query on the ****-id-list meta field is not an option because it is saved as a serialized array. Doing comparisons with 'LIKE'  on serialized array can lead to unexpected behavior (See here: https://wordpress.stackexchange.com/questions/344886/meta-query-check-for-meta-value-in-key-which-holds-an-array-of-values ) . We need to therefore FIRST fetch all timeframes and THEN filter out the timeframes the cb_manager is not allowed to see using a hook that is ran after the posts are retrieved (like the_posts).

Fortunately, there is already a system in place to filter out posts, that the cb_manager should not see. It lives in the includes/Users.php 

https://github.com/wielebenwir/commonsbooking/blob/aac5d15e28bbab6594f500701eccc3e0ac674a96/includes/Users.php#L90-L126

and is generally applicable to all post types. Therefore, removing the extra meta query on the pre_get_posts fixes the issue. This fix has only been briefly tested.

@gundelfisch , do you have some time to look at it and see if there are any other issues arising from this fix?

closes #1784