### PR TITLE
Increase phpstan level 3

### DIFF
--- a/includes/Users.php
+++ b/includes/Users.php
@@ -332,7 +332,7 @@ function commonsbooking_isUserAllowedToSee( $post, WP_User $user ): bool {
 	$isAdmin   = commonsbooking_isUserAdmin( $user );
 	$isAllowed = $isAdmin || $isAuthor;
 
-	if ( ! $isAllowed ) {
+	if ( ! $isAllowed && method_exists( $postModel, 'getAdmins' ) ) {
 		$admins    = $postModel->getAdmins();
 		$isAllowed = ( is_string( $admins ) && $user->ID == $admins ) ||
 					( is_array( $admins ) && in_array( $user->ID, $admins, true ) );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
     - commonsbooking.php
     - src/
     - includes/
-  level: 2
+  level: 3
   ignoreErrors:
     - '#Constant (COMMONSBOOKING.*|WP_DEBUG_LOG) not found.#'
 #    - '#Instantiated class (CommonsBooking.*CB_Data) not found.#'

--- a/src/API/GBFS/StationInformation.php
+++ b/src/API/GBFS/StationInformation.php
@@ -7,6 +7,7 @@ use CommonsBooking\Helper\GeoHelper;
 use CommonsBooking\Model\Location;
 use Exception;
 use stdClass;
+use WP_REST_Response;
 
 class StationInformation extends BaseRoute {
 
@@ -28,11 +29,11 @@ class StationInformation extends BaseRoute {
 	 * @param $item Location
 	 * @param $request
 	 *
-	 * @return stdClass
+	 * @return WP_REST_Response
 	 * @throws \Geocoder\Exception\Exception
 	 * @throws Exception
 	 */
-	public function prepare_item_for_response( $item, $request ): stdClass {
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem                   = new stdClass();
 		$preparedItem->station_id       = $item->ID . '';
 		$preparedItem->name             = $item->post_title;
@@ -82,6 +83,6 @@ class StationInformation extends BaseRoute {
 			}
 		}
 
-		return $preparedItem;
+		return new WP_REST_Response( $preparedItem );
 	}
 }

--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -8,6 +8,7 @@ use CommonsBooking\Model\Day;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Repository\Item;
 use stdClass;
+use WP_REST_Response;
 
 class StationStatus extends BaseRoute {
 
@@ -29,10 +30,10 @@ class StationStatus extends BaseRoute {
 	 * @param Location $item
 	 * @param $request
 	 *
-	 * @return stdClass
+	 * @return WP_REST_Response
 	 * @throws \Exception
 	 */
-	public function prepare_item_for_response( $item, $request ): stdClass {
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem                      = new stdClass();
 		$preparedItem->station_id          = $item->ID . '';
 		$preparedItem->num_bikes_available = $this->getItemCountAtLocation( $item->ID );
@@ -41,7 +42,7 @@ class StationStatus extends BaseRoute {
 		$preparedItem->is_returning        = true;
 		$preparedItem->last_reported       = time();
 
-		return $preparedItem;
+		return new WP_REST_Response( $preparedItem );
 	}
 
 	/**

--- a/src/API/ItemsRoute.php
+++ b/src/API/ItemsRoute.php
@@ -121,9 +121,9 @@ class ItemsRoute extends BaseRoute {
 	 * @param mixed           $item
 	 * @param WP_REST_Request $request
 	 *
-	 * @return stdClass
+	 * @return WP_REST_Response
 	 */
-	public function prepare_item_for_response( $item, $request ): stdClass {
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem              = new stdClass();
 		$preparedItem->id          = $item->ID . '';
 		$preparedItem->name        = $item->post_title;
@@ -142,6 +142,6 @@ class ItemsRoute extends BaseRoute {
 			];
 		}
 
-		return $preparedItem;
+		return new WP_REST_Response( $preparedItem );
 	}
 }

--- a/src/API/LocationsRoute.php
+++ b/src/API/LocationsRoute.php
@@ -108,10 +108,10 @@ class LocationsRoute extends BaseRoute {
 	 * @param $item Location
 	 * @param $request
 	 *
-	 * @return stdClass
+	 * @return WP_REST_Response
 	 * @throws \Geocoder\Exception\Exception
 	 */
-	public function prepare_item_for_response( $item, $request ) {
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem             = new stdClass();
 		$preparedItem->type       = 'Feature';
 		$preparedItem->properties = new stdClass();
@@ -157,6 +157,6 @@ class LocationsRoute extends BaseRoute {
 			}
 		}
 
-		return $preparedItem;
+		return new WP_REST_Response( $preparedItem );
 	}
 }

--- a/src/API/OwnersRoute.php
+++ b/src/API/OwnersRoute.php
@@ -8,6 +8,7 @@ use stdClass;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_User;
 
 /**
  * Endpoint for item/location owners data
@@ -51,7 +52,13 @@ class OwnersRoute extends BaseRoute {
 		return $data;
 	}
 
-	public function prepare_item_for_response( $owner, $request ): stdClass {
+	/**
+	 * @param WP_User         $owner
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $owner, $request ): WP_REST_Response {
 		$ownerObject       = new stdClass();
 		$ownerObject->id   = '' . $owner->ID;
 		$ownerObject->name = get_user_meta( $owner->ID, 'first_name', true ) . ' ' . get_user_meta( $owner->ID, 'last_name', true );
@@ -72,7 +79,7 @@ class OwnersRoute extends BaseRoute {
 		// $ownerObject->locations[] = $locationsRoute->prepare_item_for_response($location, new \WP_REST_Request());
 		// }
 		// }
-		return $ownerObject;
+		return new WP_REST_Response( $ownerObject );
 	}
 
 
@@ -103,7 +110,10 @@ class OwnersRoute extends BaseRoute {
 		return new WP_REST_Response( $data, 200 );
 	}
 
+	/**
+	 * TODO investigate why we overwrite this method
+	 */
 	public function prepare_response_for_collection( $itemdata ) {
-		return $itemdata;
+		return $itemdata; // @phpstan-ignore return.type
 	}
 }

--- a/src/Map/MapData.php
+++ b/src/Map/MapData.php
@@ -265,24 +265,27 @@ class MapData {
 		if ( $map->getMeta( 'cb_items_available_categories' ) ) {
 			$settings['filter_cb_item_categories'] = [];
 
-			foreach ( $map->getMeta( 'filtergroups' ) as $groupID => $group ) {
-				$elements = [];
-				foreach ( $group['categories'] as $termID ) {
-					$term         = get_term( $termID );
-					$customMarkup = get_term_meta( $termID, COMMONSBOOKING_METABOX_PREFIX . 'markup', true );
-					$termName     = empty( $customMarkup ) ? $term->name : $customMarkup;
+			$filterGroups = $map->getMeta( 'filtergroups' );
+			if ( is_array( $filterGroups ) ) {
+				foreach ( $filterGroups as $groupID => $group ) {
+					$elements = [];
+					foreach ( $group['categories'] as $termID ) {
+						$term         = get_term( $termID );
+						$customMarkup = get_term_meta( $termID, COMMONSBOOKING_METABOX_PREFIX . 'markup', true );
+						$termName     = empty( $customMarkup ) ? $term->name : $customMarkup;
 
-					$elements[] = [
-						'cat_id' => intval( $termID ),
-						'markup' => $termName,
+						$elements[] = [
+							'cat_id' => intval( $termID ),
+							'markup' => $termName,
+						];
+					}
+					$isExclusive                                       = $group['isExclusive'] ?? 'off';
+					$settings['filter_cb_item_categories'][ $groupID ] = [
+						'name'        => $group['name'] ?? '',
+						'elements'    => $elements,
+						'isExclusive' => $isExclusive == 'on',
 					];
 				}
-				$isExclusive                                       = $group['isExclusive'] ?? 'off';
-				$settings['filter_cb_item_categories'][ $groupID ] = [
-					'name'        => $group['name'] ?? '',
-					'elements'    => $elements,
-					'isExclusive' => $isExclusive == 'on',
-				];
 			}
 		}
 		return $settings;

--- a/src/Migration/Migration.php
+++ b/src/Migration/Migration.php
@@ -595,7 +595,7 @@ class Migration {
 	 * Migrates CB1 user agreement url option to CB2.
 	 * Only relevant for legacy user profile.
 	 *
-	 * @return true
+	 * @return bool
 	 */
 	public static function migrateUserAgreementUrl() {
 		$cb1_url = Settings::getOption( 'commons-booking-settings-pages', 'commons-booking_termsservices_url' );

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -470,7 +470,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		if ( $grid === 0 ) { // if grid is set to slot duration
 			// If we have the grid size, we use it to calculate right time end
 			$timeframeGridSize = $this->getMeta( self::START_TIMEFRAME_GRIDSIZE );
-			if ( $timeframeGridSize ) {
+			if ( is_numeric( $timeframeGridSize ) ) {
 				$grid = $timeframeGridSize;
 			}
 		}
@@ -506,7 +506,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		if ( $grid === 0 ) { // if grid is set to slot duration
 			// If we have the grid size, we use it to calculate right time start
 			$timeframeGridSize = $this->getMeta( self::END_TIMEFRAME_GRIDSIZE );
-			if ( $timeframeGridSize ) {
+			if ( is_numeric( $timeframeGridSize ) ) {
 				$grid = $timeframeGridSize;
 			}
 		}

--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -72,9 +72,9 @@ class CustomPost {
 	/**
 	 * Returns meta-field value.
 	 *
-	 * @param $field
+	 * @param string $field
 	 *
-	 * @return string The value of the meta field. An empty string if the field doesn't exist.
+	 * @return string|array The value of the meta field. An empty string if the field doesn't exist.
 	 */
 	public function getMeta( $field ) {
 		return get_post_meta( $this->post->ID, $field, true );

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -75,7 +75,7 @@ class Timeframe extends CustomPost {
 	 * Example: 2020-01-01,2020-01-02,2020-01-03
 	 */
 	public const META_MANUAL_SELECTION = 'timeframe_manual_date';
-	const MAX_DAYS_DEFAULT = 3;
+	const MAX_DAYS_DEFAULT             = 3;
 
 	/**
 	 * null means the data is not fetched yet
@@ -1242,7 +1242,14 @@ class Timeframe extends CustomPost {
 		return date( 'Y-m-d', strtotime( $today . ' + ' . $offset . ' days' ) );
 	}
 
+	/**
+	 * @return int
+	 */
 	public function getMaxDays(): int {
-		return $this->getMeta( self::META_MAX_DAYS ) ?? self::MAX_DAYS_DEFAULT;
+		$meta = $this->getMeta( self::META_MAX_DAYS );
+		if ( is_numeric( $meta ) ) {
+			return (int) $meta;
+		}
+		return self::MAX_DAYS_DEFAULT;
 	}
 }

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -75,6 +75,7 @@ class Timeframe extends CustomPost {
 	 * Example: 2020-01-01,2020-01-02,2020-01-03
 	 */
 	public const META_MANUAL_SELECTION = 'timeframe_manual_date';
+	const MAX_DAYS_DEFAULT = 3;
 
 	/**
 	 * null means the data is not fetched yet
@@ -1244,6 +1245,6 @@ class Timeframe extends CustomPost {
 	}
 
 	public function getMaxDays(): int {
-		return $this->getMeta( self::META_MAX_DAYS );
+		return $this->getMeta( self::META_MAX_DAYS ) ?? self::MAX_DAYS_DEFAULT;
 	}
 }

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -145,7 +145,7 @@ class Timeframe extends CustomPost {
 
 		$endDate = $this->getMeta( self::REPETITION_END );
 
-		if ( (string) intval( $endDate ) != $endDate ) {
+		if ( ! is_numeric( $endDate ) ) {
 			$endDate = strtotime( $endDate );
 		} else {
 			$endDate = intval( $endDate );

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -426,7 +426,7 @@ class Booking extends PostRepository {
 	 *
 	 * @param \CommonsBooking\Model\Restriction $restriction
 	 *
-	 * @return \WP_Post[]|null
+	 * @return \CommonsBooking\Model\Booking[]|null
 	 * @throws Exception
 	 */
 	public static function getByRestriction( \CommonsBooking\Model\Restriction $restriction ): ?array {

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -499,6 +499,7 @@ class Booking extends PostRepository {
 				$post = new \CommonsBooking\Model\Booking( $post );
 			}
 
+			/** @var \CommonsBooking\Model\Booking[] $posts */
 			return $posts;
 		}
 

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -130,7 +130,7 @@ class Booking extends PostRepository {
 			foreach ( $posts as &$post ) {
 				$post = new \CommonsBooking\Model\Booking( $post );
 			}
-
+			/** @var \CommonsBooking\Model\Booking[] $posts */
 			return $posts;
 		}
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,6 +5,7 @@ namespace CommonsBooking\Repository;
 
 use CommonsBooking\Plugin;
 use WP_Query;
+use WP_User;
 
 class UserRepository {
 
@@ -54,7 +55,7 @@ class UserRepository {
 	/**
 	 * Returns all users with items/locations.
 	 *
-	 * @return array
+	 * @return WP_User[]
 	 */
 	public static function getOwners(): array {
 		$owners   = [];

--- a/src/Service/BookingCodes.php
+++ b/src/Service/BookingCodes.php
@@ -58,7 +58,7 @@ class BookingCodes {
 	 *
 	 * @param int $timeframeId
 	 *
-	 * @return array   Parameters.
+	 * @return array|false   Parameters.
 	 */
 	public static function getCronParams( $timeframeId ): array {
 		$tsCurrentCronEvent = get_post_meta( $timeframeId, \CommonsBooking\View\BookingCodes::NEXT_CRON_EMAIL, true );

--- a/src/Service/BookingCodes.php
+++ b/src/Service/BookingCodes.php
@@ -60,7 +60,7 @@ class BookingCodes {
 	 *
 	 * @return array|false   Parameters.
 	 */
-	public static function getCronParams( $timeframeId ): array {
+	public static function getCronParams( $timeframeId ) {
 		$tsCurrentCronEvent = get_post_meta( $timeframeId, \CommonsBooking\View\BookingCodes::NEXT_CRON_EMAIL, true );
 		if ( empty( $tsCurrentCronEvent ) ) {
 			return false;

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -272,9 +272,9 @@ trait Cache {
 					$attributesString = isset( $match[3] ) ? $match[3] : ''; // e.g., " id=123"
 
 					$shortCodeCalls[] = [
-						'shortcode' => $shortCode,
-						'attributes'         => self::getShortcodeAndAttributes( $shortCode . $attributesString )[1],
-						'body' => isset( $match[5] ) ? trim( $match[5] ) : '',
+						'shortcode'  => $shortCode,
+						'attributes' => self::getShortcodeAndAttributes( $shortCode . $attributesString )[1],
+						'body'       => isset( $match[5] ) ? trim( $match[5] ) : '',
 					];
 				}
 			}

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -373,7 +373,7 @@ trait Cache {
 	/**
 	 * Iterates through array and statically executes given functions.
 	 *
-	 * @param string[] $shortCodeCalls array of tuples of shortcode name strings and tuples of class + static function.
+	 * @param array{shortcode: string, attributes: array, body: string} $shortCodeCalls array of tuples of shortcode name strings and tuples of class + static function.
 	 *
 	 * @return void
 	 */

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -49,7 +49,7 @@ class Scheduler {
 
 		if ( ( count( $option ) == 2 ) && Settings::getOption( $option[0], $option[1] ) != 'on' ) { // removes job if option unset
 			$this->unscheduleJob();
-			return false;
+			return;
 		}
 
 		if ( empty( $executionTime ) ) {
@@ -60,7 +60,7 @@ class Scheduler {
 				$this->timestamp = strtotime( '+1 day', $this->timestamp );
 			}
 		} else {
-			return false;
+			return;
 		}
 
 		$this->reccurence = $reccurence;

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -48,11 +48,11 @@ class Settings {
 	 * Updates a single field in a multidimensional options-array in wp_options
 	 * Will create the option if it does not exist yet.
 	 *
-	 * @param mixed $option_name the options name as defined in wp_options table, column option_name
-	 * @param mixed $field_id the field_id in the array
-	 * @param mixed $field_value the new value
+	 * @param string $option_name the options name as defined in wp_options table, column option_name
+	 * @param mixed  $field_id the field_id in the array
+	 * @param mixed  $field_value the new value
 	 *
-	 * @return true
+	 * @return bool
 	 */
 	public static function updateOption( $option_name, $field_id, $field_value ) {
 		// Load all the option values from wp_options

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -480,10 +480,10 @@ class Booking extends View {
 	 *
 	 * @param $user
 	 *
-	 * @return String
+	 * @return string|false
 	 * @throws Exception
 	 */
-	public static function getBookingListiCal( $user = null ): string {
+	public static function getBookingListiCal( $user = null ) {
 		$eventTitle_unparsed       = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_title' );
 		$eventDescription_unparsed = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'event_desc' );
 

--- a/src/View/Dashboard.php
+++ b/src/View/Dashboard.php
@@ -14,9 +14,9 @@ class Dashboard extends View {
 	}
 
 	/**
-	 * Renders list of beginngin bookings for today.
+	 * Renders list of bookings, which are starting today.
 	 *
-	 * @return void
+	 * @return string|false
 	 * @throws \Exception
 	 */
 	public static function renderBeginningBookings() {
@@ -59,9 +59,9 @@ class Dashboard extends View {
 
 
 	/**
-	 * Renders list of ending bookings for today.
+	 * Renders list of bookings, which are ending today.
 	 *
-	 * @return void
+	 * @return string|false
 	 * @throws \Exception
 	 */
 	public static function renderEndingBookings() {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -175,9 +175,9 @@ abstract class View {
 	/**
 	 * Compiles the user defined color scheme from settings (templates) using SCSSPHP and returns it
 	 *
-	 * @return string
+	 * @return string|false
 	 */
-	public static function getColorCSS(): string {
+	public static function getColorCSS() {
 		$compiler    = new Compiler();
 		$var_import  = COMMONSBOOKING_PLUGIN_DIR . 'assets/global/sass/partials/_variables.scss';
 		$import_path = COMMONSBOOKING_PLUGIN_DIR . 'assets/public/sass/partials/';

--- a/src/Wordpress/CustomPostType/CustomPostType.php
+++ b/src/Wordpress/CustomPostType/CustomPostType.php
@@ -362,7 +362,7 @@ abstract class CustomPostType {
 	 *
 	 * @param int|WP_Post|CustomPost $post - Post ID or Post Object
 	 *
-	 * @return \CommonsBooking\Model\Booking|\CommonsBooking\Model\Item|\CommonsBooking\Model\Location|\CommonsBooking\Model\Restriction|\CommonsBooking\Model\Timeframe|\CommonsBooking\Model\Map
+	 * @return CustomPost
 	 * @throws PostException
 	 */
 	public static function getModel( $post ) {

--- a/src/Wordpress/CustomPostType/CustomPostType.php
+++ b/src/Wordpress/CustomPostType/CustomPostType.php
@@ -28,7 +28,7 @@ abstract class CustomPostType {
 	protected $menuPosition;
 
 	/**
-	 * @var array{string, string}
+	 * @var array<string, string>
 	 */
 	protected $listColumns = null;
 

--- a/src/Wordpress/CustomPostType/CustomPostType.php
+++ b/src/Wordpress/CustomPostType/CustomPostType.php
@@ -161,6 +161,8 @@ abstract class CustomPostType {
 	}
 
 	/**
+	 * Returns view-class.
+	 *
 	 * @return mixed
 	 */
 	abstract public static function getView();

--- a/src/Wordpress/CustomPostType/Timeframe.php
+++ b/src/Wordpress/CustomPostType/Timeframe.php
@@ -570,7 +570,7 @@ class Timeframe extends CustomPostType {
 					'type' => 'number',
 					'min'  => '1',
 				),
-				'default_value'    => 3,
+				'default_value'    => \CommonsBooking\Model\Timeframe::MAX_DAYS_DEFAULT,
 				'default_cb' => 'commonsbooking_filter_from_cmb2',
 			),
 			array(

--- a/src/Wordpress/CustomPostType/Timeframe.php
+++ b/src/Wordpress/CustomPostType/Timeframe.php
@@ -223,9 +223,7 @@ class Timeframe extends CustomPostType {
 	}
 
 	/**
-	 * Returns view-class.
-	 *
-	 * @return void
+	 * @inheritDoc
 	 */
 	public static function getView() {
 		// @TODO implement view.

--- a/tests/php/API/GBFS/StationStatusTest.php
+++ b/tests/php/API/GBFS/StationStatusTest.php
@@ -21,7 +21,7 @@ class StationStatusTest extends CustomPostTypeTest {
 			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+10 days', strtotime( self::CURRENT_DATE ) )
 		);
-		$stationStatus     = $routeObject->prepare_item_for_response( $locationObject, null );
+		$stationStatus     = $routeObject->prepare_item_for_response( $locationObject, null )->get_data();
 		$this->assertEquals( $this->locationId, $stationStatus->station_id );
 		$this->assertEquals( 1, $stationStatus->num_bikes_available );
 		$this->assertTrue( $stationStatus->is_installed );
@@ -31,12 +31,12 @@ class StationStatusTest extends CustomPostTypeTest {
 
 		// now let's book the current day and check, that the station is empty
 		$this->createConfirmedBookingStartingToday();
-		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 
 		// the timeframe has ended now, so the station should be empty
 		$currDate->modify( '+11 days' );
 		ClockMock::freeze( $currDate );
-		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 
 		// very important for GBFS: when bookings are only allowed with a certain offset (time difference between booking and start of booking), the station should be empty
 		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
@@ -61,10 +61,10 @@ class StationStatusTest extends CustomPostTypeTest {
 			30,
 			2
 		);
-		$this->assertEquals( 0, $routeObject->prepare_item_for_response( new Location( $otherLocationId ), null )->num_bikes_available );
+		$this->assertEquals( 0, $routeObject->prepare_item_for_response( new Location( $otherLocationId ), null )->get_data()->num_bikes_available );
 		// remove the offset and the station should have the item
 		update_post_meta( $timeframeID, 'booking-startday-offset', 0 );
-		$this->assertEquals( 1, $routeObject->prepare_item_for_response( new Location( $otherLocationId ), null )->num_bikes_available );
+		$this->assertEquals( 1, $routeObject->prepare_item_for_response( new Location( $otherLocationId ), null )->get_data()->num_bikes_available );
 	}
 
 	public function testPrepare_item_for_response_hourly() {
@@ -85,12 +85,12 @@ class StationStatusTest extends CustomPostTypeTest {
 			'8:00 AM',
 			'12:00 PM'
 		);
-		$this->assertEquals( 1, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 1, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 
 		// before 08:00AM the bike is not available
 		$currDate->setTime( 6, 0, 0 );
 		ClockMock::freeze( $currDate );
-		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 
 		// now let's book two hours out of the timeframe and check that the station is empty for those two hours
 		$startBooking = new \DateTime( self::CURRENT_DATE );
@@ -106,12 +106,12 @@ class StationStatusTest extends CustomPostTypeTest {
 			'01:00 PM'
 		);
 		ClockMock::freeze( $startBooking );
-		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 		$startBooking->modify( '+1 hour' );
 		ClockMock::freeze( $startBooking );
-		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 0, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 		ClockMock::freeze( $endBooking );
-		$this->assertEquals( 1, $routeObject->prepare_item_for_response( $locationObject, null )->num_bikes_available );
+		$this->assertEquals( 1, $routeObject->prepare_item_for_response( $locationObject, null )->get_data()->num_bikes_available );
 	}
 
 	protected function setUp(): void {


### PR DESCRIPTION
Successor of #1735. 

TODO

* [x] work through all phpstan findings and adhere to the following goals

Goals of this PR (Copied from discussions of previous PRs):

* Use phpdoc `@params` or `@return` annotations where appropriate for type checks at (ci) build time

* Use [php type declarations](https://www.php.net/manual/en/language.types.declarations.php) where appropriate, for runtime checking (php language level 7.4)

For phpstan: Apart from general static type checking, my personal goal would be to reach at least [rule level 8](https://phpstan.org/user-guide/rule-levels), to check nullable types.