### PR TITLE
Increase phpstan level 6

### DIFF
--- a/commonsbooking.php
+++ b/commonsbooking.php
@@ -31,7 +31,7 @@ define( 'COMMONSBOOKING_METABOX_PREFIX', '_cb_' ); // Start with an underscore t
 define( 'COMMONSBOOKING_MAP_PATH', wp_normalize_path( plugin_dir_path( __FILE__ ) ) );
 define( 'COMMONSBOOKING_MAP_ASSETS_URL', plugins_url( 'assets/map/', __FILE__ ) );
 define( 'COMMONSBOOKING_MAP_LANG_PATH', dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
-define( 'COMMONSBOOKING_MAP_PLUGIN_DATA', get_file_data( __FILE__, array( 'Version' => 'Version' ), false ) );
+define( 'COMMONSBOOKING_MAP_PLUGIN_DATA', get_file_data( __FILE__, array( 'Version' => 'Version' ) ) );
 
 global $cb_db_version;
 $cb_db_version = '1.0';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -5,10 +5,10 @@ function commonsbooking_admin() {
 	wp_enqueue_script( 'jquery' );
 
 	// Datepicker extension
-	wp_enqueue_script( 'jquery-ui-datepicker', array( 'jquery' ) );
+	wp_enqueue_script( 'jquery-ui-datepicker', '', array( 'jquery' ) );
 
 	// Tooltip extension
-	wp_enqueue_script( 'jquery-ui-tooltip', array( 'jquery' ) );
+	wp_enqueue_script( 'jquery-ui-tooltip', '', array( 'jquery' ) );
 
 	wp_enqueue_style( 'admin-styles', COMMONSBOOKING_PLUGIN_ASSETS_URL . 'admin/css/admin.css', array(), COMMONSBOOKING_VERSION );
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -18,7 +18,7 @@ function commonsbooking_admin() {
 			'cb-scripts-admin',
 			COMMONSBOOKING_PLUGIN_ASSETS_URL . 'admin/js/admin.js',
 			array(),
-			time()
+			(string) time()
 		);
 	} else {
 		wp_enqueue_script(

--- a/includes/Public.php
+++ b/includes/Public.php
@@ -39,7 +39,7 @@ function commonsbooking_public() {
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'jquery-ui-datepicker', array( 'jquery' ) );
+	wp_enqueue_script( 'jquery-ui-datepicker', '', array( 'jquery' ) );
 
 	wp_enqueue_script(
 		'cb-scripts-vendor',

--- a/includes/Public.php
+++ b/includes/Public.php
@@ -102,7 +102,7 @@ function commonsbooking_public() {
 			'cb-scripts-public',
 			COMMONSBOOKING_PLUGIN_ASSETS_URL . 'public/js/public.js',
 			array( 'jquery' ),
-			time(),
+			(string) time(),
 			true
 		);
 	} else {

--- a/includes/Template.php
+++ b/includes/Template.php
@@ -10,11 +10,11 @@ if ( ! function_exists( 'commonsbooking_get_template_part' ) ) {
 	 * Load template files of the plugin also include a filter pn_get_template_part<br>
 	 * Based on WooCommerce function<br>
 	 *
-	 * @param string $slug
-	 * @param string $name
-	 * @param bool   $include
-	 * @param string $before
-	 * @param string $after
+	 * @param string       $slug
+	 * @param string       $name
+	 * @param bool         $include
+	 * @param string|false $before
+	 * @param string|false $after
 	 *
 	 * @return string
 	 */

--- a/includes/Template.php
+++ b/includes/Template.php
@@ -83,13 +83,17 @@ if ( ! function_exists( 'commonsbooking_get_template_part' ) ) {
 			}
 		}
 
-		if ( $template && $include === true ) {
-			echo( commonsbooking_sanitizeHTML( $before_html ) );
-			load_template( $template, false );
-			echo( commonsbooking_sanitizeHTML( $after_html ) );
-		} elseif ( $template && $include === false ) {
-			return $before_html . $template . $after_html;
+		if ( ! $template ) {
+			return '';
 		}
-		return '';
+
+		if ( $include ) {
+			echo commonsbooking_sanitizeHTML( $before_html );
+			load_template( $template, false );
+			echo commonsbooking_sanitizeHTML( $after_html );
+			return '';
+		}
+
+		return $before_html . $template . $after_html;
 	}
 }

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -277,7 +277,7 @@ function commonsbooking_isCurrentUserAllowedToBook( $timeframeID ): bool {
  *
  * It only makes sense to check this with booking posts as all CPTs are / should be public.
  *
- * @param $booking - A booking of the cb_booking type
+ * @param \CommonsBooking\Model\Booking|int|WP_Post $booking - A booking of the cb_booking type
  *
  * @return bool
  */

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -290,11 +290,7 @@ function commonsbooking_isCurrentUserAllowedToSee( $booking ): bool {
 
 	$user = wp_get_current_user();
 
-	if ( $user ) {
-		return commonsbooking_isUserAllowedToSee( $booking, $user );
-	} else {
-		return false;
-	}
+	return commonsbooking_isUserAllowedToSee( $booking, $user );
 }
 
 /**

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -110,10 +110,7 @@ add_filter(
 			}
 
 			// Save posts to global variable for later use -> fix of counts in admin lists
-			if (
-				array_key_exists( 'post_type', $_GET ) &&
-				is_array( $query->query ) && array_key_exists( 'post_type', $query->query )
-			) {
+			if ( array_key_exists( 'post_type', $_GET ) ) {
 				global ${'posts' . $query->query['post_type']};
 				${'posts' . $query->query['post_type']} = $posts;
 			}

--- a/includes/Users.php
+++ b/includes/Users.php
@@ -300,8 +300,8 @@ function commonsbooking_isCurrentUserAllowedToSee( $booking ): bool {
  * It is, however used as a helper function for commonsbooking_isCurrentUserAllowedToEdit.
  * We apply the logic, that only something that is allowed to be seen may be edited.
  *
- * @param \CommonsBooking\Model\Booking|WP_Post|int $post
- * @param WP_User                                   $user
+ * @param \CommonsBooking\Model\CustomPost|WP_Post|int $post
+ * @param WP_User                                      $user
  *
  * @return bool
  */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,6 +13,30 @@ parameters:
 			path: src/Messages/BookingCodesMessage.php
 
 		-
+			message: '#^Call to function array_key_exists\(\) with ''migrationFunction'' and array\{repoFunction\: ''getBookingCodes'', migrationFunction\: ''migrateBookingCode''\}\|array\{repoFunction\: ''getBookings'', migrationFunction\: ''migrateBooking''\}\|array\{repoFunction\: ''getCB1Taxonomies'', migrationFunction\: ''migrateTaxonomy''\}\|array\{repoFunction\: ''getItems'', migrationFunction\: ''migrateItem''\}\|array\{repoFunction\: ''getLocations'', migrationFunction\: ''migrateLocation''\}\|array\{repoFunction\: ''getTimeframes'', migrationFunction\: ''migrateTimeframe''\}\|array\{repoFunction\: false, migrationFunction\: ''migrateCB1Options''\|''migrateUserAgreemen…''\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Migration/Migration.php
+
+		-
+			message: '#^Comparison operation "\>\=" between int\<0, 39\> and 40 is always false\.$#'
+			identifier: greaterOrEqual.alwaysFalse
+			count: 2
+			path: src/Migration/Migration.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: src/Migration/Migration.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: src/Migration/Migration.php
+
+		-
 			message: '#^Access to an undefined property WP_Post\:\:\$locked\.$#'
 			identifier: property.notFound
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,12 @@ parameters:
 			path: src/Migration/Migration.php
 
 		-
+			message: '#^Parameter \#3 \$timeframe_type of static method CommonsBooking\\Migration\\Migration\:\:getExistingPost\(\) expects null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Migration/Migration.php
+
+		-
 			message: '#^Right side of && is always true\.$#'
 			identifier: booleanAnd.rightAlwaysTrue
 			count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,12 +10,12 @@ parameters:
     - commonsbooking.php
     - src/
     - includes/
-  level: 5
+  level: 6
   ignoreErrors:
     - '#Constant (COMMONSBOOKING.*|WP_DEBUG_LOG) not found.#'
 #    - '#Instantiated class (CommonsBooking.*CB_Data) not found.#'
     - '#Function cb_object_to_array not found.#'
-    - 
+    -
       identifier: requireOnce.fileNotFound # https://github.com/szepeviktor/phpstan-wordpress/issues/239
     # As long as symfony exceptions do not extend from throwable
     - '#Psr\\Cache\\InvalidArgumentException is not subtype of Throwable#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
     - commonsbooking.php
     - src/
     - includes/
-  level: 4
+  level: 5
   ignoreErrors:
     - '#Constant (COMMONSBOOKING.*|WP_DEBUG_LOG) not found.#'
 #    - '#Instantiated class (CommonsBooking.*CB_Data) not found.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
     - commonsbooking.php
     - src/
     - includes/
-  level: 3
+  level: 4
   ignoreErrors:
     - '#Constant (COMMONSBOOKING.*|WP_DEBUG_LOG) not found.#'
 #    - '#Instantiated class (CommonsBooking.*CB_Data) not found.#'

--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -52,12 +52,12 @@ class StationStatus extends BaseRoute {
 	 * or can only be booked through overbooking.
 	 * This is because the GBFS spec only accounts for items available in that instant.
 	 *
-	 * @param $locationId
+	 * @param int $locationId
 	 *
-	 * @return int|null
+	 * @return int
 	 * @throws \Exception
 	 */
-	private function getItemCountAtLocation( $locationId ) {
+	private function getItemCountAtLocation( $locationId ): int {
 		$items            = Item::getByLocation( $locationId, true );
 		$nowDT            = new \DateTime();
 		$availableCounter = 0;

--- a/src/CB/CB.php
+++ b/src/CB/CB.php
@@ -21,11 +21,13 @@ class CB {
 	/**
 	 * Returns property of (custom) post by class key and property.
 	 *
-	 * @param mixed            $key
-	 * @param mixed            $property
-	 * @param \WP_Post|WP_User $wpObject
-	 * @param mixed            $args
-	 * @param callable         $sanitizeFunction The callable used to remove unwanted tags/characters (use default 'commonsbooking_sanitizeHTML' or 'sanitize_text_field')
+	 * @param string                                $key
+	 * @param string                                $property
+	 * @param mixed|CustomPost|WP_Post|WP_User|null $wpObject
+	 * @param mixed|null                            $args
+	 * @param callable                              $sanitizeFunction The callable used to remove unwanted tags/characters (use default 'commonsbooking_sanitizeHTML' or 'sanitize_text_field')
+	 *
+	 * @since 2.10.5 parameters in doc are correctly typed.
 	 *
 	 * @return null|string property of (custom) post (sanitized) or null if not found
 	 * @throws Exception

--- a/src/CB/CB1UserFields.php
+++ b/src/CB/CB1UserFields.php
@@ -25,7 +25,7 @@ class CB1UserFields {
 	/**
 	 * @var array|string[]
 	 */
-	private array $registration_fields_required;
+	private array $registration_fields_required; // @phpstan-ignore not read variable
 	/**
 	 * @var array|array[]
 	 */
@@ -33,7 +33,7 @@ class CB1UserFields {
 	/**
 	 * @var array|mixed
 	 */
-	private $user_vars;
+	private $user_vars; // @phpstan-ignore not read variable
 
 	public function __construct() {
 

--- a/src/CB/CB1UserFields.php
+++ b/src/CB/CB1UserFields.php
@@ -25,7 +25,7 @@ class CB1UserFields {
 	/**
 	 * @var array|string[]
 	 */
-	private array $registration_fields_required; // @phpstan-ignore not read variable
+	private array $registration_fields_required; // @phpstan-ignore property.onlyWritten
 	/**
 	 * @var array|array[]
 	 */
@@ -33,7 +33,7 @@ class CB1UserFields {
 	/**
 	 * @var array|mixed
 	 */
-	private $user_vars; // @phpstan-ignore not read variable
+	private $user_vars; // @phpstan-ignore property.onlyWritten
 
 	public function __construct() {
 

--- a/src/CB/CB1UserFields.php
+++ b/src/CB/CB1UserFields.php
@@ -202,11 +202,10 @@ class CB1UserFields {
 				if ( ! isset( $_POST[ $field['field_name'] ] ) ) {
 					$errors->add( $field['field_name'] . '_error', $field['errormessage'] );
 				}
-			} elseif (
-					empty( $_POST[ $field['field_name'] ] ) ||
-					! empty( $_POST[ $field['field_name'] ] ) &&
-					sanitize_text_field( trim( $_POST[ $field['field_name'] ] ) == '' ) ) {
-					$errors->add( $field['field_name'] . '_error', $field['errormessage'] );
+			} elseif ( empty( $_POST[ $field['field_name'] ] ) ||
+						! empty( $_POST[ $field['field_name'] ] ) &&
+						sanitize_text_field( $_POST[ $field['field_name'] ] ) === '' ) {
+				$errors->add( $field['field_name'] . '_error', $field['errormessage'] );
 			}
 		}
 

--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -282,7 +282,7 @@ class Wordpress {
 	 * The problem is, that the timestamp is in the local timezone of the server.
 	 * If we convert it to UTC, we get the wrong date and everything breaks.
 	 *
-	 * @param $timestamp
+	 * @param int|string $timestamp numeric value
 	 *
 	 * @return DateTime
 	 * @throws \Exception

--- a/src/Map/MapData.php
+++ b/src/Map/MapData.php
@@ -17,8 +17,6 @@ class MapData {
 			while ( $check_capacity ) {
 				if ( $attempts > 10 ) {
 					wp_send_json_error( [ 'error' => 5 ], 408 );
-
-					wp_die();
 				}
 
 				++$attempts;
@@ -71,8 +69,6 @@ class MapData {
 		} else {
 			wp_send_json_error( [ 'error' => 1 ], 400 );
 		}
-
-		wp_die();
 	}
 
 	/**
@@ -90,13 +86,9 @@ class MapData {
 				$map       = new Map( $cb_map_id );
 			} else {
 				wp_send_json_error( [ 'error' => 2 ], 400 );
-
-				wp_die();
 			}
 		} else {
 			wp_send_json_error( [ 'error' => 3 ], 400 );
-
-			wp_die();
 		}
 
 		if ( $post->post_status == 'publish' ) {

--- a/src/Map/MapData.php
+++ b/src/Map/MapData.php
@@ -216,38 +216,38 @@ class MapData {
 
 		if ( $map->getMeta( 'custom_marker_media_id' ) ) {
 			$settings['custom_marker_icon'] = [
-				'iconUrl'    => wp_get_attachment_url( $map->getMeta( 'custom_marker_media_id' ) ),
+				'iconUrl'    => wp_get_attachment_url( $map->getMetaInt( 'custom_marker_media_id' ) ),
 				'iconSize'   => [
-					intval( $map->getMeta( 'marker_icon_width' ) ),
-					intval( $map->getMeta( 'marker_icon_height' ) ),
+					$map->getMetaInt( 'marker_icon_width' ),
+					$map->getMetaInt( 'marker_icon_height' ),
 				],
 				'iconAnchor' => [
-					intval( $map->getMeta( 'marker_icon_anchor_x' ) ),
-					intval( $map->getMeta( 'marker_icon_anchor_y' ) ),
+					$map->getMetaInt( 'marker_icon_anchor_x' ),
+					$map->getMetaInt( 'marker_icon_anchor_y' ),
 				],
 			];
 		}
 
 		if ( $map->getMeta( 'marker_item_draft_media_id' ) ) {
 			$settings['item_draft_marker_icon'] = [
-				'iconUrl'    => wp_get_attachment_url( $map->getMeta( 'marker_item_draft_media_id' ) ),
+				'iconUrl'    => wp_get_attachment_url( $map->getMetaInt( 'marker_item_draft_media_id' ) ),
 				'iconSize'   => [
-					intval( $map->getMeta( 'marker_item_draft_icon_width' ) ),
-					intval( $map->getMeta( 'marker_item_draft_icon_height' ) ),
+					$map->getMetaInt( 'marker_item_draft_icon_width' ),
+					$map->getMetaInt( 'marker_item_draft_icon_height' ),
 				],
 				'iconAnchor' => [
-					intval( $map->getMeta( 'marker_item_draft_icon_anchor_x' ) ),
-					intval( $map->getMeta( 'marker_item_draft_icon_anchor_y' ) ),
+					$map->getMetaInt( 'marker_item_draft_icon_anchor_x' ),
+					$map->getMetaInt( 'marker_item_draft_icon_anchor_y' ),
 				],
 			];
 		}
 
 		if ( $map->getMeta( 'custom_marker_cluster_media_id' ) ) {
 			$settings['marker_cluster_icon'] = [
-				'url'  => wp_get_attachment_url( $map->getMeta( 'custom_marker_cluster_media_id' ) ),
+				'url'  => wp_get_attachment_url( $map->getMetaInt( 'custom_marker_cluster_media_id' ) ),
 				'size' => [
-					'width'  => intval( $map->getMeta( 'marker_cluster_icon_width' ) ),
-					'height' => intval( $map->getMeta( 'marker_cluster_icon_height' ) ),
+					'width'  => $map->getMetaInt( 'marker_cluster_icon_width' ),
+					'height' => $map->getMetaInt( 'marker_cluster_icon_height' ),
 				],
 			];
 		}

--- a/src/Messages/BookingCodesMessage.php
+++ b/src/Messages/BookingCodesMessage.php
@@ -11,6 +11,7 @@ use CommonsBooking\Service\iCalendar;
 use CommonsBooking\CB\CB;
 use CommonsBooking\Wordpress\CustomPostType\Location;
 use DateTimeImmutable;
+use WP_User;
 
 /**
  * A message that contains booking codes to be sent by mail to the location admins.
@@ -23,7 +24,11 @@ class BookingCodesMessage extends Message {
 	protected $to;
 	private ?int $tsFrom;
 	private ?int $tsTo;
-	private ?array $locationAdmins;
+
+	/**
+	 * @var WP_User[]|null
+	 */
+	private ?array $locationAdmins = null; // TODO remove nullable, never is set to null anyway
 
 	/**
 	 * @param int      $postId       ID or Post of timeframe

--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -34,7 +34,7 @@ class BookingMessage extends Message {
 		];
 
 		// get location email adresses to send them bcc copies
-		$location          = get_post( $booking->getMeta( 'location-id' ) );
+		$location          = get_post( $booking->getMetaInt( 'location-id' ) );
 		$location_emails   = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email', $location ); /*  email addresses, comma-seperated  */
 		$location_bcc_copy = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email_bcc', $location ) == 'on'; /*  email addresses, comma-seperated  */
 		if ( $location_emails && $location_bcc_copy ) {

--- a/src/Messages/BookingReminderMessage.php
+++ b/src/Messages/BookingReminderMessage.php
@@ -27,7 +27,7 @@ class BookingReminderMessage extends Message {
 	public function sendMessage() {
 		/** @var \CommonsBooking\Model\Booking $booking */
 		$booking      = Booking::getPostById( $this->getPostId() );
-		$booking_user = get_userdata( $this->getPost()->post_author );
+		$booking_user = get_userdata( (int) $this->getPost()->post_author );
 
 		// get templates from Admin Options
 		$template_body    = Settings::getOption(

--- a/src/Messages/LocationBookingReminderMessage.php
+++ b/src/Messages/LocationBookingReminderMessage.php
@@ -79,11 +79,13 @@ class LocationBookingReminderMessage extends Message {
 		 * Default location booking reminder message
 		 *
 		 * @since 2.9.2
+		 * @since 2.10.5 filter result can be false
 		 *
-		 * @param LocationBookingReminderMessage $sendMessageToBeFiltered object to be sent.
+		 * @param LocationBookingReminderMessage|false $sendMessageToBeFiltered object to be sent.
 		 */
 		$sendMessage = apply_filters( 'commonsbooking_before_send_location_reminder_mail', $sendMessageToBeFiltered );
 		if ( $sendMessage ) {
+			// TODO $this can safely be renamed to $sendMessage?
 			$this->sendNotificationMail();
 		}
 	}

--- a/src/Messages/LocationBookingReminderMessage.php
+++ b/src/Messages/LocationBookingReminderMessage.php
@@ -57,10 +57,6 @@ class LocationBookingReminderMessage extends Message {
 			sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) )
 		);
 
-		if ( ! is_array( $location_emails ) ) {
-			return;
-		}
-
 		$recipientUser = new MessageRecipient( array_shift( $location_emails ), $booking->getLocation()->post_title );
 		$bcc_adresses  = implode( ',', $location_emails );
 

--- a/src/Messages/LocationBookingReminderMessage.php
+++ b/src/Messages/LocationBookingReminderMessage.php
@@ -30,7 +30,7 @@ class LocationBookingReminderMessage extends Message {
 		$booking_user = get_userdata( $this->getPost()->post_author );
 
 		// get location email adresses to send them bcc copies
-		$location               = get_post( $booking->getMeta( 'location-id' ) );
+		$location               = get_post( $booking->getMetaInt( 'location-id' ) );
 		$location_emails_option = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email', $location ); /*  email addresses, comma-seperated  */
 		if ( empty( $location_emails_option ) ) {
 			return;

--- a/src/Messages/LocationBookingReminderMessage.php
+++ b/src/Messages/LocationBookingReminderMessage.php
@@ -27,7 +27,7 @@ class LocationBookingReminderMessage extends Message {
 	public function sendMessage() {
 		/** @var \CommonsBooking\Model\Booking $booking */
 		$booking      = Booking::getPostById( $this->getPostId() );
-		$booking_user = get_userdata( $this->getPost()->post_author );
+		$booking_user = get_userdata( (int) $this->getPost()->post_author );
 
 		// get location email adresses to send them bcc copies
 		$location               = get_post( $booking->getMetaInt( 'location-id' ) );

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -654,7 +654,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 	 *
 	 * @TODO: optimize booking link to support different permalink settings or set individual slug (e.g. booking instead of cb_timeframe)
 	 *
-	 * @param null $linktext
+	 * @param string|null $linktext
 	 *
 	 * @return string
 	 */

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -631,7 +631,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 			$this->ID
 		);
 
-		if ( $overlappingBookings && count( $overlappingBookings ) >= 1 ) {
+		if ( count( $overlappingBookings ) >= 1 ) {
 			foreach ( $overlappingBookings as $overlappingBooking ) {
 				$overlappingBookingLinks[] = $overlappingBooking->getFormattedEditLink();
 			}

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -783,10 +783,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 			// Booking has no valid status
 			return 0;
 		}
-		if ( $interval === null ) {
-			// no interval created
-			return 0;
-		}
+
 		$days = $interval->d;
 		// when we have already moved into the next day for more one hour,it is counted as another day even if it is not completed
 		if ( $interval->h > 0 ) {

--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -16,7 +16,7 @@ use WP_Post;
  *
  * @package CommonsBooking\Model
  *
- * @property int $post_author {@see WP_Post::$post_author}
+ * @property int|string $post_author {@see WP_Post::$post_author}
  * @property string $post_status {@see WP_Post::$post_status}
  * @property int $ID {@see WP_Post::$ID}
  * @property string $post_title {@see WP_Post::$post_title}

--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -83,10 +83,15 @@ class CustomPost {
 	/**
 	 * @param string $key of post_meta field for this post
 	 *
-	 * @return int
+	 * @return int|null int if meta field yields integer value
 	 */
-	public function getMetaInt( string $key ): int {
-		return intval( $this->getMeta( $key ) );
+	public function getMetaInt( string $key ): ?int {
+		$val = $this->getMeta( $key );
+
+		if ( filter_var( $val, FILTER_VALIDATE_INT ) !== false ) {
+			return (int) $val;
+		}
+		return null;
 	}
 
 

--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -81,6 +81,16 @@ class CustomPost {
 	}
 
 	/**
+	 * @param string $key of post_meta field for this post
+	 *
+	 * @return int
+	 */
+	public function getMetaInt( string $key ): int {
+		return intval( $this->getMeta( $key ) );
+	}
+
+
+	/**
 	 * When getting a value from a Model Object, we can use this magic method to get the value from the WP_Post object instead.
 	 * This, for example, allows us to use $booking->post_title instead of $booking->post->post_title.
 	 *

--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -72,7 +72,7 @@ class CustomPost {
 	/**
 	 * Returns meta-field value.
 	 *
-	 * @param string $field
+	 * @param string $field key of post_meta field for this post
 	 *
 	 * @return string|array The value of the meta field. An empty string if the field doesn't exist.
 	 */

--- a/src/Model/Map.php
+++ b/src/Model/Map.php
@@ -51,7 +51,7 @@ class Map extends CustomPost {
 
 		/** @var \CommonsBooking\Model\Location $post */
 		foreach ( $locationObjects as $post ) {
-			$location_meta = get_post_meta( $post->ID, null, true );
+			$location_meta = get_post_meta( $post->ID, '', true );
 
 			// set serialized empty array if not set
 			// THIS FUNCTIONALITY IS DEPRECATED, closing days were a feature of 0.9.X

--- a/src/Model/Restriction.php
+++ b/src/Model/Restriction.php
@@ -294,7 +294,8 @@ class Restriction extends CustomPost {
 
 				$userDisabledBookingCancellationOnTotalBreakdown = \CommonsBooking\Settings\Settings::getOption( 'commonsbooking_options_restrictions', 'restrictions-no-cancel-on-total-breakdown' ) == 'on';
 				// cancel all affected booking
-				if ( ! $userDisabledBookingCancellationOnTotalBreakdown && $this->isActive() && $this->getType() == self::TYPE_REPAIR ) {
+				if ( ! $userDisabledBookingCancellationOnTotalBreakdown
+					&& $this->getType() === self::TYPE_REPAIR ) {
 					$this->cancelBookings( $bookings );
 				}
 			}

--- a/src/Model/Restriction.php
+++ b/src/Model/Restriction.php
@@ -94,7 +94,7 @@ class Restriction extends CustomPost {
 	/**
 	 * Returns start-time \DateTime.
 	 *
-	 * @param null $endDateString
+	 * @param int|string|null $endDateString numeric string
 	 *
 	 * @return DateTime
 	 */
@@ -104,10 +104,10 @@ class Restriction extends CustomPost {
 
 		if ( $endTimeString ) {
 			$endTime = Wordpress::getUTCDateTime();
-			$endTime->setTimestamp( $endTimeString );
-			$endDate->setTime( $endTime->format( 'H' ), $endTime->format( 'i' ) );
+			$endTime->setTimestamp( (int) $endTimeString );
+			$endDate->setTime( (int) $endTime->format( 'H' ), (int) $endTime->format( 'i' ) );
 		} else {
-			$endDate->setTimestamp( $endDateString );
+			$endDate->setTimestamp( (int) $endDateString );
 		}
 
 		return $endDate;
@@ -204,7 +204,7 @@ class Restriction extends CustomPost {
 	public function getStartTimeDateTime(): DateTime {
 		$startDateString = $this->getMeta( self::META_START );
 		$startDate       = Wordpress::getUTCDateTime();
-		$startDate->setTimestamp( $startDateString );
+		$startDate->setTimestamp( (int) $startDateString );
 
 		return $startDate;
 	}

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -195,9 +195,6 @@ class Timeframe extends CustomPost {
 		if ( ! $user ) {
 			$user = wp_get_current_user();
 		}
-		if ( ! $user ) {
-			return false;
-		}
 
 		// these roles are always allowed to book
 		$privilegedRolesDefaults = [ 'administrator' ];

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -116,7 +116,7 @@ class Timeframe extends CustomPost {
 
 		$startDate = $this->getMeta( self::REPETITION_START );
 
-		if ( (string) intval( $startDate ) !== $startDate ) {
+		if ( ! is_numeric( $startDate ) ) {
 			$startDate = strtotime( $startDate );
 		} else {
 			$startDate = intval( $startDate );

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -619,7 +619,7 @@ class Timeframe extends CustomPost {
 				}
 
 				// check if end date is before start date
-				if ( ( $this->getStartDate() && $this->getEndDate() ) && ( $this->getStartDate() > $this->getTimeframeEndDate() ) ) {
+				if ( $this->getEndDate() && ( $this->getStartDate() > $this->getTimeframeEndDate() ) ) {
 					throw new TimeframeInvalidException(
 						__(
 							'End date is before start date. Please set a valid end date.',

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -1137,7 +1137,7 @@ class Timeframe extends CustomPost {
 	 *
 	 * TODO: Clarify what the exact difference between endTime and endDate is.
 	 *
-	 * @param null $endDateString
+	 * @param string|int|null $endDateString
 	 *
 	 * @return DateTime
 	 * @throws Exception

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -1066,7 +1066,7 @@ class Timeframe extends CustomPost {
 		if ( $this->isFullDay() ) {
 			return Wordpress::getUTCDateTimeByTimestamp( $startDateString );
 		}
-		return Wordpress::convertTimestampToUTCDatetime( $startDateString );
+		return Wordpress::convertTimestampToUTCDatetime( intval( $startDateString ) );
 	}
 
 	/**
@@ -1087,7 +1087,7 @@ class Timeframe extends CustomPost {
 		$startDate = Wordpress::getUTCDateTimeByTimestamp( $startDateString );
 		if ( $startTimeString ) {
 			$startTime = Wordpress::getUTCDateTimeByTimestamp( strtotime( $startTimeString ) );
-			$startDate->setTime( $startTime->format( 'H' ), $startTime->format( 'i' ) );
+			$startDate->setTime( (int) $startTime->format( 'H' ), (int) $startTime->format( 'i' ) );
 		}
 
 		return $startDate;
@@ -1148,7 +1148,7 @@ class Timeframe extends CustomPost {
 
 		if ( $endTimeString ) {
 			$endTime = Wordpress::getUTCDateTimeByTimestamp( strtotime( $endTimeString ) );
-			$endDate->setTime( $endTime->format( 'H' ), $endTime->format( 'i' ) );
+			$endDate->setTime( (int) $endTime->format( 'H' ), (int) $endTime->format( 'i' ) );
 		} else {
 			$endDate = Wordpress::getUTCDateTimeByTimestamp( $endDateString );
 		}

--- a/src/Repository/BookablePost.php
+++ b/src/Repository/BookablePost.php
@@ -150,8 +150,8 @@ abstract class BookablePost extends PostRepository {
 	 *
 	 * THIS METHOD DOES NOT SEEM TO BE USED ANYWHERE.
 	 *
-	 * @param $userId
-	 * @param false  $asModel - Wether the posts should be returned as their respective model class or as WP_Post
+	 * @param mixed $userId
+	 * @param bool  $asModel - Whether the posts should be returned as their respective model class or as WP_Post
 	 *
 	 * @return array
 	 */

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -209,12 +209,12 @@ class Booking extends PostRepository {
 	}
 
 	/**
-	 * @param $startDate int
-	 * @param $endDate int
+	 * @param int        $startDate
+	 * @param int        $endDate
 	 * @param $locationId
 	 * @param $itemId
-	 * @param array         $customArgs
-	 * @param array         $postStatus
+	 * @param array      $customArgs
+	 * @param array      $postStatus
 	 *
 	 * @return \CommonsBooking\Model\Booking[]
 	 * @throws Exception
@@ -279,8 +279,8 @@ class Booking extends PostRepository {
 	/**
 	 * Returns all bookings, allowed to see for user.
 	 *
-	 * @param bool $asModel if true, returns as Booking array, if false, return int array (defaults to false)
-	 * @param null $minTimestamp
+	 * @param bool     $asModel if true, returns as Booking array, if false, return int array (defaults to false)
+	 * @param int|null $minTimestamp
 	 *
 	 * @return \CommonsBooking\Model\Booking[]|int[]
 	 * @throws Exception
@@ -447,9 +447,9 @@ class Booking extends PostRepository {
 	 *
 	 * @param $itemId
 	 * @param $locationId
-	 * @param $startDate
-	 * @param $endDate
-	 * @param null       $postId
+	 * @param int        $startDate
+	 * @param int        $endDate
+	 * @param int|null   $postId
 	 *
 	 * @return \CommonsBooking\Model\Booking[]|null
 	 */

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -67,7 +67,7 @@ class BookingCodes {
 			}
 			// when we still don't have an end-date, we will just get the coming ADVANCE_GENERATION_DAYS (should default to 365 days)
 			if ( ! $endDate ) {
-				$endDate = strtotime( '+' . $advanceGenerationDays . ' days', null ); // null means date and time now
+				$endDate = strtotime( '+' . $advanceGenerationDays . ' days' ); // null means date and time now
 				// a code will be generated for $endDate because time generally > 00:00:00 (due to initialitaion with current date and time)
 			}
 

--- a/src/Repository/Timeframe.php
+++ b/src/Repository/Timeframe.php
@@ -838,7 +838,7 @@ class Timeframe extends PostRepository {
 	 * @param array        $locations
 	 * @param array        $items
 	 * @param array        $types
-	 * @param false        $returnAsModel
+	 * @param bool         $returnAsModel
 	 * @param string[]     $postStatus
 	 *
 	 * @return array

--- a/src/Repository/Timeframe.php
+++ b/src/Repository/Timeframe.php
@@ -134,7 +134,7 @@ class Timeframe extends PostRepository {
 			// Get Post-IDs considering types, items and locations
 			$postIds = self::getPostIdsByType( $types, $items, $locations );
 
-			if ( $postIds && count( $postIds ) ) {
+			if ( $postIds ) {
 				$posts = self::getPostsByBaseParams(
 					$date,
 					$minTimestamp,
@@ -144,7 +144,7 @@ class Timeframe extends PostRepository {
 				);
 			}
 
-			if ( $posts && count( $posts ) ) {
+			if ( $posts ) {
 				$posts = self::filterTimeframes( $posts, $date );
 			}
 
@@ -329,7 +329,7 @@ class Timeframe extends PostRepository {
 	 *
 	 * @since 2.9.0 Supports now single and multi selection for items and locations
 	 *
-	 * @return mixed
+	 * @return string[]|int[]
 	 * @throws \Psr\Cache\InvalidArgumentException
 	 */
 	public static function getPostIdsByType( array $types = [], array $items = [], array $locations = [] ) {
@@ -873,7 +873,7 @@ class Timeframe extends PostRepository {
 			// Get Post-IDs considering types, items and locations
 			$postIds = self::getPostIdsByType( $types, $items, $locations );
 
-			if ( $postIds && count( $postIds ) ) {
+			if ( $postIds ) {
 				$posts = self::getPostsByBaseParams(
 					null,
 					$minTimestamp,

--- a/src/Repository/Timeframe.php
+++ b/src/Repository/Timeframe.php
@@ -908,7 +908,7 @@ class Timeframe extends PostRepository {
 	 * @param array        $locations
 	 * @param array        $items
 	 * @param array        $types
-	 * @param false        $returnAsModel
+	 * @param bool         $returnAsModel
 	 * @param string[]     $postStatus
 	 *
 	 * @return array

--- a/src/Service/BookingRuleApplied.php
+++ b/src/Service/BookingRuleApplied.php
@@ -157,9 +157,6 @@ class BookingRuleApplied extends BookingRule {
 		}
 
 		foreach ( $ruleset as $rule ) {
-			if ( ! ( $rule instanceof BookingRuleApplied ) ) {
-				continue; // skip invalid rules during booking validation
-			}
 			$conflictingBookings = $rule->checkBookingCompliance( $booking );
 			if ( $conflictingBookings ) {
 				$errorMessage =

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -373,7 +373,7 @@ trait Cache {
 	/**
 	 * Iterates through array and statically executes given functions.
 	 *
-	 * @param array{shortcode: string, attributes: array, body: string} $shortCodeCalls array of tuples of shortcode name strings and tuples of class + static function.
+	 * @param array<array{shortcode: string, attributes: array, body: string}> $shortCodeCalls array of tuples of shortcode name strings and tuples of class + static function.
 	 *
 	 * @return void
 	 */

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -116,7 +116,7 @@ trait Cache {
 				$directory = $customCachePath;
 			}
 			// Since this is the default cache path by Symfony we'd rather set it to null so that Symfony can take over with it's own default value.
-			elseif ( $customCachePath == '/tmp/symfony-cache/' ) {
+			if ( $customCachePath === '/tmp/symfony-cache/' ) {
 				$directory = null;
 			}
 		}

--- a/src/Service/Cache.php
+++ b/src/Service/Cache.php
@@ -26,7 +26,7 @@ trait Cache {
 	/**
 	 * Returns cache item based on calling class, function and args.
 	 *
-	 * @param null $custom_id
+	 * @param mixed|null $custom_id
 	 *
 	 * @return mixed
 	 * @throws \Psr\Cache\InvalidArgumentException
@@ -52,7 +52,7 @@ trait Cache {
 	/**
 	 * Returns cache id, based on calling class, function and args.
 	 *
-	 * @param null $custom_id
+	 * @param mixed|null $custom_id
 	 *
 	 * @return string
 	 * @since 2.7.2 added Plugin_Dir to Namespace to avoid conflicts on multiple instances on same server
@@ -145,7 +145,7 @@ trait Cache {
 	 *
 	 * @param $value
 	 * @param array       $tags
-	 * @param null        $custom_id
+	 * @param mixed|null  $custom_id
 	 * @param string|null $expirationString set expiration as timestamp or string 'midnight' to set expiration to 00:00 next day
 	 *
 	 * @return bool

--- a/src/Service/MassOperations.php
+++ b/src/Service/MassOperations.php
@@ -30,7 +30,7 @@ class MassOperations {
 		} else {
 			$result = array(
 				'success' => false,
-				'message' => empty( $errorMessage ) ?? __( 'An error occurred while moving bookings.', 'commonsbooking' ),
+				'message' => ! empty( $errorMessage ) ? $errorMessage : __( 'An error occurred while moving bookings.', 'commonsbooking' ),
 			);
 		}
 

--- a/src/Service/MassOperations.php
+++ b/src/Service/MassOperations.php
@@ -69,9 +69,7 @@ class MassOperations {
 			if ( \CommonsBooking\Repository\Booking::getExistingBookings( $booking->getItemID(), $moveLocation->ID, $booking->getStartDate(), $booking->getEndDate() ) ) {
 				throw new \Exception( sprintf( __( 'There is already a booking on the new location during the timeframe of booking with ID %s.', 'commonsbooking' ), $booking->ID ) );
 			}
-			if ( $moveLocation !== null ) {
-				update_post_meta( $booking->ID, 'location-id', $moveLocation->ID );
-			}
+			update_post_meta( $booking->ID, 'location-id', $moveLocation->ID );
 		}
 
 		return true;

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -225,7 +225,7 @@ class Scheduler {
 	 * - The job has been updated and needs to be rescheduled
 	 * - The plugin has been deactivated
 	 *
-	 * @return int|false|\WP_Error
+	 * @return int|false
 	 */
 	private function unscheduleJob() {
 		return wp_clear_scheduled_hook( $this->jobhook );

--- a/src/Service/TimeframeExport.php
+++ b/src/Service/TimeframeExport.php
@@ -354,11 +354,11 @@ class TimeframeExport {
 	/**
 	 * Gets export fields array from the comma separated string in the settings.
 	 *
-	 * @param $inputString
+	 * @param string|null $inputString
 	 *
-	 * @return false|string[]
+	 * @return string[] returns an empty array when non-string or empty-string input
 	 */
-	private static function convertInputFields( $inputString ) {
+	private static function convertInputFields( $inputString ): array {
 		return array_filter( explode( ',', sanitize_text_field( $inputString ) ) );
 	}
 

--- a/src/Service/TimeframeExport.php
+++ b/src/Service/TimeframeExport.php
@@ -111,6 +111,11 @@ class TimeframeExport {
 	}
 
 
+	/**
+	 * @return void
+	 * @throws CacheException
+	 * @throws InvalidArgumentException
+	 */
 	public static function ajaxExportCsv() {
 		// verify nonce
 		check_ajax_referer( 'cb_export_timeframes', 'nonce' );
@@ -145,8 +150,6 @@ class TimeframeExport {
 					'message' => $e->getMessage(),
 				)
 			);
-
-			return;
 		}
 		$nextPage = $exportObject->lastProcessedPage ? $exportObject->lastProcessedPage + 1 : 1;
 		$exportObject->getExportData( $nextPage );
@@ -161,8 +164,6 @@ class TimeframeExport {
 						'message' => $e->getMessage(),
 					)
 				);
-
-				return;
 			}
 			wp_send_json(
 				array(

--- a/src/Service/iCalendar.php
+++ b/src/Service/iCalendar.php
@@ -272,7 +272,7 @@ class iCalendar {
 			if ( $isTimeSpan ) {
 				$occurence = new TimeSpan( new DateTime( $eventDate[0], false ), new DateTime( $eventDate[1], false ) );
 			} else {
-				$occurence = new MultiDay( $eventDate[0], $eventDate[1] );
+				$occurence = new MultiDay( new Date( $eventDate[0] ), new Date( $eventDate[1] ) );
 			}
 		} else {
 			$occurence = new SingleDay( new Date( $eventDate ) );

--- a/src/Service/iCalendar.php
+++ b/src/Service/iCalendar.php
@@ -251,10 +251,10 @@ class iCalendar {
 	/**
 	 * Adds a generic event to Calendar
 	 *
-	 * @param array|DateTimeImmutable $eventDate
-	 * @param string                  $eventTitle
-	 * @param string                  $eventDescription
-	 * @param bool                    $isTimeSpan
+	 * @param DateTimeImmutable[]|DateTimeImmutable $eventDate
+	 * @param string                                $eventTitle
+	 * @param string                                $eventDescription
+	 * @param bool                                  $isTimeSpan
 	 *
 	 * @return Event|false
 	 */
@@ -266,18 +266,16 @@ class iCalendar {
 	) {
 
 		if ( is_array( $eventDate ) ) {
-			if ( count( $eventDate ) < 2 || ! ( $eventDate[0] instanceof DateTimeImmutable ) || ! ( $eventDate[1] instanceof DateTimeImmutable ) || $eventDate[0] > $eventDate[1] ) {
-				return false;
+			if ( count( $eventDate ) < 2 || $eventDate[0] > $eventDate[1] ) {
+				return false; // FIXME Why fail siltenly?
 			}
 			if ( $isTimeSpan ) {
 				$occurence = new TimeSpan( new DateTime( $eventDate[0], false ), new DateTime( $eventDate[1], false ) );
 			} else {
 				$occurence = new MultiDay( $eventDate[0], $eventDate[1] );
 			}
-		} elseif ( $eventDate instanceof DateTimeImmutable ) {
-			$occurence = new SingleDay( new Date( $eventDate ) );
 		} else {
-			return false;
+			$occurence = new SingleDay( new Date( $eventDate ) );
 		}
 
 		// Create Event domain entity.

--- a/src/Service/iCalendar.php
+++ b/src/Service/iCalendar.php
@@ -86,14 +86,14 @@ class iCalendar {
 	 * This should be relatively secure, since the hash is salted.
 	 * Returns false when user is not logged in
 	 *
-	 * @return string | bool - false when user is not logged in
+	 * @return string | false - false when user is not logged in
 	 */
 	public static function getCurrentUserCalendarLink() {
 		if ( ! is_user_logged_in() ) {
 			return false;}
 
 		$user_id         = wp_get_current_user()->ID;
-		$user_hash       = wp_hash( $user_id );
+		$user_hash       = wp_hash( (string) $user_id );
 		$script_location = get_site_url() . '/';
 
 		return add_query_arg(

--- a/src/Service/iCalendar.php
+++ b/src/Service/iCalendar.php
@@ -30,7 +30,10 @@ use DateInterval;
  */
 class iCalendar {
 
-	private ?Calendar $calendar;
+	/**
+	 * @var Calendar
+	 */
+	private Calendar $calendar;
 
 	public const URL_SLUG       = COMMONSBOOKING_PLUGIN_SLUG . '_ical_download';
 	public const QUERY_USER     = COMMONSBOOKING_PLUGIN_SLUG . '_user';

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -20,12 +20,15 @@ class Booking extends View {
 	/**
 	 * Returns template data for frontend.
 	 *
+	 * @since 2.10.5 wp_json_encode does not contain any bitmap option (before it was true => inferred to JSON_HEX_TAG)
+	 *        which is not needed, since it's not embedded into html.
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public static function getTemplateData(): void {
 		header( 'Content-Type: application/json' );
-		echo wp_json_encode( self::getBookingListData(), true );
+		echo wp_json_encode( self::getBookingListData() );
 		wp_die(); // All ajax handlers die when finished
 	}
 

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -108,6 +108,7 @@ class Booking extends View {
 				'location' => [],
 				'status'   => [],
 			];
+			$bookingDataArray['data']     = [];
 
 			$posts = \CommonsBooking\Repository\Booking::getForUser(
 				$user,
@@ -256,7 +257,7 @@ class Booking extends View {
 			}
 
 			// TODO remove null values from $bookingDataArray['data'] to not break pagination logic
-			if ( array_key_exists( 'data', $bookingDataArray ) && count( $bookingDataArray['data'] ) ) {
+			if ( count( $bookingDataArray['data'] ) ) {
 				$totalCount                      = count( $bookingDataArray['data'] );
 				$bookingDataArray['total']       = $totalCount;
 				$bookingDataArray['total_pages'] = ceil( $totalCount / $postsPerPage );

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -447,7 +447,7 @@ HTML;
 		if ( count( $lines ) % 2 != 0 ) {
 			array_push( $lines, '<tr><td>&nbsp;</td><td>&nbsp;</td></tr>' );
 		}
-		$parts = array_chunk( $lines, ceil( count( $lines ) / 2 ) );
+		$parts = array_chunk( $lines, intval( ceil( count( $lines ) / 2 ) ) );
 
 		return "<table  cellspacing='0' cellpadding='20' class='cmb2-codes-outer-table' ><tbody><tr><td><table class='cmb2-codes-column' cellspacing=\"0\" cellpadding=\"8\" border=\"1\"><tbody>" .
 						implode( '', $parts[0] ) .

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -459,7 +459,7 @@ HTML;
 	/**
 	 * Renders CVS file (txt-format) with booking codes for download
 	 *
-	 * @param $timeframeId
+	 * @param int|null $timeframeId
 	 */
 	public static function renderCSV( $timeframeId = null ) {
 		if ( $timeframeId == null ) {

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -479,9 +479,9 @@ class Calendar {
 	 * Returns Last day of month after next as default for calendar view,
 	 * based on $startDate param.
 	 *
-	 * @param $startDate
+	 * @param Day $startDate
 	 *
-	 * @return false|int
+	 * @return int
 	 */
 	private static function getDefaultCalendarEnddateTimestamp( $startDate ) {
 		return strtotime( 'last day of +3 months', $startDate->getDateObject()->getTimestamp() );

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -133,7 +133,6 @@ abstract class View {
 						$addRange = false;
 
 						if (
-							! $range['start_date'] ||
 							$range['start_date'] > $timeframeStartDate
 						) {
 							$cptData[ $item->ID ]['ranges'][ $key ]['start_date'] = $timeframeStartDate;

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -251,11 +251,12 @@ class Booking extends Timeframe {
 			exit;
 		}
 
-		if ( $itemId === null || ! get_post( $itemId ) ) {
+		if ( $itemId === null || ! filter_var( $itemId, FILTER_VALIDATE_INT ) || ! get_post( (int) $itemId ) ) {
 			// translators: $s = id of the item
 			throw new BookingDeniedException( sprintf( __( 'Item does not exist. (%s)', 'commonsbooking' ), $itemId ) );
 		}
-		if ( $locationId === null || ! get_post( $locationId ) ) {
+
+		if ( $locationId === null || ! filter_var( $locationId, FILTER_VALIDATE_INT ) || ! get_post( (int) $locationId ) ) {
 			// translators: $s = id of the location
 			throw new BookingDeniedException( sprintf( __( 'Location does not exist. (%s)', 'commonsbooking' ), $locationId ) );
 		}
@@ -263,6 +264,12 @@ class Booking extends Timeframe {
 		if ( $repetitionStart === null || $repetitionEnd === null ) {
 			throw new BookingDeniedException( __( 'Start- and/or end-date is missing.', 'commonsbooking' ) );
 		}
+
+		// Validation end, set correctly typed params
+		$itemId          = (int) $itemId;
+		$locationId      = (int) $locationId;
+		$repetitionStart = (int) $repetitionStart;
+		$repetitionEnd   = (int) $repetitionEnd;
 
 		if ( $post_ID != null && ! get_post( $post_ID ) ) {
 			throw new BookingDeniedException(

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -302,7 +302,7 @@ class Booking extends Timeframe {
 			// checks if it's an edit, but ignores exact start/end time
 			$isEdit = count( $existingBookings ) === 1 &&
 						array_values( $existingBookings )[0]->getPost()->post_name === $requestedPostName &&
-						array_values( $existingBookings )[0]->getPost()->post_author === get_current_user_id();
+						intval( array_values( $existingBookings )[0]->getPost()->post_author ) === get_current_user_id();
 
 			if ( ( ! $isEdit || count( $existingBookings ) > 1 ) && $post_status !== 'canceled' ) {
 				if ( $booking ) {

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -102,7 +102,7 @@ class Booking extends Timeframe {
 
 			$postarr = array(
 				'post_title'  => esc_html__( 'Admin-Booking', 'commonsbooking' ),
-				'post_author' => $booking_user,
+				'post_author' => (int) $booking_user,
 				'post_status' => $post_status,
 				'meta_input'  => [
 					'admin_booking_id' => get_current_user_id(),

--- a/src/Wordpress/CustomPostType/Timeframe.php
+++ b/src/Wordpress/CustomPostType/Timeframe.php
@@ -991,7 +991,8 @@ class Timeframe extends CustomPostType {
 			$post = $timeframe->getPost();
 			if ( $post->post_status !== 'draft' ) {
 				$post->post_status = 'draft';
-				wp_update_post( $post );
+				$postArr           = get_object_vars( $post );
+				wp_update_post( $postArr );
 			}
 			return false;
 		}

--- a/src/Wordpress/Widget/UserWidget.php
+++ b/src/Wordpress/Widget/UserWidget.php
@@ -26,6 +26,9 @@ class UserWidget extends WP_Widget {
 		);
 	}
 
+	/**
+	 * @var array<string, mixed>
+	 */
 	public $args = array(
 		'before_title'  => '<h4 class="widgettitle">',
 		'after_title'   => '</h4>',
@@ -33,6 +36,12 @@ class UserWidget extends WP_Widget {
 		'after_widget'  => '</div></div>',
 	);
 
+	/**
+	 * @param array<string, mixed> $args
+	 * @param array<string, mixed> $instance
+	 *
+	 * @return void
+	 */
 	public function widget( $args, $instance ) {
 
 		echo commonsbooking_sanitizeHTML( $args['before_widget'] );
@@ -60,7 +69,10 @@ class UserWidget extends WP_Widget {
 		echo commonsbooking_sanitizeHTML( $args['after_widget'] );
 	}
 
-	public function renderWidgetContent() {
+	/**
+	 * @return string
+	 */
+	public function renderWidgetContent(): string {
 
 		$content = '';
 
@@ -103,11 +115,11 @@ class UserWidget extends WP_Widget {
 	}
 
 	/**
-	 * @param $instance
+	 * @param array<string, mixed> $instance
 	 *
 	 * @return string
 	 */
-	public function form( $instance ) {
+	public function form( $instance ): string {
 
 		$title = ! empty( $instance['title'] ) ? $instance['title'] : esc_html__( '', 'commonsbooking' );
 		$text  = ! empty( $instance['text'] ) ? $instance['text'] : esc_html__( '', 'commonsbooking' );
@@ -129,7 +141,12 @@ class UserWidget extends WP_Widget {
 		return ''; // Parent class returns string, not used
 	}
 
-	public function update( $new_instance, $old_instance ) {
+	/**
+	 * @param array<string, mixed> $new_instance New settings for this instance as input by the user via WP_Widget::form().
+	 * @param array<string, mixed> $old_instance Old settings for this instance.
+	 * @return array<string, mixed> Settings to save or bool false to cancel saving.
+	 */
+	public function update( $new_instance, $old_instance ): array {
 
 		$instance = array();
 


### PR DESCRIPTION
Successor of https://github.com/wielebenwir/commonsbooking/pull/1822

Rule [level 6](https://phpstan.org/user-guide/rule-levels) prooves: `report missing typehints`

At the time of creating this pr, there are more than 700 issues. So help is appreaciated.

------

Goals of this PR (Copied from discussions of previous PRs):

* Use phpdoc @params or @return annotations where appropriate for type checks at (ci) build time

* Use [php type declarations](https://www.php.net/manual/en/language.types.declarations.php) where appropriate, for runtime checking (php language level 7.4)

For phpstan: Apart from general static type checking, my personal goal would be to reach at least [rule level 8](https://phpstan.org/user-guide/rule-levels), to check nullable types.

TODO:
* [ ] fix all phpstan findings