### PR TITLE
TimeframeExport: hide previous success/error messages on consecutive export runs

### DIFF
--- a/assets/admin/js/src/export.js
+++ b/assets/admin/js/src/export.js
@@ -29,6 +29,9 @@
                 settings: settings, progress: progress
             };
 
+            // Initialize visibility
+            doneSpan.hide();
+            failedSpan.hide();
             inProgress.show();
 
 


### PR DESCRIPTION
This fixes the visibilty of the doneSpan (success message) and failedSpan (error message) on consecutive timeframe exports, by properly initializing them "on-click".
Before the (error or success) message of a previous export would still be visible after the next (error or success) run.
