### PR TITLE
Uses translated strings in LitePicker instantiation, instead of static german labels

### DIFF
--- a/assets/public/js/src/litepicker.js
+++ b/assets/public/js/src/litepicker.js
@@ -265,8 +265,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 "useResetBtn": true,
                 "maxDays": globalCalendarData['maxDays'],
                 "buttonText": {
-                    apply: 'Buchen',
-                    cancel: 'Abbrechen',
+                    apply: globalCalendarData['i18n.buttonText.apply'],
+                    cancel: globalCalendarData['i18n.buttonText.cancel'],
                 },
                 onAutoApply: (datePicked) => {
                     if (datePicked) {

--- a/src/View/Item.php
+++ b/src/View/Item.php
@@ -68,13 +68,15 @@ class Item extends View {
 				$args['location'] = new \CommonsBooking\Model\Location( get_post( $location ) );
 			}
 
-			$calendarData          = Calendar::getCalendarDataArray(
+			$calendarData                           = Calendar::getCalendarDataArray(
 				$item,
 				array_key_exists( 'location', $args ) ? $args['location'] : null,
 				date( 'Y-m-d', strtotime( 'first day of this month', time() ) ),
 				date( 'Y-m-d', strtotime( '+3 months', time() ) )
 			);
-			$args['calendar_data'] = wp_json_encode( $calendarData );
+			$calendarData['i18n.buttonText.apply']  = __( 'Book', 'commonsbooking' );
+			$calendarData['i18n.buttonText.cancel'] = __( 'Cancel', 'commonsbooking' );
+			$args['calendar_data']                  = wp_json_encode( $calendarData );
 
 			Plugin::setCacheItem( $args, [ 'misc' ], $customId );
 

--- a/templates/timeframe-calendar.php
+++ b/templates/timeframe-calendar.php
@@ -5,6 +5,8 @@
  * The variable $templateData is set by the files item-single.php or location-single.php
  * This file is loaded as sub-template in the files files item-single.php and location-single.php
  * We recommend not to edit this file as it might be modified and enhancend during updates
+ *
+ * @see $templateData['calendar_data'] / calendarData -- src/View/Item.php
  */
 
 	global $templateData;


### PR DESCRIPTION
Uses globalCalendarData from View/Item.php to instantiate litepicker with translated Strings from pot source, instead of static german labels.

Found this by accident, but I'm unsure if it's a problem or was a problem?