### PR TITLE
docs: add a getting started index page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,7 +45,7 @@ export default defineConfig({
           text: 'Bearbeite diese Seite auf Github'
         },
         sidebar: {
-          '/dokumentation/': { base: '/dokumentation/', items: sidebarDocs_de() },
+          '/dokumentation/': { items: sidebarDocs_de() },
         },
         footer: {
           message: 'Lizensiert unter der GNU v2 Lizenz. <br> <a href="/impressum/">Impressum</a> | <a href="/datenschutzerklaerung/">Datenschutzerklärung</a>',
@@ -84,7 +84,7 @@ export default defineConfig({
             text: 'Edit this page on Github'
           },
           sidebar: {
-            '/en/documentation/': { base: '/en/documentation/', items: sidebarDocs_en() },
+            '/en/documentation/': { items: sidebarDocs_en() },
           },
           footer: {
             message: 'Licensed under the GNU v2 License. <br> <a href="/en/imprint/">Imprint</a> | <a href="/en/privacy-policy/">Privacy Policy</a>',
@@ -159,15 +159,16 @@ export function sidebarDocs_de(): DefaultTheme.SidebarItem[] {
           ]
       },
       {
-          text: 'Erste Schritte', base: '/dokumentation/erste-schritte/',
+          text: 'Erste Schritte',
           collapsed: true,
           items: [
-              { text: 'Artikel anlegen', link: 'artikel-anlegen' },
-              { text: 'Stationen anlegen', link: 'stationen-anlegen' },
-              { text: 'Buchungszeiträume verwalten', link: 'buchungszeitraeume-verwalten'},
-              { text: 'Buchungsregeln einrichten', link: 'buchungsregeln-einrichten' },
-              { text: 'Buchungseinschränkungen verwalten', link: 'buchungseinschraenkungen-verwalten' },
-              { text: 'Zeitrahmen & Feiertage definieren', link: 'zeitrahmen-feiertage-definieren' }
+              { text: 'Los gehts', link: '/dokumentation/erste-schritte/'},
+              { text: 'Artikel anlegen', link: '/dokumentation/erste-schritte/artikel-anlegen' },
+              { text: 'Stationen anlegen', link: '/dokumentation/erste-schritte/stationen-anlegen' },
+              { text: 'Buchungszeiträume verwalten', link: '/dokumentation/erste-schritte/buchungszeitraeume-verwalten'},
+              { text: 'Buchungsregeln einrichten', link: '/dokumentation/erste-schritte/buchungsregeln-einrichten' },
+              { text: 'Buchungseinschränkungen verwalten', link: '/dokumentation/erste-schritte/buchungseinschraenkungen-verwalten' },
+              { text: 'Zeitrahmen & Feiertage definieren', link: '/dokumentation/erste-schritte/zeitrahmen-feiertage-definieren' }
           ]
       },
       {
@@ -220,12 +221,12 @@ export function sidebarDocs_de(): DefaultTheme.SidebarItem[] {
           ]
       },
       {
-          text: 'Schnittstellen / API', base: '/dokumentation/schnittstellen-api/',
-          link: '/',
+          text: 'Schnittstellen / API',
           collapsed: true,
           items: [
-              { text: 'Was ist die CommonsAPI?', link: 'was-ist-die-commonsapi' },
-              { text: 'CommonsBooking API', link: 'commonsbooking-api' },
+              { text: 'Übersicht', link: '/dokumentation/schnittstellen-api/'},
+              { text: 'Was ist die CommonsAPI?', link: '/dokumentation/schnittstellen-api/was-ist-die-commonsapi' },
+              { text: 'CommonsBooking API', link: '/dokumentation/schnittstellen-api/commonsbooking-api' },
               { text: 'GBFS', link: 'gbfs'}
           ]
       },

--- a/docs/dokumentation/erste-schritte/index.md
+++ b/docs/dokumentation/erste-schritte/index.md
@@ -1,19 +1,27 @@
-#  Ausleihangebote verwalten
+# Erste Schritte
 
 __
 
-In diesem Abschnitt erfährst du, wie Du Artikel und Standorte anlegst und
-diese dann entsprechenden Ausleihzeitfenstern zuweist. Ausleihfenster werden
-durch das Anlegen der Zeitrahmen und der sog. Einschränkungen beeinflusst.
+Nachdem die [Installation](/dokumentation/installation/installieren) nun abgeschlossen ist,
+erfährst du in diesem Abschnitt, wie du eine erste interaktive Buchung über deine Website ermöglichst.
 
-  * Jeder Artikel geht davon aus, das das CommonsBooking Plugin im Backend geöffnet ist. Du also den Reiter “CommonsBooking”) in der Leiste links gewählt hast. 
+Du erfährst:
 
-###  Artikel
+* wie du **Stationen** und **Artikel** anlegst
+* wie du **Zeitrahmen** für Ausleihzeiträume definierst
+* wie du **Buchungseinschränkungen** und Regeln einrichtest
+* wie du **Feiertage** im Buchungssystem berücksichtigst
 
-  * [ Station anlegen ](/dokumentation/erste-schritte/stationen-anlegen)
-  * [ Artikel anlegen ](/dokumentation/erste-schritte/artikel-anlegen)
-  * [ Zeitrahmen: Buchungszeiträume verwalten ](/dokumentation/erste-schritte/buchungszeitraeume-verwalten)
-  * [ Buchungseinschränkungen verwalten ](/dokumentation/erste-schritte/buchungseinschraenkungen-verwalten)
-  * [ Buchungsregeln einrichten (Ab 2.9) ](/dokumentation/erste-schritte/buchungsregeln-einrichten)
-  * [ Zeitrahmen: Feiertage definieren ](/dokumentation/erste-schritte/zeitrahmen-feiertage-definieren)
+::: info Wichtig
+Jeder Artikel geht davon aus, das das CommonsBooking Plugin im Backend geöffnet ist. Du also den Reiter “CommonsBooking” in der Leiste links gewählt hast.
+:::
+
+## Schritt für Schritt
+
+  * [Station anlegen](/dokumentation/erste-schritte/stationen-anlegen)
+  * [Artikel anlegen](/dokumentation/erste-schritte/artikel-anlegen)
+  * [Zeitrahmen: Buchungszeiträume verwalten](/dokumentation/erste-schritte/buchungszeitraeume-verwalten)
+  * [Buchungseinschränkungen verwalten](/dokumentation/erste-schritte/buchungseinschraenkungen-verwalten)
+  * [Buchungsregeln einrichten (Ab 2.9)](/dokumentation/erste-schritte/buchungsregeln-einrichten)
+  * [Zeitrahmen: Feiertage definieren](/dokumentation/erste-schritte/zeitrahmen-feiertage-definieren)
 

--- a/docs/dokumentation/index.md
+++ b/docs/dokumentation/index.md
@@ -2,7 +2,14 @@
 
 Die folgende Dokumentation gilt, wenn nicht anders beschrieben, für die neue Version von CommonsBooking (ab Version 2.x.x).
 
-### Habt ihr Fragen oder einen Fehler entdeckt?
+
+::: tip Neu hier?
+Los geht es mit der [Installation](/dokumentation/installation/installieren) und den [ersten Schritten](/dokumentation/erste-schritte).
+:::
+
+
+
+## Habt ihr Fragen oder einen Fehler entdeckt?
 
 Schreibt uns eine [Support-Anfrage über unser Support-System](https://support.commonsbooking.org).
 Dort findet ihr auch eine FAQ mit häufigen Fragen und Antworten.

--- a/docs/dokumentation/installation/installieren.md
+++ b/docs/dokumentation/installation/installieren.md
@@ -2,7 +2,12 @@
 
 __
 
-Installieren der aktuellen Version des neuen CommonsBooking (Version 2.x.x)
+Installieren der aktuellen Version des neuen CommonsBooking (Version 2.x.x).
+
+::: warning Migration?
+**Du hast bereits CommonsBooking 0.9.x installiert?**
+Hier gelangst du zur [Migration](dokumentation/installation/migration-von-cb1)
+:::
 
 ###  ComonsBooking installieren
 


### PR DESCRIPTION
Änderungen für die deutsche Doku:

* Fügt die nötigen Verweise für erste Schritte, Installation und Migration hinzu, wenn User auf die Seite gelangen.

* Fügt eine Übersichtsseite der ersten Schritte hinzu

* Unten das löst ein Problem mit der Anzeige der `nächste Seite` Links im Footer einer Seite.

Changes to docs code:

* removes redundant base config of sidebar

* When we want to show a index page in a sidebar group, we need to use absolute links in sidebar links: 
  So this introduces now absolute links for sidebar group when displaying index page in sidebar-group
  ```
  /dokumentation/erste-schritte/ -> index.md
  /dokumentation/erste-schritte/station-anlegen -> station-anlegen.md
  ```
  This fixes the nextPage/PrevPage rendering, because vitepress did not correctly render the next page `Station anlegen` after `erste-schrittet`index, but rendered `Installieren` every time.