### PR TITLE
Fix for wrong start time of return date

### DIFF
--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -495,7 +495,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 
 		$date_end   = date_i18n( $date_format, $this->getRawEndDate() );
 		$time_end   = date_i18n( $time_format, $this->getRawEndDate() + 60 ); // we add 60 seconds because internal timestamp is set to hh:59
-		$time_start = date_i18n( $time_format, strtotime( $this->getStartTime() ) );
+		$time_start = date_i18n( $time_format, $this->getStartDate() );
 
 		if ( $this->isFullDay() ) {
 			return $date_end;

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -467,11 +467,14 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 
 		$grid = $this->getGrid();
 
+		// the pickup and return time is not obvious from the booking. For example, if the
+		// booking spans over two different slot based timeframes we would need to save one start-time and end-time for the pickup and one for the return
+		// this is why we consult the underlying timeframe to get the slot duration. (See #1865)
 		if ( $grid === 0 ) { // if grid is set to slot duration
 			// If we have the grid size, we use it to calculate right time end
 			$timeframeGridSize = $this->getMeta( self::START_TIMEFRAME_GRIDSIZE );
 			if ( is_numeric( $timeframeGridSize ) ) {
-				$grid = $timeframeGridSize;
+				$grid = intval( $timeframeGridSize );
 			}
 		}
 
@@ -507,7 +510,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 			// If we have the grid size, we use it to calculate right time start
 			$timeframeGridSize = $this->getMeta( self::END_TIMEFRAME_GRIDSIZE );
 			if ( is_numeric( $timeframeGridSize ) ) {
-				$grid = $timeframeGridSize;
+				$grid = intval( $timeframeGridSize );
 			}
 		}
 

--- a/tests/php/Model/BookingTest.php
+++ b/tests/php/Model/BookingTest.php
@@ -248,7 +248,7 @@ class BookingTest extends CustomPostTypeTest {
 
 	public function testReturnDatetime() {
 		// TODO 12:01? correct
-		$this->assertEquals( 'July 3, 2021 8:00 am - 12:01 am', $this->testBookingTomorrow->returnDatetime() );
+		$this->assertEquals( 'July 3, 2021 12:00 am - 12:01 am', $this->testBookingTomorrow->returnDatetime() );
 
 		// Test Return for Slot Timeframes (#1342)
 		$this->assertEquals( self::CURRENT_DATE_FORMATTED . ' 3:00 pm - 6:00 pm', $this->testBookingSpanningOverTwoSlots->returnDatetime() );

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -223,7 +223,9 @@ abstract class CustomPostTypeTest extends BaseTestCase {
 		$timeframeMaxDays = 3,
 		$postTitle = 'Booking',
 		$grid = 0,
-		$weekdays = [ '1', '2', '3', '4', '5', '6', '7' ]
+		$weekdays = [ '1', '2', '3', '4', '5', '6', '7' ],
+		$startGridSize = '', // How long is the timeframe in which the booking starts
+		$endGridSize = '' // How long is the timeframe in which the booking ends
 	) {
 		// Create booking
 		$bookingId = wp_insert_post(
@@ -246,6 +248,13 @@ abstract class CustomPostTypeTest extends BaseTestCase {
 		update_post_meta( $bookingId, 'repetition-start', $repetitionStart );
 		update_post_meta( $bookingId, 'repetition-end', $repetitionEnd );
 		update_post_meta( $bookingId, 'weekdays', $weekdays );
+
+		if ( $startGridSize ) {
+			update_post_meta( $bookingId, \CommonsBooking\Model\Booking::START_TIMEFRAME_GRIDSIZE, $startGridSize );
+		}
+		if ( $endGridSize ) {
+			update_post_meta( $bookingId, \CommonsBooking\Model\Booking::END_TIMEFRAME_GRIDSIZE, $endGridSize );
+		}
 
 		$this->bookingIds[] = $bookingId;
 
@@ -569,7 +578,7 @@ abstract class CustomPostTypeTest extends BaseTestCase {
             location bigint(20) unsigned NOT NULL,
             item bigint(20) unsigned NOT NULL,
             code varchar(100) NOT NULL,
-            PRIMARY KEY (date, timeframe, location, item, code) 
+            PRIMARY KEY (date, timeframe, location, item, code)
         ) $charset_collate;";
 
 		$wpdb->query( $sql );


### PR DESCRIPTION
When we receive the confirmation email for a booking, the return date shows the time of the booking instead of the time of the actual return date.

In the screenshot below: 11:55 should be 19:00.

<img width="260" height="109" alt="Bildschirmfoto 2025-07-19 um 11 56 35" src="https://github.com/user-attachments/assets/7adfd756-3711-41e2-96e1-529b2f8b0d30" />

This PR fixes it for us. I don't know if there was a specific reason for why it was implemented differently.