### PR TITLE
Cache: add save post feature flag

### DIFF
--- a/docs/dokumentation/erweiterte-funktionalitaet/cache.md
+++ b/docs/dokumentation/erweiterte-funktionalitaet/cache.md
@@ -30,15 +30,40 @@ Ein falsch konfigurierter Cache kann deine Seite verlangsamen.
 
 * **Regelmäßiges Aufwärmen des Caches durch Cronjob**:
   :::warning ACHTUNG
-  Diese Einstellung ist nur für ganz besondere Randfälle gedacht und betrifft dich vermutlich nicht.Außerdem ist die Funktion experimentell und kann unerwünschte Nebeneffekte haben. Wir konnten zum Beispiel nicht feststellen, ob der Cache nach einer Buchung rechtzeitig geleert wird. Der Cronjob sollte wahrscheinlich relativ häufig ausgeführt werden, wenn die Funktion genutzt werden soll.
+  Diese Einstellung ist nur für ganz besondere Randfälle gedacht und betrifft dich vermutlich nicht.
+  Außerdem ist die Funktion experimentell und kann unerwünschte Nebeneffekte haben.
+  Wir konnten zum Beispiel nicht feststellen, ob der Cache nach einer Buchung rechtzeitig geleert wird.
+  Der Cronjob sollte wahrscheinlich relativ häufig ausgeführt werden, wenn die Funktion genutzt werden soll.
   :::
   Wenn deine Seite selten aufgerufen wird aber viele Artikel / Buchungen enthält kann es sein, dass beim ersten Aufrufen
   die Seite sehr langsam reagiert. Falls sich das zum Problem entwickelt, kannst du den Cache regelmäßig aufwärmen lassen.
+
   Das geht mit der Option "Regelmäßiges Aufwärmen des Caches durch Cronjob". Wenn diese Checkbox aktiviert ist, wird der Cache regelmäßig
   durch einen Cronjob aufgewärmt. Anschließend kannst du einstellen, wie oft der Cache automatisch aufgewärmt werden soll. Dies kann zu höherer Serverlast führen, wenn der Cache sehr regelmäßig aufgewärmt wird.
-  Damit das gelingt MUSS WP-Cron in den System Task Scheduler eingebunden sein. Siehe hier: [Hooking WP-Cron Into the System Task Scheduler](https://developer.wordpress.org/plugins/cron/hooking-wp-cron-into-the-system-task-scheduler/)
+  Damit das gelingt, **MUSS** WP-Cron in den System Task Scheduler eingebunden sein. Siehe hier: [Hooking WP-Cron Into the System Task Scheduler](https://developer.wordpress.org/plugins/cron/hooking-wp-cron-into-the-system-task-scheduler/)
+
+  Technisches Detail: Zusätzlich kannst du das **verzögerte Leeren** des Caches freischalten, um so alle Vorteile des
+  Cache-Aufwärmens zu nutzen. Dazu setze folgendes [Feature-Flag](https://de.wikipedia.org/wiki/Feature_Toggle)
+  via `add_filter`.
+  ```php
+  add_filter( 'commonsbooking_feature_schedule_cache_savepost_enabled', '__return_true' )
+  ```
+  Nun wird deine Installation die vorgehaltenen Daten eines Posts **verzögert** Leeren und nicht sofort.
+  Das heißt, die Operation zum Erstellen einer Buchung, wird so schneller beendet.
 
 ## Bekannte Probleme
+
+### Doppel-Buchungen
+
+::: warning Behoben in 2.10.6
+:::
+
+In der Version 2.10.X bis 2.10.5 war es durch einen fehlerhaften Cache-Zustand möglich, Doppel-Buchungen zu erstellen.
+Mit der Version 2.10.6 ist dies behoben und mit der Version 2.10.7 kann das verzögerte Aufwärmen separat freigeschaltet werden.
+Siehe dazu den o.g. Filter-Hook `commonsbooking_feature_schedule_cache_savepost_enabled`.
+
+
+### Inkompatible Plugins
 
 In der Vergangenheit gab es bereits Probleme mit anderen Wordpress-Plugins wie z.B. 'REDIS Object Cache'.
 Aus diesem Grund raten wir von der Nutzung solcher Plugins ab.

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ CommonsBooking was developed for the ["Commons Cargobike" movement](http://commo
 
 ## Changelog
 
+### 2.10.7
+ADDED: Filter Hook to enable deferred cache warmup for savePost actions
+
 ### 2.10.6 (22.08.2025)
 FIXED: Removed deferred cache clearing in order to avoid double booking
 FIXED: Wrong pickup / return time displayed (thx @janschoenherr)

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -830,7 +830,18 @@ class Plugin {
 		if ( ! in_array( $post->post_status, $ignoredStates ) || $update ) {
 			$tags   = Wordpress::getRelatedPostIds( $post_id );
 			$tags[] = 'misc';
-			self::clearCache( $tags );
+
+			/**
+			 * Enables the scheduling of cache-clearing on savePost actions. Defaults to false.
+			 *
+			 * @since 2.10.7 initial
+			 */
+			$schedule_cache_enabled = apply_filters( 'commonsbooking_feature_schedule_cache_savepost_enabled', false );
+			if ( $schedule_cache_enabled ) {
+				self::scheduleClearCache( $tags );
+			} else {
+				self::clearCache( $tags );
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds a feature-flag to enable plugin users to still use the clearCache routine as scheduled event in savePost actions.

* uses php constant via `define`
* adds instructions in plugin docs

---

Release `2.10.6` replaced the `scheduleClearCache` with `clearCache`, because of reports of double-bookings (see #1864), caused by the scheduled clearCache event not being run.

This would render the `warmup-cache` feature (see #1757), introduced in `2.10.5` pretty much useless.

At least in our instance (dasallrad.org) there were no cases of double-bookings, and I highly suspect it is because we have a minutely cron-job in place.

Because of this I would like to be able to use this feature.