### PR TITLE
fix #1273 (bring back restriction blocking for ALL items / locations)

### DIFF
--- a/src/Wordpress/CustomPostType/Restriction.php
+++ b/src/Wordpress/CustomPostType/Restriction.php
@@ -417,7 +417,7 @@ class Restriction extends CustomPostType {
 					__(
 						'Select the type of restriction.<br>
 				Select <strong>Notice</strong>, the item can still be used and if e.g. only one part is missing or defective.<br>
-				Select <strong>total breakdown</strong> if the defect means that the item can no longer be used. If you select total breakdown 
+				Select <strong>total breakdown</strong> if the defect means that the item can no longer be used. If you select total breakdown
 				all affected bookings will be automatically canceled after activating this restriction and after clicking send the information email.
 				',
 						'commonsbooking'
@@ -431,12 +431,14 @@ class Restriction extends CustomPostType {
 				'name'             => esc_html__( 'Location', 'commonsbooking' ),
 				'id'               => \CommonsBooking\Model\Restriction::META_LOCATION_ID,
 				'type'             => 'select',
+				'show_option_none' => commonsbooking_isCurrentUserAdmin() ? esc_html__( 'All', 'commonsbooking' ) : false,
 				'options'          => self::sanitizeOptions( \CommonsBooking\Repository\Location::getByCurrentUser() ),
 			),
 			array(
 				'name'             => esc_html__( 'Item', 'commonsbooking' ),
 				'id'               => \CommonsBooking\Model\Restriction::META_ITEM_ID,
 				'type'             => 'select',
+				'show_option_none' => esc_html__( 'All', 'commonsbooking' ),
 				'options'          => self::sanitizeOptions( \CommonsBooking\Repository\Item::getByCurrentUser() ),
 			),
 			array(


### PR DESCRIPTION
As already suggested in #1273 , an easy fix for this would be to allow "all" locations for just the admin and "all" items will accessible to cb_managers. This way, they can still only block items at locations managed by them. 

This is a much simpler fix than the reworks I previously proposed but I would prefer this one.

closes #1273 