### PR TITLE
fix #1900 (overbooking not counted)

### DIFF
--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -1222,10 +1222,15 @@ class Timeframe extends CustomPost {
 	 * manual = manual selection of dates
 	 * norep = no repetition
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function getRepetition() {
-		return $this->getMeta( self::META_REPETITION );
+		$meta = $this->getMeta( self::META_REPETITION );
+		if ( $meta ) {
+			return strval( $meta );
+		} else {
+			return 'norep'; // usually not set for booking timeframes
+		}
 	}
 
 	/**


### PR DESCRIPTION
fixed through updating getRepetition to always return 'norep' when it is not defined. repetition is usually not defined for bookings. Therefore we should return norep in those cases.

closes #1900