### PR TITLE
adds phpcs i18n check to CI/CD (using wpcs action)

### DIFF
--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -1,4 +1,4 @@
-name: WPCS check
+name: WPCS WP.i18n check
 
 on:
   push:


### PR DESCRIPTION
Alternative to #2000 

This pr uses the wpcs action (which adds the annotations to all changed files of a pull request, where the wpcs check was run on).

I validated the successfull check in commit https://github.com/wielebenwir/commonsbooking/pull/2007/commits/506e7b7c6be73dc9e261a038085c58ce9f0ef352 and its wpcs action run).