### PR TITLE
fix #1906 slot based manual timeframes not found

### DIFF
--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -95,7 +95,7 @@ class Day {
 	 * @return string
 	 */
 	public function getDate(): string {
-		return date('Y-m-d', strtotime($this->date));
+		return date( 'Y-m-d', strtotime( $this->date ) );
 	}
 
 	/**
@@ -360,9 +360,7 @@ class Day {
 
 					// Manual Rep
 				case 'manual':
-					$manualSelectionDates = $timeframe->getManualSelectionDates();
-					$date1 = $this->getDate();
-					return in_array( $date1, $manualSelectionDates);
+					return in_array( $this->getDate(), $timeframe->getManualSelectionDates() );
 
 				// No Repetition
 				case 'norep':


### PR DESCRIPTION
getDate is used nowhere in the templates and if, it is localized through WP functions so it should be safe to force this Y-m-d date output. In that way, we can quickly check if a day is in the manual repetition days by using get_date and in_array, as originally planned. See the issue #1906 for a more detailed problem description.

closes #1906