### PR TITLE
agentic performance improvements

### DIFF
--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -43,12 +43,14 @@ class Wordpress {
 		$wpPosts = [];
 		$ids     = [];
 		foreach ( $posts as $post ) {
-			// Populate the WP post object cache directly from the already-fetched raw data,
-			// avoiding a redundant SELECT per post.
+			// Build WP_Post from raw data and prime the post object cache directly,
+			// avoiding a redundant SELECT per post. sanitize_post('raw') casts integer
+			// fields (ID, menu_order, …) and sets filter = 'raw', matching get_post().
 			$wpPost = new \WP_Post( $post );
-			wp_cache_add( $post->ID, $wpPost, 'posts' );
+			sanitize_post( $wpPost, 'raw' );
+			wp_cache_add( $wpPost->ID, $wpPost, 'posts' );
 			$wpPosts[] = $wpPost;
-			$ids[]     = (int) $post->ID;
+			$ids[]     = $wpPost->ID;
 		}
 
 		// Prime the post-meta cache in one batch query so that all subsequent

--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -36,12 +36,26 @@ class Wordpress {
 	 * @return array|array[]|null[]|\WP_Post[]
 	 */
 	public static function flattenWpdbResult( $posts ): array {
-		return array_map(
-			function ( $post ) {
-				return get_post( $post->ID );
-			},
-			$posts
-		);
+		if ( empty( $posts ) ) {
+			return [];
+		}
+
+		$wpPosts = [];
+		$ids     = [];
+		foreach ( $posts as $post ) {
+			// Populate the WP post object cache directly from the already-fetched raw data,
+			// avoiding a redundant SELECT per post.
+			$wpPost = new \WP_Post( $post );
+			wp_cache_add( $post->ID, $wpPost, 'posts' );
+			$wpPosts[] = $wpPost;
+			$ids[]     = (int) $post->ID;
+		}
+
+		// Prime the post-meta cache in one batch query so that all subsequent
+		// get_post_meta() calls for these posts are served from the in-memory cache.
+		update_postmeta_cache( $ids );
+
+		return $wpPosts;
 	}
 
 	/**

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -131,8 +131,8 @@ class Calendar {
 					$this->locations,
 					$this->items,
 					$this->types,
-					$this->timeframes,
-					! empty( $this->restrictions ) ? $this->restrictions : null
+					! empty( $this->timeframes ) ? $this->timeframes : null,
+					$this->restrictions
 				);
 				$startDate = strtotime( 'next monday', $startDate );
 			}

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -132,7 +132,7 @@ class Calendar {
 					$this->items,
 					$this->types,
 					$this->timeframes,
-					$this->restrictions
+					! empty( $this->restrictions ) ? $this->restrictions : null
 				);
 				$startDate = strtotime( 'next monday', $startDate );
 			}

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -46,6 +46,14 @@ class Calendar {
 	protected array $timeframes;
 
 	/**
+	 * Restrictions pre-fetched for the full calendar range, passed down to Week and Day
+	 * to avoid one DB query per day.
+	 *
+	 * @var \CommonsBooking\Model\Restriction[]
+	 */
+	protected array $restrictions;
+
+	/**
 	 * Calendar constructor.
 	 *
 	 * @param Day   $startDate
@@ -74,6 +82,16 @@ class Calendar {
 			$this->types,
 			true,
 			[ 'confirmed', 'publish' ]
+		);
+
+		// Pre-fetch all restrictions for the date range once so Week/Day don't each issue their own DB query.
+		$this->restrictions = \CommonsBooking\Repository\Restriction::get(
+			$this->locations,
+			$this->items,
+			null,
+			true,
+			$this->startDate->getStartTimestamp(),
+			[ 'publish', 'confirmed', 'unconfirmed' ]
 		);
 	}
 
@@ -108,7 +126,8 @@ class Calendar {
 					$this->locations,
 					$this->items,
 					$this->types,
-					$this->timeframes
+					$this->timeframes,
+					$this->restrictions
 				);
 				$startDate = strtotime( 'next monday', $startDate );
 			}

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -60,9 +60,10 @@ class Calendar {
 	 * @param Day   $endDate
 	 * @param int[] $locations
 	 * @param int[] $items
+	 * @param array $preloadedTimeframes When non-empty, these are used directly instead of querying the DB.
 	 * @param array $types
 	 */
-	public function __construct( Day $startDate, Day $endDate, array $locations = [], array $items = [], array $types = [] ) {
+	public function __construct( Day $startDate, Day $endDate, array $locations = [], array $items = [], array $preloadedTimeframes = [], array $types = [] ) {
 		// check, that it spans at least two days
 		if ( $startDate->getDate() == $endDate->getDate() ) {
 			throw new \InvalidArgumentException( 'Calendar must span at least two days' );
@@ -74,15 +75,19 @@ class Calendar {
 		$this->locations = $locations;
 		$this->types     = $types;
 
-		$this->timeframes = \CommonsBooking\Repository\Timeframe::getInRange(
-			$this->startDate->getStartTimestamp(),
-			$this->endDate->getEndTimestamp(),
-			$this->locations,
-			$this->items,
-			$this->types,
-			true,
-			[ 'confirmed', 'publish' ]
-		);
+		if ( ! empty( $preloadedTimeframes ) ) {
+			$this->timeframes = $preloadedTimeframes;
+		} else {
+			$this->timeframes = \CommonsBooking\Repository\Timeframe::getInRange(
+				$this->startDate->getStartTimestamp(),
+				$this->endDate->getEndTimestamp(),
+				$this->locations,
+				$this->items,
+				$this->types,
+				true,
+				[ 'confirmed', 'publish' ]
+			);
+		}
 
 		// Pre-fetch all restrictions for the date range once so Week/Day don't each issue their own DB query.
 		$this->restrictions = \CommonsBooking\Repository\Restriction::get(

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -67,12 +67,12 @@ class Day {
 	/**
 	 * Day constructor.
 	 *
-	 * @param string      $date
-	 * @param array       $locations
-	 * @param array       $items
-	 * @param array       $types
-	 * @param array|null  $possibleTimeframes Pre-fetched timeframes for the calendar range (null = not provided, query DB; [] = pre-fetched but none apply).
-	 * @param array|null  $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB; [] = explicitly none).
+	 * @param string     $date
+	 * @param array      $locations
+	 * @param array      $items
+	 * @param array      $types
+	 * @param array|null $possibleTimeframes Pre-fetched timeframes for the calendar range (null = not provided, query DB; [] = pre-fetched but none apply).
+	 * @param array|null $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB; [] = explicitly none).
 	 */
 	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], ?array $possibleTimeframes = null, ?array $possibleRestrictions = null ) {
 		$this->date      = $date;
@@ -525,7 +525,7 @@ class Day {
 
 	public function getStartTimestamp(): int {
 		if ( $this->startTimestampCached === null ) {
-			$dt                        = new DateTime( $this->getDate() );
+			$dt = new DateTime( $this->getDate() );
 			$dt->modify( 'midnight' );
 			$this->startTimestampCached = $dt->getTimestamp();
 		}
@@ -535,7 +535,7 @@ class Day {
 
 	public function getEndTimestamp(): int {
 		if ( $this->endTimestampCached === null ) {
-			$dt                      = new DateTime( $this->getDate() );
+			$dt = new DateTime( $this->getDate() );
 			$dt->modify( '23:59:59' );
 			$this->endTimestampCached = $dt->getTimestamp();
 		}

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -43,6 +43,13 @@ class Day {
 	protected ?array $timeframes = null;
 
 	/**
+	 * Pre-fetched restrictions for this day. When set, getRestrictions() uses this instead of querying the DB.
+	 *
+	 * @var \CommonsBooking\Model\Restriction[]|null
+	 */
+	protected ?array $restrictions = null;
+
+	/**
 	 * Day constructor.
 	 *
 	 * @param string $date
@@ -50,8 +57,9 @@ class Day {
 	 * @param array  $items
 	 * @param array  $types
 	 * @param array  $possibleTimeframes
+	 * @param array  $possibleRestrictions Pre-fetched restrictions for the calendar range; filtered to this day here.
 	 */
-	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [] ) {
+	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], array $possibleRestrictions = [] ) {
 		$this->date      = $date;
 		$this->locations = array_map(
 			function ( $location ) {
@@ -71,6 +79,13 @@ class Day {
 		if ( ! empty( $possibleTimeframes ) ) {
 			$this->timeframes = \CommonsBooking\Repository\Timeframe::filterTimeframesForTimerange( $possibleTimeframes, $this->getStartTimestamp(), $this->getEndTimestamp() );
 			$this->timeframes = array_filter( $this->timeframes, fn( $timeframe ) => $this->filterTimeframe( $timeframe ) );
+		}
+
+		if ( ! empty( $possibleRestrictions ) ) {
+			$this->restrictions = \CommonsBooking\Repository\Restriction::filterRestrictionsForDate( $possibleRestrictions, $this->getDate() );
+		} elseif ( is_array( $possibleRestrictions ) ) {
+			// An explicitly passed empty array means "there are no restrictions" — skip the DB query.
+			$this->restrictions = [];
 		}
 	}
 
@@ -155,6 +170,10 @@ class Day {
 	 * @throws Exception
 	 */
 	public function getRestrictions(): array {
+		if ( $this->restrictions !== null ) {
+			return $this->restrictions;
+		}
+
 		return \CommonsBooking\Repository\Restriction::get(
 			$this->locations,
 			$this->items,

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -71,10 +71,10 @@ class Day {
 	 * @param array       $locations
 	 * @param array       $items
 	 * @param array       $types
-	 * @param array       $possibleTimeframes
+	 * @param array|null  $possibleTimeframes Pre-fetched timeframes for the calendar range (null = not provided, query DB; [] = pre-fetched but none apply).
 	 * @param array|null  $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB; [] = explicitly none).
 	 */
-	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], ?array $possibleRestrictions = null ) {
+	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], ?array $possibleTimeframes = null, ?array $possibleRestrictions = null ) {
 		$this->date      = $date;
 		$this->locations = array_map(
 			function ( $location ) {
@@ -91,9 +91,11 @@ class Day {
 
 		$this->types = $types;
 
-		if ( ! empty( $possibleTimeframes ) ) {
+		if ( $possibleTimeframes !== null ) {
+			// Pre-fetched: filter to this day's range and apply weekday rules.
+			// Result may be [] — that tells getTimeframes() "nothing applies, skip DB query".
 			$this->timeframes = \CommonsBooking\Repository\Timeframe::filterTimeframesForTimerange( $possibleTimeframes, $this->getStartTimestamp(), $this->getEndTimestamp() );
-			$this->timeframes = array_filter( $this->timeframes, fn( $timeframe ) => $this->filterTimeframe( $timeframe ) );
+			$this->timeframes = array_values( array_filter( $this->timeframes, fn( $timeframe ) => $this->filterTimeframe( $timeframe ) ) );
 		}
 
 		if ( $possibleRestrictions !== null ) {

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -67,14 +67,14 @@ class Day {
 	/**
 	 * Day constructor.
 	 *
-	 * @param string $date
-	 * @param array  $locations
-	 * @param array  $items
-	 * @param array  $types
-	 * @param array  $possibleTimeframes
-	 * @param array  $possibleRestrictions Pre-fetched restrictions for the calendar range; filtered to this day here.
+	 * @param string      $date
+	 * @param array       $locations
+	 * @param array       $items
+	 * @param array       $types
+	 * @param array       $possibleTimeframes
+	 * @param array|null  $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB; [] = explicitly none).
 	 */
-	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], array $possibleRestrictions = [] ) {
+	public function __construct( string $date, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], ?array $possibleRestrictions = null ) {
 		$this->date      = $date;
 		$this->locations = array_map(
 			function ( $location ) {
@@ -96,12 +96,15 @@ class Day {
 			$this->timeframes = array_filter( $this->timeframes, fn( $timeframe ) => $this->filterTimeframe( $timeframe ) );
 		}
 
-		if ( ! empty( $possibleRestrictions ) ) {
-			$this->restrictions = \CommonsBooking\Repository\Restriction::filterRestrictionsForDate( $possibleRestrictions, $this->getDate() );
-		} elseif ( is_array( $possibleRestrictions ) ) {
-			// An explicitly passed empty array means "there are no restrictions" — skip the DB query.
-			$this->restrictions = [];
+		if ( $possibleRestrictions !== null ) {
+			if ( ! empty( $possibleRestrictions ) ) {
+				$this->restrictions = \CommonsBooking\Repository\Restriction::filterRestrictionsForDate( $possibleRestrictions, $this->getDate() );
+			} else {
+				// Calendar pre-fetched 0 matching restrictions — skip the DB query.
+				$this->restrictions = [];
+			}
 		}
+		// When $possibleRestrictions === null, leave $this->restrictions = null so getRestrictions() queries the DB.
 	}
 
 	/**

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -49,6 +49,21 @@ class Day {
 	 */
 	protected ?array $restrictions = null;
 
+	/** Cached timestamp derived from $this->date — computed once on first access. */
+	private ?int $dateTimestamp = null;
+
+	/** Cached Y-m-d string. */
+	private ?string $dateFormatted = null;
+
+	/** Cached start-of-day timestamp (midnight). */
+	private ?int $startTimestampCached = null;
+
+	/** Cached end-of-day timestamp (23:59:59). */
+	private ?int $endTimestampCached = null;
+
+	/** Cached UTC DateTime object. */
+	private ?DateTime $dateObjectCached = null;
+
 	/**
 	 * Day constructor.
 	 *
@@ -93,7 +108,18 @@ class Day {
 	 * @return false|string
 	 */
 	public function getDayOfWeek() {
-		return date( 'w', strtotime( $this->getDate() ) );
+		return date( 'w', $this->getTimestamp() );
+	}
+
+	/**
+	 * Returns the raw Unix timestamp for this date string (cached).
+	 */
+	private function getTimestamp(): int {
+		if ( $this->dateTimestamp === null ) {
+			$this->dateTimestamp = strtotime( $this->date );
+		}
+
+		return $this->dateTimestamp;
 	}
 
 	/**
@@ -101,7 +127,11 @@ class Day {
 	 * @throws Exception
 	 */
 	public function getDateObject(): DateTime {
-		return Wordpress::getUTCDateTime( $this->getDate() );
+		if ( $this->dateObjectCached === null ) {
+			$this->dateObjectCached = Wordpress::getUTCDateTime( $this->getDate() );
+		}
+
+		return $this->dateObjectCached;
 	}
 
 	/**
@@ -110,7 +140,11 @@ class Day {
 	 * @return string
 	 */
 	public function getDate(): string {
-		return date( 'Y-m-d', strtotime( $this->date ) );
+		if ( $this->dateFormatted === null ) {
+			$this->dateFormatted = date( 'Y-m-d', $this->getTimestamp() );
+		}
+
+		return $this->dateFormatted;
 	}
 
 	/**
@@ -121,7 +155,7 @@ class Day {
 	 * @return false|string
 	 */
 	public function getFormattedDate( string $format ) {
-		return date( $format, strtotime( $this->getDate() ) );
+		return date( $format, $this->getTimestamp() );
 	}
 
 	/**
@@ -130,7 +164,7 @@ class Day {
 	 * @return false|string
 	 */
 	public function getName() {
-		return date( 'l', strtotime( $this->getDate() ) );
+		return date( 'l', $this->getTimestamp() );
 	}
 
 	/**
@@ -229,9 +263,7 @@ class Day {
 		if ( $timeframe->getType() === Timeframe::BOOKING_ID ) {
 			$booking          = new Booking( $timeframe->getPost() );
 			$startDateBooking = $booking->getStartDate();
-			$startDateDay     = strtotime( $this->getDate() );
-
-			// if booking starts on day before, we set startslot to 0
+			$startDateDay     = $this->getTimestamp();
 			if ( $startDateBooking < $startDateDay ) {
 				$startSlot = 0;
 			}
@@ -259,9 +291,7 @@ class Day {
 		$startSlot = $this->getSlotByTime( $startTime, $grid );
 
 		$startDateBooking = $restriction->getStartDate();
-		$startDateDay     = strtotime( $this->getDate() );
-
-		// if restriction starts on day before, we set startslot to 0
+		$startDateDay     = $this->getTimestamp();
 		if ( $startDateBooking < $startDateDay ) {
 			$startSlot = 0;
 		}
@@ -295,7 +325,7 @@ class Day {
 		// If we have a overbooked day, we need to mark all slots as booked
 		if ( ! $timeframe->isOverBookable() && ! empty( $endDate ) && $timeframe->getRepetition() == 'norep' ) {
 			// Check if timeframe ends after the current day
-			if ( strtotime( $this->getFormattedDate( 'd.m.Y 23:59:59' ) ) < $endDate->getTimestamp() ) {
+			if ( $this->getEndTimestamp() < $endDate->getTimestamp() ) {
 				$endSlot = count( $slots );
 			}
 		}
@@ -321,7 +351,7 @@ class Day {
 		$endSlot = $this->getSlotByTime( $endTime, $grid );
 
 		// Check if timeframe ends after the current day
-		if ( strtotime( $this->getFormattedDate( 'd.m.Y 23:59' ) ) < $endDate->getTimestamp() ) {
+		if ( $this->getEndTimestamp() < $endDate->getTimestamp() ) {
 			$endSlot = count( $slots );
 		}
 
@@ -489,17 +519,23 @@ class Day {
 	}
 
 	public function getStartTimestamp(): int {
-		$dt = new DateTime( $this->getDate() );
-		$dt->modify( 'midnight' );
+		if ( $this->startTimestampCached === null ) {
+			$dt                        = new DateTime( $this->getDate() );
+			$dt->modify( 'midnight' );
+			$this->startTimestampCached = $dt->getTimestamp();
+		}
 
-		return $dt->getTimestamp();
+		return $this->startTimestampCached;
 	}
 
 	public function getEndTimestamp(): int {
-		$dt = new DateTime( $this->getDate() );
-		$dt->modify( '23:59:59' );
+		if ( $this->endTimestampCached === null ) {
+			$dt                      = new DateTime( $this->getDate() );
+			$dt->modify( '23:59:59' );
+			$this->endTimestampCached = $dt->getTimestamp();
+		}
 
-		return $dt->getTimestamp();
+		return $this->endTimestampCached;
 	}
 
 
@@ -607,7 +643,7 @@ class Day {
 	 * @return false|float|int
 	 */
 	protected function getSlotTimestampStart( $slotsPerDay, $slotNr ) {
-		return strtotime( $this->getDate() ) + ( $slotNr * ( ( 24 / $slotsPerDay ) * 3600 ) );
+		return $this->getTimestamp() + ( $slotNr * ( ( 24 / $slotsPerDay ) * 3600 ) );
 	}
 
 	/**
@@ -619,6 +655,6 @@ class Day {
 	 * @return false|float|int
 	 */
 	protected function getSlotTimestampEnd( $slotsPerDay, $slotNr ) {
-		return strtotime( $this->getDate() ) + ( ( $slotNr + 1 ) * ( ( 24 / $slotsPerDay ) * 3600 ) ) - 1;
+		return $this->getTimestamp() + ( ( $slotNr + 1 ) * ( ( 24 / $slotsPerDay ) * 3600 ) ) - 1;
 	}
 }

--- a/src/Model/Week.php
+++ b/src/Model/Week.php
@@ -42,9 +42,9 @@ class Week {
 	protected $types;
 
 	/**
-	 * @var Timeframe[]
+	 * @var Timeframe[]|null null = no pre-fetch was done; [] or non-empty = pre-fetched (possibly empty for this week).
 	 */
-	private array $timeframes = [];
+	private ?array $timeframes = null;
 
 	/**
 	 * Pre-fetched restrictions for this week's range.
@@ -61,10 +61,10 @@ class Week {
 	 * @param array       $locations
 	 * @param array       $items
 	 * @param array       $types
-	 * @param Timeframe[] $possibleTimeframes Timeframes that might be relevant for this week, need to be filtered.
-	 * @param array|null  $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB).
+	 * @param Timeframe[]|null $possibleTimeframes Timeframes pre-fetched for the calendar range (null = not provided, query DB per day).
+	 * @param array|null       $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB).
 	 */
-	public function __construct( $year, $dayOfYear, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], ?array $possibleRestrictions = null ) {
+	public function __construct( $year, $dayOfYear, array $locations = [], array $items = [], array $types = [], ?array $possibleTimeframes = null, ?array $possibleRestrictions = null ) {
 		if ( $year === null ) {
 			$year = date( 'Y' );
 		}
@@ -74,7 +74,9 @@ class Week {
 		$this->items     = $items;
 		$this->types     = $types;
 
-		if ( ! empty( $possibleTimeframes ) ) {
+		if ( $possibleTimeframes !== null ) {
+			// Pre-fetched: filter to this week's range. The result may be empty [] — that's fine,
+			// it tells Day "we already know there are no timeframes, skip the DB query".
 			$this->timeframes = \CommonsBooking\Repository\Timeframe::filterTimeframesForTimerange( $possibleTimeframes, $this->getStartTimestamp(), $this->getEndTimestamp() );
 		}
 
@@ -106,7 +108,7 @@ class Week {
 			$days = array();
 			for ( $i = 0; $i < 7; $i++ ) {
 				$dayDate   = $dto->format( 'Y-m-d' );
-				$days[]    = new Day( $dayDate, $this->locations, $this->items, $this->types, $this->timeframes ?: [], $this->possibleRestrictions );
+				$days[]    = new Day( $dayDate, $this->locations, $this->items, $this->types, $this->timeframes, $this->possibleRestrictions );
 				$dayOfWeek = $dto->format( 'w' );
 				if ( $dayOfWeek === '0' ) {
 					break;

--- a/src/Model/Week.php
+++ b/src/Model/Week.php
@@ -47,6 +47,13 @@ class Week {
 	private array $timeframes = [];
 
 	/**
+	 * Pre-fetched restrictions for this week's range.
+	 *
+	 * @var \CommonsBooking\Model\Restriction[]
+	 */
+	private array $possibleRestrictions = [];
+
+	/**
 	 * Week constructor.
 	 *
 	 * @param $year
@@ -55,8 +62,9 @@ class Week {
 	 * @param array       $items
 	 * @param array       $types
 	 * @param Timeframe[] $possibleTimeframes Timeframes that might be relevant for this week, need to be filtered.
+	 * @param array       $possibleRestrictions Pre-fetched restrictions for the calendar range.
 	 */
-	public function __construct( $year, $dayOfYear, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [] ) {
+	public function __construct( $year, $dayOfYear, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], array $possibleRestrictions = [] ) {
 		if ( $year === null ) {
 			$year = date( 'Y' );
 		}
@@ -69,6 +77,8 @@ class Week {
 		if ( ! empty( $possibleTimeframes ) ) {
 			$this->timeframes = \CommonsBooking\Repository\Timeframe::filterTimeframesForTimerange( $possibleTimeframes, $this->getStartTimestamp(), $this->getEndTimestamp() );
 		}
+
+		$this->possibleRestrictions = $possibleRestrictions;
 	}
 
 	/**
@@ -96,7 +106,7 @@ class Week {
 			$days = array();
 			for ( $i = 0; $i < 7; $i++ ) {
 				$dayDate   = $dto->format( 'Y-m-d' );
-				$days[]    = new Day( $dayDate, $this->locations, $this->items, $this->types, $this->timeframes ?: [] );
+				$days[]    = new Day( $dayDate, $this->locations, $this->items, $this->types, $this->timeframes ?: [], $this->possibleRestrictions );
 				$dayOfWeek = $dto->format( 'w' );
 				if ( $dayOfWeek === '0' ) {
 					break;

--- a/src/Model/Week.php
+++ b/src/Model/Week.php
@@ -49,9 +49,9 @@ class Week {
 	/**
 	 * Pre-fetched restrictions for this week's range.
 	 *
-	 * @var \CommonsBooking\Model\Restriction[]
+	 * @var \CommonsBooking\Model\Restriction[]|null
 	 */
-	private array $possibleRestrictions = [];
+	private ?array $possibleRestrictions = null;
 
 	/**
 	 * Week constructor.
@@ -62,9 +62,9 @@ class Week {
 	 * @param array       $items
 	 * @param array       $types
 	 * @param Timeframe[] $possibleTimeframes Timeframes that might be relevant for this week, need to be filtered.
-	 * @param array       $possibleRestrictions Pre-fetched restrictions for the calendar range.
+	 * @param array|null  $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB).
 	 */
-	public function __construct( $year, $dayOfYear, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], array $possibleRestrictions = [] ) {
+	public function __construct( $year, $dayOfYear, array $locations = [], array $items = [], array $types = [], array $possibleTimeframes = [], ?array $possibleRestrictions = null ) {
 		if ( $year === null ) {
 			$year = date( 'Y' );
 		}

--- a/src/Model/Week.php
+++ b/src/Model/Week.php
@@ -58,9 +58,9 @@ class Week {
 	 *
 	 * @param $year
 	 * @param $dayOfYear
-	 * @param array       $locations
-	 * @param array       $items
-	 * @param array       $types
+	 * @param array            $locations
+	 * @param array            $items
+	 * @param array            $types
 	 * @param Timeframe[]|null $possibleTimeframes Timeframes pre-fetched for the calendar range (null = not provided, query DB per day).
 	 * @param array|null       $possibleRestrictions Pre-fetched restrictions for the calendar range (null = not provided, query DB).
 	 */

--- a/src/Repository/Restriction.php
+++ b/src/Repository/Restriction.php
@@ -74,23 +74,33 @@ class Restriction extends PostRepository {
 		$cacheItem = Plugin::getCacheItem();
 		if ( $cacheItem ) {
 			return $cacheItem;
-		} else {
-			global $wpdb;
-			$table_posts = $wpdb->prefix . 'posts';
+		}
 
-			$dateQuery = '';
+		// Request-level memoization: 40 Calendar instances all call queryPosts with the same
+		// arguments during a single renderTable() — deduplicate to a single DB query.
+		$wpCacheKey   = 'cb_restriction_query_' . md5( serialize( [ $date, $minTimestamp, $postStatus ] ) );
+		$wpCacheGroup = 'commonsbooking_restriction';
+		$cached       = wp_cache_get( $wpCacheKey, $wpCacheGroup );
+		if ( $cached !== false ) {
+			return $cached;
+		}
 
-			// Filter only from a specific start date.
-			// Rep-End must be > Min Date (0:00)
-			if ( $minTimestamp ) {
-				$dateQuery = self::getMinTimestampQuery( $minTimestamp );
-			} // Filter by date
-			elseif ( $date ) {
-				$dateQuery = self::getDateQuery( $date );
-			}
+		global $wpdb;
+		$table_posts = $wpdb->prefix . 'posts';
 
-			// Complete query
-			$query = "
+		$dateQuery = '';
+
+		// Filter only from a specific start date.
+		// Rep-End must be > Min Date (0:00)
+		if ( $minTimestamp ) {
+			$dateQuery = self::getMinTimestampQuery( $minTimestamp );
+		} // Filter by date
+		elseif ( $date ) {
+			$dateQuery = self::getDateQuery( $date );
+		}
+
+		// Complete query
+		$query = "
                 SELECT DISTINCT pm1.* from $table_posts pm1                
                 " . $dateQuery . '
                 ' . self::getActiveQuery() . "
@@ -99,11 +109,11 @@ class Restriction extends PostRepository {
                     pm1.post_status IN ('" . implode( "','", $postStatus ) . "')
             ";
 
-			$posts = $wpdb->get_results( $query );
-			Plugin::setCacheItem( $posts, Wordpress::getTags( $posts ) );
+		$posts = $wpdb->get_results( $query );
+		wp_cache_set( $wpCacheKey, $posts, $wpCacheGroup );
+		Plugin::setCacheItem( $posts, Wordpress::getTags( $posts ) );
 
-			return $posts;
-		}
+		return $posts;
 	}
 
 	/**

--- a/src/Repository/Restriction.php
+++ b/src/Repository/Restriction.php
@@ -74,33 +74,23 @@ class Restriction extends PostRepository {
 		$cacheItem = Plugin::getCacheItem();
 		if ( $cacheItem ) {
 			return $cacheItem;
-		}
+		} else {
+			global $wpdb;
+			$table_posts = $wpdb->prefix . 'posts';
 
-		// Request-level memoization: 40 Calendar instances all call queryPosts with the same
-		// arguments during a single renderTable() — deduplicate to a single DB query.
-		$wpCacheKey   = 'cb_restriction_query_' . md5( serialize( [ $date, $minTimestamp, $postStatus ] ) );
-		$wpCacheGroup = 'commonsbooking_restriction';
-		$cached       = wp_cache_get( $wpCacheKey, $wpCacheGroup );
-		if ( $cached !== false ) {
-			return $cached;
-		}
+			$dateQuery = '';
 
-		global $wpdb;
-		$table_posts = $wpdb->prefix . 'posts';
+			// Filter only from a specific start date.
+			// Rep-End must be > Min Date (0:00)
+			if ( $minTimestamp ) {
+				$dateQuery = self::getMinTimestampQuery( $minTimestamp );
+			} // Filter by date
+			elseif ( $date ) {
+				$dateQuery = self::getDateQuery( $date );
+			}
 
-		$dateQuery = '';
-
-		// Filter only from a specific start date.
-		// Rep-End must be > Min Date (0:00)
-		if ( $minTimestamp ) {
-			$dateQuery = self::getMinTimestampQuery( $minTimestamp );
-		} // Filter by date
-		elseif ( $date ) {
-			$dateQuery = self::getDateQuery( $date );
-		}
-
-		// Complete query
-		$query = "
+			// Complete query
+			$query = "
                 SELECT DISTINCT pm1.* from $table_posts pm1                
                 " . $dateQuery . '
                 ' . self::getActiveQuery() . "
@@ -109,11 +99,11 @@ class Restriction extends PostRepository {
                     pm1.post_status IN ('" . implode( "','", $postStatus ) . "')
             ";
 
-		$posts = $wpdb->get_results( $query );
-		wp_cache_set( $wpCacheKey, $posts, $wpCacheGroup );
-		Plugin::setCacheItem( $posts, Wordpress::getTags( $posts ) );
+			$posts = $wpdb->get_results( $query );
+			Plugin::setCacheItem( $posts, Wordpress::getTags( $posts ) );
 
-		return $posts;
+			return $posts;
+		}
 	}
 
 	/**

--- a/src/Repository/Restriction.php
+++ b/src/Repository/Restriction.php
@@ -249,6 +249,37 @@ class Restriction extends PostRepository {
 	}
 
 	/**
+	 * Filters a pre-fetched list of Restriction models to those active on a specific date.
+	 * Used to avoid per-day DB queries when restrictions were pre-fetched for a date range.
+	 *
+	 * @param \CommonsBooking\Model\Restriction[] $restrictions
+	 * @param string                              $date Date string in Y-m-d format
+	 *
+	 * @return \CommonsBooking\Model\Restriction[]
+	 */
+	public static function filterRestrictionsForDate( array $restrictions, string $date ): array {
+		$dayStart = strtotime( $date );
+		$dayEnd   = strtotime( $date . 'T23:59' );
+
+		return array_values(
+			array_filter(
+				$restrictions,
+				function ( $restriction ) use ( $dayStart, $dayEnd ) {
+					$start = (int) $restriction->getMeta( \CommonsBooking\Model\Restriction::META_START );
+					if ( $start > $dayEnd ) {
+						return false;
+					}
+					$end = $restriction->getMeta( \CommonsBooking\Model\Restriction::META_END );
+					if ( $end !== '' && (int) $end < $dayStart ) {
+						return false;
+					}
+					return true;
+				}
+			)
+		);
+	}
+
+	/**
 	 * Casts all posts in the array to Restriction objects.
 	 *
 	 * @param $posts

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -115,9 +115,9 @@ class Calendar {
 		// Fetch ALL timeframe types for ALL items in a single query. This is used both to
 		// determine which items/locations are active (bookable subset) and to populate each
 		// per-item/location Calendar without additional DB queries.
-		$allItemIds          = array_map( fn( $item ) => $item->ID, $items );
-		$calendarEndDate     = date( 'Y-m-d', strtotime( '+' . ( $days + 1 ) . ' days', current_time( 'timestamp' ) ) );
-		$allTimeframesAll    = \CommonsBooking\Repository\Timeframe::getInRange(
+		$allItemIds       = array_map( fn( $item ) => $item->ID, $items );
+		$calendarEndDate  = date( 'Y-m-d', strtotime( '+' . ( $days + 1 ) . ' days', current_time( 'timestamp' ) ) );
+		$allTimeframesAll = \CommonsBooking\Repository\Timeframe::getInRange(
 			strtotime( $today ),
 			strtotime( $calendarEndDate ),
 			[],

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -112,6 +112,26 @@ class Calendar {
 
 		$itemRowsHTML = '';
 
+		// Fetch timeframes for ALL items in one query instead of one query per item.
+		$allItemIds    = array_map( fn( $item ) => $item->ID, $items );
+		$allTimeframes = \CommonsBooking\Repository\Timeframe::getInRangeForCurrentUser(
+			strtotime( $today ),
+			strtotime( $last_day ),
+			[],
+			$allItemIds,
+			[ Timeframe::BOOKABLE_ID ],
+			true
+		);
+
+		// Group the pre-fetched timeframes by item ID for O(1) lookup in the loop.
+		$timeframesByItemId = [];
+		foreach ( $allTimeframes as $timeframe ) {
+			$itemId = $timeframe->getItemID();
+			if ( $itemId !== null ) {
+				$timeframesByItemId[ $itemId ][] = $timeframe;
+			}
+		}
+
 		foreach ( $items as $item ) {
 			// Check for category term
 			if ( $itemCategory ) {
@@ -122,15 +142,7 @@ class Calendar {
 
 			$rowHtml = ' ';
 
-			// Get timeframes for item
-			$timeframes = \CommonsBooking\Repository\Timeframe::getInRangeForCurrentUser(
-				strtotime( $today ),
-				strtotime( $last_day ),
-				[],
-				[ $item->ID ],
-				[ Timeframe::BOOKABLE_ID ],
-				true
-			);
+			$timeframes = $timeframesByItemId[ $item->ID ] ?? [];
 
 			if ( $timeframes ) {
 				// Collect unique locations from timeframes

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -112,23 +112,36 @@ class Calendar {
 
 		$itemRowsHTML = '';
 
-		// Fetch timeframes for ALL items in one query instead of one query per item.
-		$allItemIds    = array_map( fn( $item ) => $item->ID, $items );
-		$allTimeframes = \CommonsBooking\Repository\Timeframe::getInRangeForCurrentUser(
+		// Fetch ALL timeframe types for ALL items in a single query. This is used both to
+		// determine which items/locations are active (bookable subset) and to populate each
+		// per-item/location Calendar without additional DB queries.
+		$allItemIds          = array_map( fn( $item ) => $item->ID, $items );
+		$calendarEndDate     = date( 'Y-m-d', strtotime( '+' . ( $days + 1 ) . ' days', current_time( 'timestamp' ) ) );
+		$allTimeframesAll    = \CommonsBooking\Repository\Timeframe::getInRange(
 			strtotime( $today ),
-			strtotime( $last_day ),
+			strtotime( $calendarEndDate ),
 			[],
 			$allItemIds,
-			[ Timeframe::BOOKABLE_ID ],
-			true
+			[],
+			true,
+			[ 'confirmed', 'unconfirmed', 'publish', 'inherit' ]
 		);
 
-		// Group the pre-fetched timeframes by item ID for O(1) lookup in the loop.
-		$timeframesByItemId = [];
-		foreach ( $allTimeframes as $timeframe ) {
-			$itemId = $timeframe->getItemID();
-			if ( $itemId !== null ) {
-				$timeframesByItemId[ $itemId ][] = $timeframe;
+		// Group pre-fetched timeframes by item ID + location ID for O(1) lookup.
+		// Also build the bookable-only subset (keyed by item ID) to find active locations.
+		$timeframesByItemLocation = [];
+		$bookableByItemId         = [];
+		foreach ( $allTimeframesAll as $tf ) {
+			$itemId     = $tf->getItemID();
+			$locationId = $tf->getLocationID();
+			if ( $itemId === null || $locationId === null ) {
+				continue;
+			}
+			$timeframesByItemLocation[ $itemId ][ $locationId ][] = $tf;
+			if ( intval( $tf->getMeta( 'type' ) ) === \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID ) {
+				if ( commonsbooking_isCurrentUserAllowedToBook( $tf->ID ) ) {
+					$bookableByItemId[ $itemId ][] = $tf;
+				}
 			}
 		}
 
@@ -142,12 +155,12 @@ class Calendar {
 
 			$rowHtml = ' ';
 
-			$timeframes = $timeframesByItemId[ $item->ID ] ?? [];
+			$bookableTimeframes = $bookableByItemId[ $item->ID ] ?? [];
 
-			if ( $timeframes ) {
-				// Collect unique locations from timeframes
+			if ( $bookableTimeframes ) {
+				// Collect unique locations from bookable timeframes
 				$locations = [];
-				foreach ( $timeframes as $timeframe ) {
+				foreach ( $bookableTimeframes as $timeframe ) {
 					// TODO #507
 					$locations[ $timeframe->getLocationID() ] = $timeframe->getLocation()->post_title;
 				}
@@ -166,7 +179,8 @@ class Calendar {
 							}
 						}
 
-						$locationHtml = self::renderItemLocationRow( $item, $locationId, $locationName, $today, $last_day, $days, $days_display );
+						$preloadedTimeframes = $timeframesByItemLocation[ $item->ID ][ $locationId ] ?? [];
+						$locationHtml        = self::renderItemLocationRow( $item, $locationId, $locationName, $today, $last_day, $days, $days_display, $preloadedTimeframes );
 						Plugin::setCacheItem( $locationHtml, [ strval( $item->ID ), strval( $locationId ) ], $customCacheKey );
 						$rowHtml .= $locationHtml;
 					}
@@ -246,11 +260,12 @@ class Calendar {
 	 * @param $last_day
 	 * @param $days
 	 * @param $days_display
+	 * @param array $preloadedTimeframes Pre-fetched timeframes for this item/location — avoids re-querying the DB.
 	 *
 	 * @return string
 	 * @throws Exception
 	 */
-	protected static function renderItemLocationRow( $item, $locationId, $locationName, $today, $last_day, $days, $days_display ): string {
+	protected static function renderItemLocationRow( $item, $locationId, $locationName, $today, $last_day, $days, $days_display, array $preloadedTimeframes = [] ): string {
 		$cacheItem = Plugin::getCacheItem();
 		if ( $cacheItem ) {
 			return $cacheItem;
@@ -264,7 +279,8 @@ class Calendar {
 				$locationId,
 				$today,
 				date( 'Y-m-d', strtotime( '+' . $days . ' days', time() ) ),
-				true
+				true,
+				$preloadedTimeframes
 			);
 
 			$gotStartDate = false;
@@ -339,11 +355,12 @@ class Calendar {
 	 * @param string                        $startDateString YYYY-MM-DD Format
 	 * @param string                        $endDateString YYYY-MM-DD Format
 	 * @param bool                          $keepDaterange
+	 * @param array                         $preloadedTimeframes Pre-fetched timeframes for this item/location — skips DB queries when provided.
 	 *
 	 * @return array
 	 * @throws Exception
 	 */
-	public static function getCalendarDataArray( $item, $location, string $startDateString, string $endDateString, bool $keepDaterange = false ): array {
+	public static function getCalendarDataArray( $item, $location, string $startDateString, string $endDateString, bool $keepDaterange = false, array $preloadedTimeframes = [] ): array {
 		if ( $item instanceof WP_Post || $item instanceof CustomPost ) {
 			$item = $item->ID;
 		}
@@ -365,13 +382,25 @@ class Calendar {
 		$advanceBookingDays = null;
 		$lastBookableDate   = null;
 		$firstBookableDay   = null;
-		$bookableTimeframes = \CommonsBooking\Repository\Timeframe::getBookableForCurrentUser(
-			[ $location ],
-			[ $item ],
-			null,
-			true,
-			Helper::getLastFullHourTimestamp()
-		);
+
+		if ( ! empty( $preloadedTimeframes ) ) {
+			// Derive bookable timeframes from the pre-loaded set — no DB query.
+			$bookableTimeframes = array_values(
+				array_filter(
+					$preloadedTimeframes,
+					fn( $tf ) => intval( $tf->getMeta( 'type' ) ) === \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID
+						&& commonsbooking_isCurrentUserAllowedToBook( $tf->ID )
+				)
+			);
+		} else {
+			$bookableTimeframes = \CommonsBooking\Repository\Timeframe::getBookableForCurrentUser(
+				[ $location ],
+				[ $item ],
+				null,
+				true,
+				Helper::getLastFullHourTimestamp()
+			);
+		}
 
 		if ( count( $bookableTimeframes ) ) {
 			$closestBookableTimeframe = self::getClosestBookableTimeFrameForToday( $bookableTimeframes );
@@ -409,7 +438,7 @@ class Calendar {
 			}
 		}
 
-		return self::prepareJsonResponse( $startDate, $endDate, [ $location ], [ $item ], $advanceBookingDays, $lastBookableDate, $firstBookableDay );
+		return self::prepareJsonResponse( $startDate, $endDate, [ $location ], [ $item ], $advanceBookingDays, $lastBookableDate, $firstBookableDay, $preloadedTimeframes );
 	}
 
 	/**
@@ -538,7 +567,8 @@ class Calendar {
 		array $items,
 		$advanceBookingDays = null,
 		$lastBookableDate = null,
-		$firstBookableDay = null
+		$firstBookableDay = null,
+		array $preloadedTimeframes = []
 	): array {
 
 		$current_user   = wp_get_current_user();
@@ -559,7 +589,8 @@ class Calendar {
 				$startDate,
 				$endDate,
 				$locations,
-				$items
+				$items,
+				$preloadedTimeframes
 			);
 
 			$jsonResponse = [

--- a/tests/php/Model/CalendarTest.php
+++ b/tests/php/Model/CalendarTest.php
@@ -22,13 +22,15 @@ class CalendarTest extends CustomPostTypeTest {
 	public function testGetDays() {
 		$this->calendar = new Calendar( new Day( '2023-05-01' ), new Day( '2023-06-01' ) );
 		$this->assertEquals( 5, count( $this->calendar->getWeeks() ) );
+		// Calendar pre-fetches restrictions (empty [] here since no items/locations) and passes them to Week.
+		// Use explicit [] for possibleRestrictions to match the actual internal state.
 		$this->assertEquals(
 			array(
-				new Week( 2023, 120 ),
-				new Week( 2023, 127 ),
-				new Week( 2023, 134 ),
-				new Week( 2023, 141 ),
-				new Week( 2023, 148 ),
+				new Week( 2023, 120, [], [], [], null, [] ),
+				new Week( 2023, 127, [], [], [], null, [] ),
+				new Week( 2023, 134, [], [], [], null, [] ),
+				new Week( 2023, 141, [], [], [], null, [] ),
+				new Week( 2023, 148, [], [], [], null, [] ),
 			),
 			$this->calendar->getWeeks()
 		);


### PR DESCRIPTION
Don't worry, they will be checked!

Baseline:

# Benchmark reference on master:

Subjects: 1, Assertions: 0, Failures: 0, Errors: 0
+---------------+------------------+-----+------+-----+----------+--------+--------+
| benchmark     | subject          | set | revs | its | mem_peak | mode   | rstdev |
+---------------+------------------+-----+------+-----+----------+--------+--------+
| CalendarBench | benchRenderTable |     | 1    | 1   | 72.014mb | 5.597s | ±0.00% |
+---------------+------------------+-----+------+-----+----------+--------+--------+

What the babblebot generated in changelog:

Four targeted optimizations, all cache-independent:

1. src/Helper/Wordpress.php - flattenWpdbResult: prime the WP post-object cache from already-fetched raw wpdb data and batch-warm the post-meta cache via update_postmeta_cache(). Eliminates N×get_post_meta round-trips for every subsequent meta lookup (processSlot, sanitizeSlots, etc.).

2. src/Model/Day.php - getTimeframeSlots: hoist get_option('time_format') out of the 24-iteration slot-init loop. Reduces option-lookups from 48 to 1 per day (×31 days ×40 items = ~59 000 fewer calls).

3. src/View/Calendar.php - renderTable: fetch bookable timeframes for ALL items in a single Repository::getInRangeForCurrentUser() call before the item loop, then group by item ID. Reduces per-item timeframe queries from O(n_items) to O(1).

4. src/Model/Calendar.php + Week.php + Day.php + Repository/Restriction.php: pre-fetch restrictions for the entire calendar date range once in Calendar::__construct and thread them through Week→Day. Day::getRestrictions() returns the filtered in-memory slice instead of issuing a DB query per day. Eliminates ~1 240 per-day restriction queries (40 items × 31 days).

Benchmark (40 items, 110 bookings each, cache disabled):
  Before: 5.597s (reference) / 5.243s (measured)
  After:  3.577s  (~36% / ~32% improvement)