### PR TITLE
Draft: perf: introduce cb-outdated post status to exclude past bookings from…

### DIFF
--- a/BookingOutdatedPerformance.txt
+++ b/BookingOutdatedPerformance.txt
@@ -1,0 +1,80 @@
+# Results from local run
+
+## With cb-outdated status set
+```
+❯ php8.1 vendor/bin/phpunit --bootstrap tests/php/bootstrap.php tests/php/Service/BookingOutdatedPerformanceTest.php
+Installing...
+Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
+Not running ajax tests. To execute these, use --group ajax.
+Not running ms-files tests. To execute these, use --group ms-files.
+Not running external-http tests. To execute these, use --group external-http.
+PHPUnit 9.6.33 by Sebastian Bergmann and contributors.
+
+
+  ┌ BookingOutdatedPerformanceTest  N = 2000 ┐
+  │ Phase                           Time (s)  ms / booking │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Create 2000 bookings               3.094        1.55 │
+  │ markOutdatedBookings()             2.029        1.01 │
+  │ Batches (×500)                    4.000             │
+  │ getByTimerange()                   0.009             │
+  │ getExistingBookings()              0.002             │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Total                              5.169             │
+  └─────────────────────────────────────────────┘
+
+.
+  ┌ BookingOutdatedPerformanceTest  N = 5000 ┐
+  │ Phase                           Time (s)  ms / booking │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Create 5000 bookings               6.879        1.38 │
+  │ markOutdatedBookings()            15.879        3.18 │
+  │ Batches (×500)                   10.000             │
+  │ getByTimerange()                   0.066             │
+  │ getExistingBookings()              0.002             │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Total                             22.868             │
+  └─────────────────────────────────────────────┘
+
+....                                                               5 / 5 (100%)
+
+``
+
+
+## Without cb-outdated status set
+```
+❯ php8.1 vendor/bin/phpunit --bootstrap tests/php/bootstrap.php tests/php/Service/BookingOutdatedPerformanceTest.php
+Installing...
+Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
+Not running ajax tests. To execute these, use --group ajax.
+Not running ms-files tests. To execute these, use --group ms-files.
+Not running external-http tests. To execute these, use --group external-http.
+PHPUnit 9.6.33 by Sebastian Bergmann and contributors.
+
+
+  ┌ BookingOutdatedPerformanceTest  N = 2000 ┐
+  │ Phase                           Time (s)  ms / booking │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Create 2000 bookings               6.484        3.24 │
+  │ markOutdatedBookings()          0         0          │
+  │ Batches (×500)                 0                    │
+  │ getByTimerange()                   4.874             │
+  │ getExistingBookings()           0                    │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Total                           0                    │
+  └─────────────────────────────────────────────┘
+
+F
+  ┌ BookingOutdatedPerformanceTest  N = 5000 ┐
+  │ Phase                           Time (s)  ms / booking │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Create 5000 bookings              15.680        3.14 │
+  │ markOutdatedBookings()          0         0          │
+  │ Batches (×500)                 0                    │
+  │ getByTimerange()                  28.206             │
+  │ getExistingBookings()           0                    │
+  │ ──────────────────────────────  ──────────  ────────────── │
+  │ Total                           0                    │
+  └─────────────────────────────────────────────┘
+
+```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,8 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	enforceTimeLimit="true"
+	timeoutForLargeTests="120"
 	>
 	<testsuites>
 		<testsuite name="default">

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -53,6 +53,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 	public static $bookingStates = [
 		'canceled',
 		'confirmed',
+		'cb-outdated',
 		'unconfirmed',
 	];
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -786,6 +786,28 @@ class Plugin {
 
 		// iCal rewrite
 		iCalendar::initRewrite();
+
+		// Reset cb-outdated status when a booking's end date is extended into the future
+		add_action( 'save_post_cb_booking', [ self::class, 'maybeResetOutdatedBooking' ] );
+	}
+
+	/**
+	 * Reverts a 'cb-outdated' booking back to 'confirmed' when its end date has been moved into the future.
+	 *
+	 * @param int $postId
+	 * @return void
+	 */
+	public static function maybeResetOutdatedBooking( int $postId ): void {
+		$post = get_post( $postId );
+		if ( ! $post || $post->post_status !== 'cb-outdated' ) {
+			return;
+		}
+		$end = (int) get_post_meta( $postId, \CommonsBooking\Model\Timeframe::REPETITION_END, true );
+		if ( $end >= strtotime( 'midnight' ) ) {
+			remove_action( 'save_post_cb_booking', [ self::class, 'maybeResetOutdatedBooking' ] );
+			wp_update_post( [ 'ID' => $postId, 'post_status' => 'confirmed' ] );
+			add_action( 'save_post_cb_booking', [ self::class, 'maybeResetOutdatedBooking' ] );
+		}
 	}
 
 	/**

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -43,7 +43,7 @@ class Booking extends PostRepository {
 	 * @return \CommonsBooking\Model\Booking[]
 	 * @throws Exception
 	 */
-	public static function getEndingBookingsByDate( int $timestamp, array $customArgs = [] ): array {
+	public static function getEndingBookingsByDate( int $timestamp, array $customArgs = [], array $postStatus = [ 'confirmed', 'unconfirmed' ] ): array {
 		$startTimestamp = self::getStartTimestamp( $timestamp );
 		$endTimestamp   = self::getEndTimestamp( $startTimestamp );
 
@@ -70,7 +70,7 @@ class Booking extends PostRepository {
 					'compare' => '=',
 				),
 			),
-			'post_status' => array( 'confirmed', 'unconfirmed' ),
+			'post_status' => $postStatus,
 			'nopaging'    => true,
 		);
 
@@ -89,7 +89,7 @@ class Booking extends PostRepository {
 	 * @return \CommonsBooking\Model\Booking[]
 	 * @throws Exception
 	 */
-	public static function getBeginningBookingsByDate( int $timestamp, array $customArgs = [] ): array {
+	public static function getBeginningBookingsByDate( int $timestamp, array $customArgs = [], array $postStatus = [ 'confirmed' ] ): array {
 		$startTimestamp = self::getStartTimestamp( $timestamp );
 		$endTimestamp   = self::getEndTimestamp( $startTimestamp );
 
@@ -117,7 +117,7 @@ class Booking extends PostRepository {
 					'type'    => 'numeric',
 				),
 			),
-			'post_status' => array( 'confirmed' ),
+			'post_status' => $postStatus,
 			'nopaging'    => true,
 		);
 
@@ -146,7 +146,7 @@ class Booking extends PostRepository {
 	 * @return null|\CommonsBooking\Model\Booking
 	 * @throws Exception
 	 */
-	public static function getByDate( int $startDateTimestamp, int $endDateTimestamp, int $locationId, int $itemId ): ?\CommonsBooking\Model\Booking {
+	public static function getByDate( int $startDateTimestamp, int $endDateTimestamp, int $locationId, int $itemId, array $postStatus = [ 'confirmed', 'unconfirmed' ] ): ?\CommonsBooking\Model\Booking {
 		// Default query
 		$args = array(
 			'post_type'   => \CommonsBooking\Wordpress\CustomPostType\Booking::$postType,
@@ -179,7 +179,7 @@ class Booking extends PostRepository {
 					'compare' => '=',
 				),
 			),
-			'post_status' => array( 'confirmed', 'unconfirmed' ),
+			'post_status' => $postStatus,
 			'nopaging'    => true,
 		);
 
@@ -188,15 +188,15 @@ class Booking extends PostRepository {
 			$posts = $query->get_posts();
 			$posts = array_filter(
 				$posts,
-				function ( $post ) {
-					return in_array( $post->post_status, array( 'confirmed', 'unconfirmed' ) );
+				function ( $post ) use ( $postStatus ) {
+					return in_array( $post->post_status, $postStatus );
 				}
 			);
 
 			// If there is exactly one result, return it.
 			if ( count( $posts ) == 1 ) {
 				$booking = new \CommonsBooking\Model\Booking( $posts[0] );
-				if ( in_array( $booking->getPost()->post_status, array( 'confirmed', 'unconfirmed' ) ) ) {
+				if ( in_array( $booking->getPost()->post_status, $postStatus ) ) {
 					return $booking;
 				}
 			} elseif ( count( $posts ) > 1 ) {

--- a/src/Service/Booking.php
+++ b/src/Service/Booking.php
@@ -40,6 +40,42 @@ class Booking {
 		}
 	}
 
+	/**
+	 * Transitions confirmed bookings whose end date is in the past to 'cb-outdated'.
+	 * Run daily via Scheduler so that past bookings are excluded from active queries.
+	 *
+	 * @return void
+	 */
+	public static function markOutdatedBookings(): void {
+		$midnight = strtotime( 'midnight' );
+
+		$args = [
+			'post_type'      => \CommonsBooking\Wordpress\CustomPostType\Booking::$postType,
+			'post_status'    => 'confirmed',
+			'meta_query'     => [
+				'relation' => 'AND',
+				[
+					'key'     => \CommonsBooking\Model\Timeframe::REPETITION_END,
+					'value'   => $midnight,
+					'compare' => '<',
+					'type'    => 'numeric',
+				],
+				[
+					'key'     => 'type',
+					'value'   => Timeframe::BOOKING_ID,
+					'compare' => '=',
+				],
+			],
+			'posts_per_page' => 500,
+			'fields'         => 'ids',
+		];
+
+		$query = new WP_Query( $args );
+		foreach ( $query->posts as $id ) {
+			wp_update_post( [ 'ID' => $id, 'post_status' => 'cb-outdated' ] );
+		}
+	}
+
 	private static function sendMessagesForDay( int $tsDate, bool $onStartDate, Message $message ) {
 		if ( $onStartDate ) {
 			$bookings = \CommonsBooking\Repository\Booking::getBeginningBookingsByDate( $tsDate );

--- a/src/Service/Booking.php
+++ b/src/Service/Booking.php
@@ -47,6 +47,8 @@ class Booking {
 	 * @return void
 	 */
 	public static function markOutdatedBookings(): void {
+		global $wpdb;
+
 		$midnight = strtotime( 'midnight' );
 
 		$args = [
@@ -71,8 +73,22 @@ class Booking {
 		];
 
 		$query = new WP_Query( $args );
-		foreach ( $query->posts as $id ) {
-			wp_update_post( [ 'ID' => $id, 'post_status' => 'cb-outdated' ] );
+		$ids   = $query->posts;
+
+		if ( empty( $ids ) ) {
+			return;
+		}
+
+		// Bulk-update in a single SQL statement instead of one wp_update_post()
+		// per row — critical for performance when thousands of bookings age out.
+		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->posts} SET post_status = 'cb-outdated' WHERE ID IN ($placeholders)", $ids ) );
+
+		// Flush the per-post object cache so subsequent get_post() calls
+		// reflect the new status without a stale cache hit.
+		foreach ( $ids as $id ) {
+			clean_post_cache( $id );
 		}
 	}
 

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -202,6 +202,14 @@ class Scheduler {
 			'update_option_commonsbooking_options_export'
 		);
 
+		// Mark past confirmed bookings as outdated (performance: excludes them from active queries)
+		new Scheduler(
+			'mark_outdated_bookings',
+			[ \CommonsBooking\Service\Booking::class, 'markOutdatedBookings' ],
+			'daily',
+			'tomorrow midnight'
+		);
+
 		// Init cache warmup job
 		$cacheWarmupSetting = Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'warmup_cron' );
 		if ( $cacheWarmupSetting ) {

--- a/tests/php/Repository/BookingStatusFilterTest.php
+++ b/tests/php/Repository/BookingStatusFilterTest.php
@@ -85,7 +85,7 @@ class BookingStatusFilterTest extends CustomPostTypeTest {
 	public function testGetEndingBookingsByDate_excludesCbOutdatedByDefault() {
 		$endTs = strtotime( 'midnight' );
 
-		$this->createBooking(
+		$bookingId = $this->createBooking(
 			$this->locationId,
 			$this->itemId,
 			strtotime( '-2 days' ),
@@ -96,9 +96,9 @@ class BookingStatusFilterTest extends CustomPostTypeTest {
 		);
 
 		$bookings = Booking::getEndingBookingsByDate( $endTs );
-		foreach ( $bookings as $booking ) {
-			$this->assertNotEquals( 'cb-outdated', $booking->post_status );
-		}
+		$ids      = array_map( fn( $b ) => $b->ID, $bookings );
+
+		$this->assertNotContains( $bookingId, $ids );
 	}
 
 	/**
@@ -135,7 +135,7 @@ class BookingStatusFilterTest extends CustomPostTypeTest {
 	public function testGetBeginningBookingsByDate_excludesCbOutdatedByDefault() {
 		$startTs = strtotime( 'midnight' );
 
-		$this->createBooking(
+		$bookingId = $this->createBooking(
 			$this->locationId,
 			$this->itemId,
 			$startTs,
@@ -146,9 +146,9 @@ class BookingStatusFilterTest extends CustomPostTypeTest {
 		);
 
 		$bookings = Booking::getBeginningBookingsByDate( $startTs );
-		foreach ( $bookings as $booking ) {
-			$this->assertNotEquals( 'cb-outdated', $booking->post_status );
-		}
+		$ids      = array_map( fn( $b ) => $b->ID, $bookings );
+
+		$this->assertNotContains( $bookingId, $ids );
 	}
 
 	/**

--- a/tests/php/Repository/BookingStatusFilterTest.php
+++ b/tests/php/Repository/BookingStatusFilterTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace CommonsBooking\Tests\Repository;
+
+use CommonsBooking\Repository\Booking;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+
+/**
+ * Verifies that every public Repository\Booking retrieval method:
+ *  (a) excludes 'cb-outdated' bookings by default, and
+ *  (b) can include them when the caller explicitly passes 'cb-outdated'
+ *      in the $postStatus parameter.
+ *
+ * Tests (b) are RED before the $postStatus parameters are added to the
+ * hardcoded methods (getEndingBookingsByDate, getBeginningBookingsByDate,
+ * getByDate) and GREEN afterwards.
+ */
+class BookingStatusFilterTest extends CustomPostTypeTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->firstTimeframeId = $this->createBookableTimeFrameIncludingCurrentDay();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		\Mockery::close();
+	}
+
+	// -----------------------------------------------------------------------
+	// getByTimerange — already has $postStatus param
+	// -----------------------------------------------------------------------
+
+	public function testGetByTimerange_excludesCbOutdatedByDefault() {
+		$start = strtotime( '-3 days' );
+		$end   = strtotime( '-2 days' );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getByTimerange( $start, $end, $this->locationId, $this->itemId );
+		$ids      = array_map( fn( $b ) => $b->ID, $bookings );
+
+		$this->assertNotContains( $bookingId, $ids );
+	}
+
+	public function testGetByTimerange_includesCbOutdatedWhenExplicitlyRequested() {
+		$start = strtotime( '-3 days' );
+		$end   = strtotime( '-2 days' );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getByTimerange(
+			$start,
+			$end,
+			$this->locationId,
+			$this->itemId,
+			[],
+			[ 'confirmed', 'unconfirmed', 'cb-outdated' ]
+		);
+		$ids = array_map( fn( $b ) => $b->ID, $bookings );
+
+		$this->assertContains( $bookingId, $ids );
+	}
+
+	// -----------------------------------------------------------------------
+	// getEndingBookingsByDate — hardcoded status before fix
+	// -----------------------------------------------------------------------
+
+	public function testGetEndingBookingsByDate_excludesCbOutdatedByDefault() {
+		$endTs = strtotime( 'midnight' );
+
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-2 days' ),
+			$endTs,
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getEndingBookingsByDate( $endTs );
+		foreach ( $bookings as $booking ) {
+			$this->assertNotEquals( 'cb-outdated', $booking->post_status );
+		}
+	}
+
+	/**
+	 * RED before adding $postStatus param to getEndingBookingsByDate().
+	 * GREEN after.
+	 */
+	public function testGetEndingBookingsByDate_includesCbOutdatedWhenExplicitlyRequested() {
+		$endTs = strtotime( 'midnight' );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-2 days' ),
+			$endTs,
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getEndingBookingsByDate(
+			$endTs,
+			[],
+			[ 'confirmed', 'unconfirmed', 'cb-outdated' ]
+		);
+		$ids = array_map( fn( $b ) => $b->ID, $bookings );
+
+		$this->assertContains( $bookingId, $ids );
+	}
+
+	// -----------------------------------------------------------------------
+	// getBeginningBookingsByDate — hardcoded status before fix
+	// -----------------------------------------------------------------------
+
+	public function testGetBeginningBookingsByDate_excludesCbOutdatedByDefault() {
+		$startTs = strtotime( 'midnight' );
+
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$startTs,
+			strtotime( '+2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getBeginningBookingsByDate( $startTs );
+		foreach ( $bookings as $booking ) {
+			$this->assertNotEquals( 'cb-outdated', $booking->post_status );
+		}
+	}
+
+	/**
+	 * RED before adding $postStatus param to getBeginningBookingsByDate().
+	 * GREEN after.
+	 */
+	public function testGetBeginningBookingsByDate_includesCbOutdatedWhenExplicitlyRequested() {
+		$startTs = strtotime( 'midnight' );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$startTs,
+			strtotime( '+2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getBeginningBookingsByDate(
+			$startTs,
+			[],
+			[ 'confirmed', 'cb-outdated' ]
+		);
+		$ids = array_map( fn( $b ) => $b->ID, $bookings );
+
+		$this->assertContains( $bookingId, $ids );
+	}
+
+	// -----------------------------------------------------------------------
+	// getByDate — hardcoded status before fix
+	// -----------------------------------------------------------------------
+
+	public function testGetByDate_excludesCbOutdatedByDefault() {
+		$start = strtotime( '-3 days' );
+		$end   = strtotime( '-2 days' );
+
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$result = Booking::getByDate( $start, $end, $this->locationId, $this->itemId );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * RED before adding $postStatus param to getByDate().
+	 * GREEN after.
+	 */
+	public function testGetByDate_includesCbOutdatedWhenExplicitlyRequested() {
+		$start = strtotime( '-3 days' );
+		$end   = strtotime( '-2 days' );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$result = Booking::getByDate(
+			$start,
+			$end,
+			$this->locationId,
+			$this->itemId,
+			[ 'confirmed', 'unconfirmed', 'cb-outdated' ]
+		);
+
+		$this->assertNotNull( $result );
+		$this->assertEquals( $bookingId, $result->ID );
+	}
+
+	// -----------------------------------------------------------------------
+	// getForUser — already has $postStatus param
+	// -----------------------------------------------------------------------
+
+	public function testGetForUser_excludesCbOutdatedByDefault() {
+		$user = get_user_by( 'id', self::USER_ID );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::getForUser( $user, false );
+		$ids      = array_map(
+			fn( $b ) => is_object( $b ) ? $b->ID : $b,
+			$bookings
+		);
+
+		$this->assertNotContains( $bookingId, $ids );
+	}
+
+	// -----------------------------------------------------------------------
+	// get() (Booking repo) — already has $postStatus param
+	// -----------------------------------------------------------------------
+
+	public function testGet_excludesCbOutdatedByDefault() {
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		$bookings = Booking::get();
+		$ids      = array_map(
+			fn( $b ) => is_object( $b ) ? $b->ID : $b,
+			$bookings
+		);
+
+		$this->assertNotContains( $bookingId, $ids );
+	}
+}

--- a/tests/php/Service/BookingOutdatedPerformanceTest.php
+++ b/tests/php/Service/BookingOutdatedPerformanceTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Repository\Booking as BookingRepository;
+use CommonsBooking\Service\Booking as BookingService;
+use CommonsBooking\Wordpress\CustomPostType\Booking as BookingCPT;
+use CommonsBooking\Wordpress\CustomPostType\Timeframe;
+
+/**
+ * Performance tests for the cb-outdated marking pipeline.
+ *
+ * Extends BookingOutdatedScaleTest to reuse createPastLinearBookings().
+ * Each test measures and prints wall-clock time for:
+ *   - booking creation
+ *   - markOutdatedBookings() (looped until all past bookings are covered,
+ *     because the method processes at most 500 per call)
+ *   - getByTimerange() on the full past range (the key query we optimise)
+ *
+ * Run these with:
+ *   php8.1 vendor/bin/phpunit --bootstrap tests/php/bootstrap.php \
+ *       tests/php/Service/BookingOutdatedPerformanceTest.php
+ *
+ * Each test is annotated @large so PHPUnit enforces the 120-second
+ * timeoutForLargeTests limit configured in phpunit.xml.dist.
+ * A test exceeding that budget fails with a PHPUnit\Framework\RiskyTestError.
+ *
+ * @group slow
+ * @large
+ */
+class BookingOutdatedPerformanceTest extends BookingOutdatedScaleTest {
+
+	// -----------------------------------------------------------------------
+	// Internal timing log — printed once per test in tearDown
+	// -----------------------------------------------------------------------
+
+	/** @var array<string, float> */
+	private array $timing = [];
+
+	private int $scenarioCount = 0;
+
+	protected function tearDown(): void {
+		if ( $this->timing ) {
+			$this->printReport();
+		}
+		parent::tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// Timing helpers
+	// -----------------------------------------------------------------------
+
+	private function tick(): float {
+		return microtime( true );
+	}
+
+	private function elapsed( float $since ): float {
+		return microtime( true ) - $since;
+	}
+
+	private function record( string $label, float $seconds ): void {
+		$this->timing[ $label ] = $seconds;
+	}
+
+	private function printReport(): void {
+		$n    = $this->scenarioCount;
+		$rows = [
+			[ 'Phase',                   'Time (s)',           'ms / booking'                                        ],
+			[ str_repeat( '─', 30 ),     str_repeat( '─', 10 ), str_repeat( '─', 14 )                               ],
+			[ "Create $n bookings",      $this->timing['create'] ?? 0,
+				( $n > 0 ) ? ( ( $this->timing['create'] ?? 0 ) / $n * 1000 ) : 0                                    ],
+			[ 'markOutdatedBookings()',   $this->timing['mark'] ?? 0,
+				( $n > 0 ) ? ( ( $this->timing['mark'] ?? 0 ) / $n * 1000 ) : 0                                      ],
+			[ 'Batches (×500)',           $this->timing['batches'] ?? 0,     ''                                       ],
+			[ 'getByTimerange()',         $this->timing['query'] ?? 0,       ''                                       ],
+			[ 'getExistingBookings()',    $this->timing['existing'] ?? 0,    ''                                       ],
+			[ str_repeat( '─', 30 ),     str_repeat( '─', 10 ),             str_repeat( '─', 14 )                    ],
+			[ 'Total',                   $this->timing['total'] ?? 0,        ''                                       ],
+		];
+
+		$out  = PHP_EOL;
+		$out .= sprintf( '  ┌ BookingOutdatedPerformanceTest  N = %d ┐' . PHP_EOL, $n );
+		foreach ( $rows as $row ) {
+			$label   = str_pad( (string) $row[0], 30 );
+			$seconds = is_float( $row[1] ) ? sprintf( '%8.3f', $row[1] ) : str_pad( (string) $row[1], 8 );
+			$msPerB  = is_float( $row[2] ?? '' ) ? sprintf( '%10.2f', $row[2] ) : str_pad( (string) ( $row[2] ?? '' ), 10 );
+			$out    .= sprintf( '  │ %s  %s  %s │' . PHP_EOL, $label, $seconds, $msPerB );
+		}
+		$out .= '  └' . str_repeat( '─', strlen( '  ┌ BookingOutdatedPerformanceTest  N = 200 ┐' ) - 4 ) . '┘' . PHP_EOL;
+		$out .= PHP_EOL;
+
+		fwrite( STDOUT, $out );
+	}
+
+	// -----------------------------------------------------------------------
+	// Bulk-SQL booking creation (bypasses WP hooks for speed)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Overrides the parent implementation with a direct-SQL version that is
+	 * ~30× faster than wp_insert_post() + update_post_meta().
+	 *
+	 * Only the five meta fields that markOutdatedBookings() and the two
+	 * repository queries actually need are written:
+	 *   type, repetition-start, repetition-end, location-id, item-id
+	 *
+	 * @return array<int, array{id: int, start: int, end: int}>
+	 */
+	protected function createPastLinearBookings( int $count ): array {
+		global $wpdb;
+
+		$midnight   = strtotime( 'midnight' );
+		$now        = current_time( 'mysql' );
+		$slots      = [];
+		$metaRows   = [];
+
+		for ( $i = $count; $i >= 1; $i-- ) {
+			$dayStart = $midnight - $i * DAY_IN_SECONDS;
+			$dayEnd   = $midnight - ( $i - 1 ) * DAY_IN_SECONDS - 1;
+
+			// Insert the post row directly — no hooks, no cache invalidation.
+			$wpdb->insert(
+				$wpdb->posts,
+				[
+					'post_title'        => 'Perf Booking',
+					'post_type'         => BookingCPT::$postType,
+					'post_status'       => 'confirmed',
+					'post_author'       => \CommonsBooking\Tests\Wordpress\CustomPostTypeTest::USER_ID,
+					'post_date'         => $now,
+					'post_date_gmt'     => $now,
+					'post_modified'     => $now,
+					'post_modified_gmt' => $now,
+					'post_name'         => '',
+					'to_ping'           => '',
+					'pinged'            => '',
+					'post_content_filtered' => '',
+					'post_excerpt'      => '',
+					'post_content'      => '',
+					'guid'              => '',
+					'comment_status'    => 'closed',
+					'ping_status'       => 'closed',
+				],
+				[
+					'%s', '%s', '%s', '%d',
+					'%s', '%s', '%s', '%s',
+					'%s', '%s', '%s', '%s',
+					'%s', '%s', '%s', '%s',
+					'%s', '%s',
+				]
+			);
+
+			$id = $wpdb->insert_id;
+
+			// Track so that parent tearDown can clean them up via $this->bookingIds.
+			$this->bookingIds[] = $id;
+
+			$slots[]    = [ 'id' => $id, 'start' => $dayStart, 'end' => $dayEnd ];
+			$metaRows[] = [ $id, 'type',               Timeframe::BOOKING_ID ];
+			$metaRows[] = [ $id, 'repetition-start',   $dayStart             ];
+			$metaRows[] = [ $id, 'repetition-end',     $dayEnd               ];
+			$metaRows[] = [ $id, 'location-id',        $this->locationId     ];
+			$metaRows[] = [ $id, 'item-id',            $this->itemId         ];
+		}
+
+		// Single batch INSERT for all postmeta rows.
+		if ( $metaRows ) {
+			$placeholders = implode(
+				', ',
+				array_fill( 0, count( $metaRows ), '(%d, %s, %s)' )
+			);
+			$flat = [];
+			foreach ( $metaRows as $r ) {
+				$flat[] = $r[0];
+				$flat[] = $r[1];
+				$flat[] = $r[2];
+			}
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) VALUES $placeholders", $flat ) );
+		}
+
+		return $slots;
+	}
+
+	// -----------------------------------------------------------------------
+	// Timed scenario
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Runs the full outdated-marking pipeline with granular timing.
+	 *
+	 * markOutdatedBookings() processes at most 500 bookings per call, so for
+	 * N > 500 we loop ceil(N/500) times to ensure full coverage.
+	 *
+	 * Correctness is verified by spot-checking the first, middle, and last
+	 * booking IDs (checking all N would itself become a performance bottleneck).
+	 * The definitive correctness assertion is that getByTimerange() returns
+	 * empty after marking — that is the query we are optimising.
+	 */
+	protected function runTimedScenario( int $count ): void {
+		$this->scenarioCount = $count;
+		$this->timing        = [];
+		$tTotal              = $this->tick();
+
+		$midnight = strtotime( 'midnight' );
+
+		// ── 1. Create past bookings ──────────────────────────────────────────
+		$t        = $this->tick();
+		$slots    = $this->createPastLinearBookings( $count );
+		$pastIds  = array_column( $slots, 'id' );
+		$this->record( 'create', $this->elapsed( $t ) );
+
+		// ── 2. Future control booking ────────────────────────────────────────
+		$futureId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$midnight + DAY_IN_SECONDS,
+			$midnight + 2 * DAY_IN_SECONDS,
+			'8:00 AM',
+			'12:00 PM',
+			'confirmed'
+		);
+
+		// ── 3. markOutdatedBookings() — loop until all past slots covered ────
+		/*$batches      = (int) ceil( $count / 500 );
+		$t            = $this->tick();
+		for ( $i = 0; $i < $batches; $i++ ) {
+			BookingService::markOutdatedBookings();
+		}
+		$this->record( 'mark',    $this->elapsed( $t ) );
+		$this->record( 'batches', $batches );
+
+		// ── 4. Spot-check correctness (first / middle / last) ────────────────
+		$probeIndices = array_unique( [ 0, (int) ( $count / 2 ), $count - 1 ] );
+		foreach ( $probeIndices as $i ) {
+			$this->assertEquals(
+				'cb-outdated',
+				get_post( $pastIds[ $i ] )->post_status,
+				"Booking at index $i (ID {$pastIds[$i]}) should be cb-outdated"
+			);
+		}
+		$this->assertEquals( 'confirmed', get_post( $futureId )->post_status, 'Future booking must remain confirmed' );*/
+
+		// ── 5. Query timing — the key perf measurement ───────────────────────
+		$rangeStart = $slots[0]['start'];
+		$rangeEnd   = $slots[ $count - 1 ]['end'];
+
+		$t           = $this->tick();
+		$byTimerange = BookingRepository::getByTimerange( $rangeStart, $rangeEnd, $this->locationId, $this->itemId );
+		$this->record( 'query', $this->elapsed( $t ) );
+		$this->assertEmpty( $byTimerange, "getByTimerange must not return any of the $count cb-outdated bookings" );
+
+		$t        = $this->tick();
+		$existing = BookingRepository::getExistingBookings( $this->itemId, $this->locationId, $rangeStart, $rangeEnd );
+		$this->record( 'existing', $this->elapsed( $t ) );
+		$this->assertEmpty( $existing, "getExistingBookings must not return any of the $count cb-outdated bookings" );
+
+		$this->record( 'total', $this->elapsed( $tTotal ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// Test cases
+	// -----------------------------------------------------------------------
+
+	public function testWith2000PastBookings(): void {
+		$this->runTimedScenario( 2000 );
+	}
+
+	public function testWith5000PastBookings(): void {
+		$this->runTimedScenario( 5000 );
+	}
+}

--- a/tests/php/Service/BookingOutdatedPerformanceTest.php
+++ b/tests/php/Service/BookingOutdatedPerformanceTest.php
@@ -268,4 +268,13 @@ class BookingOutdatedPerformanceTest extends BookingOutdatedScaleTest {
 	public function testWith5000PastBookings(): void {
 		$this->runTimedScenario( 5000 );
 	}
+
+	public function testWith6000PastBookings(): void {
+		$this->runTimedScenario( 6000 );
+	}
+
+	public function testWith7000PastBookings(): void {
+		$this->runTimedScenario( 7000 );
+	}
+
 }

--- a/tests/php/Service/BookingOutdatedPerformanceTest.php
+++ b/tests/php/Service/BookingOutdatedPerformanceTest.php
@@ -221,7 +221,7 @@ class BookingOutdatedPerformanceTest extends BookingOutdatedScaleTest {
 		);
 
 		// ── 3. markOutdatedBookings() — loop until all past slots covered ────
-		/*$batches      = (int) ceil( $count / 500 );
+		$batches      = (int) ceil( $count / 500 );
 		$t            = $this->tick();
 		for ( $i = 0; $i < $batches; $i++ ) {
 			BookingService::markOutdatedBookings();
@@ -238,7 +238,7 @@ class BookingOutdatedPerformanceTest extends BookingOutdatedScaleTest {
 				"Booking at index $i (ID {$pastIds[$i]}) should be cb-outdated"
 			);
 		}
-		$this->assertEquals( 'confirmed', get_post( $futureId )->post_status, 'Future booking must remain confirmed' );*/
+		$this->assertEquals( 'confirmed', get_post( $futureId )->post_status, 'Future booking must remain confirmed' );
 
 		// ── 5. Query timing — the key perf measurement ───────────────────────
 		$rangeStart = $slots[0]['start'];

--- a/tests/php/Service/BookingOutdatedScaleTest.php
+++ b/tests/php/Service/BookingOutdatedScaleTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Repository\Booking as BookingRepository;
+use CommonsBooking\Service\Booking as BookingService;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+
+/**
+ * Verifies that cb-outdated correctly excludes past bookings from all relevant
+ * repository methods at scale.
+ *
+ * A helper creates N confirmed bookings linearly in the past (one per day,
+ * from $count days ago up to yesterday). After markOutdatedBookings() runs:
+ *   - Every past booking must be cb-outdated
+ *   - A control future booking must remain confirmed
+ *   - All key repository queries must return empty / must not contain the
+ *     outdated booking IDs
+ *
+ * The same scenario is exercised at three scales: 2, 20, and 200 bookings.
+ */
+class BookingOutdatedScaleTest extends CustomPostTypeTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->firstTimeframeId = $this->createBookableTimeFrameIncludingCurrentDay();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		\Mockery::close();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helper
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Creates $count confirmed bookings in the past, each spanning exactly one
+	 * calendar day. The sequence runs from ($count days ago) up to and
+	 * including yesterday:
+	 *
+	 *   slot[0]  : midnight(-N)   …  midnight(-N+1) - 1
+	 *   slot[1]  : midnight(-N+1) …  midnight(-N+2) - 1
+	 *   …
+	 *   slot[N-1]: midnight(-1)   …  midnight      - 1   (= yesterday)
+	 *
+	 * All repetition-end values are < today's midnight, so every booking is
+	 * a candidate for markOutdatedBookings().
+	 *
+	 * @return array<int, array{id: int, start: int, end: int}>
+	 */
+	protected function createPastLinearBookings( int $count ): array {
+		$midnight = strtotime( 'midnight' );
+		$slots    = [];
+
+		for ( $i = $count; $i >= 1; $i-- ) {
+			$dayStart = $midnight - $i * DAY_IN_SECONDS;
+			$dayEnd   = $midnight - ( $i - 1 ) * DAY_IN_SECONDS - 1;
+
+			$id = $this->createBooking(
+				$this->locationId,
+				$this->itemId,
+				$dayStart,
+				$dayEnd,
+				'8:00 AM',
+				'12:00 PM',
+				'confirmed'
+			);
+
+			$slots[] = [ 'id' => $id, 'start' => $dayStart, 'end' => $dayEnd ];
+		}
+
+		return $slots;
+	}
+
+	/**
+	 * Core scenario executed at each scale.
+	 *
+	 * Steps:
+	 *  1. Create $count linearly-spaced past confirmed bookings.
+	 *  2. Create one future confirmed booking as a control.
+	 *  3. Assert all past bookings are 'confirmed' (sanity check).
+	 *  4. Run markOutdatedBookings().
+	 *  5. Assert every past booking is now 'cb-outdated'.
+	 *  6. Assert the future booking is still 'confirmed'.
+	 *  7. Assert cb-outdated bookings are absent from:
+	 *       - getByTimerange()
+	 *       - getExistingBookings()
+	 *       - getEndingBookingsByDate()
+	 *       - getBeginningBookingsByDate()
+	 */
+	protected function runScenario( int $count ): void {
+		$midnight = strtotime( 'midnight' );
+
+		// 1. Past bookings
+		$slots   = $this->createPastLinearBookings( $count );
+		$pastIds = array_column( $slots, 'id' );
+
+		// 2. Future control booking (tomorrow → day after tomorrow)
+		$futureId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$midnight + DAY_IN_SECONDS,
+			$midnight + 2 * DAY_IN_SECONDS,
+			'8:00 AM',
+			'12:00 PM',
+			'confirmed'
+		);
+
+		// 3. Sanity: all past bookings start as confirmed
+		foreach ( $pastIds as $id ) {
+			$this->assertEquals( 'confirmed', get_post( $id )->post_status, "Booking #$id should be confirmed before cron" );
+		}
+
+		// 4. Run the cron method
+		BookingService::markOutdatedBookings();
+
+		// 5. Every past booking must now be cb-outdated
+		foreach ( $pastIds as $id ) {
+			$this->assertEquals( 'cb-outdated', get_post( $id )->post_status, "Booking #$id should be cb-outdated after cron" );
+		}
+
+		// 6. Future booking must be unaffected
+		$this->assertEquals( 'confirmed', get_post( $futureId )->post_status, 'Future booking must remain confirmed' );
+
+		$rangeStart = $slots[0]['start'];
+		$rangeEnd   = $slots[ $count - 1 ]['end'];
+
+		// 7a. getByTimerange — covers the full past range
+		$byTimerange = BookingRepository::getByTimerange(
+			$rangeStart,
+			$rangeEnd,
+			$this->locationId,
+			$this->itemId
+		);
+		$this->assertEmpty( $byTimerange, "getByTimerange must not return any of the $count cb-outdated bookings" );
+
+		// 7b. getExistingBookings — same range
+		$existing = BookingRepository::getExistingBookings(
+			$this->itemId,
+			$this->locationId,
+			$rangeStart,
+			$rangeEnd
+		);
+		$this->assertEmpty( $existing, "getExistingBookings must not return any of the $count cb-outdated bookings" );
+
+		// 7c. getEndingBookingsByDate — last past day
+		$lastDayTs   = $slots[ $count - 1 ]['start']; // midnight of yesterday
+		$endingIds   = array_map( fn( $b ) => $b->ID, BookingRepository::getEndingBookingsByDate( $lastDayTs ) );
+		$this->assertNotContains(
+			$slots[ $count - 1 ]['id'],
+			$endingIds,
+			'getEndingBookingsByDate must not return the last cb-outdated booking'
+		);
+
+		// 7d. getBeginningBookingsByDate — first past day
+		$firstDayTs    = $slots[0]['start']; // midnight of $count days ago
+		$beginningIds  = array_map( fn( $b ) => $b->ID, BookingRepository::getBeginningBookingsByDate( $firstDayTs ) );
+		$this->assertNotContains(
+			$slots[0]['id'],
+			$beginningIds,
+			'getBeginningBookingsByDate must not return the first cb-outdated booking'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests at increasing scale
+	// -----------------------------------------------------------------------
+
+	public function testWith2PastBookings(): void {
+		$this->runScenario( 2 );
+	}
+
+	public function testWith20PastBookings(): void {
+		$this->runScenario( 20 );
+	}
+
+	public function testWith200PastBookings(): void {
+		$this->runScenario( 200 );
+	}
+}

--- a/tests/php/Service/BookingOutdatedTest.php
+++ b/tests/php/Service/BookingOutdatedTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Plugin;
+use CommonsBooking\Service\Booking;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+
+class BookingOutdatedTest extends CustomPostTypeTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->firstTimeframeId = $this->createBookableTimeFrameIncludingCurrentDay();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		\Mockery::close();
+	}
+
+	public function testMarkOutdated_marksConfirmedPastBooking() {
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'confirmed'
+		);
+
+		Booking::markOutdatedBookings();
+
+		$post = get_post( $bookingId );
+		$this->assertEquals( 'cb-outdated', $post->post_status );
+	}
+
+	public function testMarkOutdated_doesNotMarkFutureBooking() {
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '+1 day' ),
+			strtotime( '+5 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'confirmed'
+		);
+
+		Booking::markOutdatedBookings();
+
+		$post = get_post( $bookingId );
+		$this->assertEquals( 'confirmed', $post->post_status );
+	}
+
+	public function testMarkOutdated_doesNotMarkCanceledBooking() {
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'canceled'
+		);
+
+		Booking::markOutdatedBookings();
+
+		$post = get_post( $bookingId );
+		$this->assertEquals( 'canceled', $post->post_status );
+	}
+
+	public function testOutdatedExcludedFromExistingBookings() {
+		$start = strtotime( '-3 days' );
+		$end   = strtotime( '-2 days' );
+
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			'8:00 AM',
+			'12:00 PM',
+			'confirmed'
+		);
+
+		Booking::markOutdatedBookings();
+
+		$existing = \CommonsBooking\Repository\Booking::getExistingBookings(
+			$this->itemId,
+			$this->locationId,
+			$start,
+			$end
+		);
+
+		$ids = array_map( fn( $b ) => $b->ID, $existing );
+		$this->assertNotContains( $bookingId, $ids );
+	}
+
+	public function testMaybeResetOutdatedBooking_resetsWhenEndInFuture() {
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		// Extend end date into the future
+		update_post_meta( $bookingId, \CommonsBooking\Model\Timeframe::REPETITION_END, strtotime( '+3 days' ) );
+
+		Plugin::maybeResetOutdatedBooking( $bookingId );
+
+		$post = get_post( $bookingId );
+		$this->assertEquals( 'confirmed', $post->post_status );
+	}
+
+	public function testMaybeResetOutdatedBooking_doesNotResetWhenEndInPast() {
+		$bookingId = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-2 days' ),
+			'8:00 AM',
+			'12:00 PM',
+			'cb-outdated'
+		);
+
+		Plugin::maybeResetOutdatedBooking( $bookingId );
+
+		$post = get_post( $bookingId );
+		$this->assertEquals( 'cb-outdated', $post->post_status );
+	}
+}


### PR DESCRIPTION
… active queries

Adds a new 'cb-outdated' post status that is transitioned to daily via cron for confirmed bookings whose end date has passed. Since all performance-critical query paths use explicit post_status allow-lists that do not include 'cb-outdated', past bookings are automatically excluded without any query rewrites — eliminating the root cause of loading 9,500+ past bookings on every calendar render.

- src/Model/Booking.php: register 'cb-outdated' in $bookingStates
- src/Service/Booking.php: add markOutdatedBookings() (batched, 500/run)
- src/Service/Scheduler.php: schedule markOutdatedBookings() daily at midnight
- src/Plugin.php: add maybeResetOutdatedBooking() hook to revert status when an admin extends a booking's end date back into the future
- tests/php/Service/BookingOutdatedTest.php: 6 tests covering all new logic