### PR TITLE
Filter ergänzen sodass Buchungsmails an Stationen abgewählt werden können

### DIFF
--- a/docs/de/documentation/advanced-functionality/hooks-and-filters.md
+++ b/docs/de/documentation/advanced-functionality/hooks-and-filters.md
@@ -94,6 +94,7 @@ zurückgibt.
   * commonsbooking_mail_subject
   * commonsbooking_mail_body
   * commonsbooking_mail_attachment
+  * commonsbooking_send_booking_message_to_locations_enabled
   * commonsbooking_disableCache
 
 Es gibt auch Filter Hooks, mit denen du zusätzliche Benutzerrollen, die
@@ -158,4 +159,13 @@ Nutzungs-Beispiel:
 ```php
 // Sets the mobile calendar view to display 2 month
 add_filter('commonsbooking_mobile_calendar_month_count', fn(): int => 2);
+```
+
+### Filter `commonsbooking_send_booking_message_to_locations_enabled`
+
+Mit diesem Filter kannst du BCC-Empfaenger von Stations-E-Mails fuer Buchungs-Mails aktivieren oder deaktivieren.
+
+```php
+// Deaktiviert Stations-BCC fuer alle Buchungs-Mails.
+add_filter( 'commonsbooking_send_booking_message_to_locations_enabled', '__return_false' );
 ```

--- a/docs/en/documentation/advanced-functionality/hooks-and-filters.md
+++ b/docs/en/documentation/advanced-functionality/hooks-and-filters.md
@@ -86,6 +86,7 @@ receives a value, modifies it, and then returns it.
   * commonsbooking_mail_subject
   * commonsbooking_mail_body
   * commonsbooking_mail_attachment
+  * commonsbooking_send_booking_message_to_locations_enabled
   * commonsbooking_disableCache
 
 There are also filter hooks that allow you to add additional user roles
@@ -144,4 +145,13 @@ How many months are displayed in the mobile calendar view can be adjusted using 
 ```php
 // Sets the mobile calendar view to display 2 months
 add_filter('commonsbooking_mobile_calendar_month_count', fn(): int => 2);
+```
+
+### Filter `commonsbooking_send_booking_message_to_locations_enabled`
+
+Use this filter to enable or disable location BCC recipients for booking mails.
+
+```php
+// Disable location BCC for all booking mails.
+add_filter( 'commonsbooking_send_booking_message_to_locations_enabled', '__return_false' );
 ```

--- a/src/Messages/BookingMessage.php
+++ b/src/Messages/BookingMessage.php
@@ -37,6 +37,7 @@ class BookingMessage extends Message {
 		$location          = get_post( $booking->getMetaInt( 'location-id' ) );
 		$location_emails   = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email', $location ); /*  email addresses, comma-seperated  */
 		$location_bcc_copy = CB::get( Location::$postType, COMMONSBOOKING_METABOX_PREFIX . 'location_email_bcc', $location ) == 'on'; /*  email addresses, comma-seperated  */
+		$location_bcc_copy = apply_filters( 'commonsbooking_send_booking_message_to_locations_enabled', $location_bcc_copy );
 		if ( $location_emails && $location_bcc_copy ) {
 			$bcc_adresses = str_replace( ' ', '', $location_emails );
 		} else {


### PR DESCRIPTION
Da unsere Buchungsemails neben Emailadresse und Name auch noch Adresse und Telefonnummer enthalten, können wir die Mails (BookingMessage) nicht einfach an die Stationen schicken, da die Stationen nicht alle eine Datenschutzbelehrung bekommen haben. Manche Stationen möchten durchaus Erinnerungsmails (LocationBookingReminderMessage) und Buchungscodes (BookingCodesMessage) erhalten, aber aktuell lässt es sich nicht unabhängig voneinander ein- und ausschalten. Kann ich diesen Filter-Hook bekommen?