### PR TITLE
timezone sensitive testing / fix for #1388 (2)

### DIFF
--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -37,7 +37,7 @@ class Helper {
 
 		$date_format = commonsbooking_sanitizeHTML( get_option( 'date_format' ) );
 
-		return date_i18n( $date_format, $timestamp );
+		return wp_date( $date_format, $timestamp );
 	}
 
 	/**
@@ -51,7 +51,7 @@ class Helper {
 
 		$time_format = commonsbooking_sanitizeHTML( get_option( 'time_format' ) );
 
-		return date_i18n( $time_format, $timestamp );
+		return wp_date( $time_format, $timestamp );
 	}
 
 	/**

--- a/src/Helper/Wordpress.php
+++ b/src/Helper/Wordpress.php
@@ -313,11 +313,8 @@ class Wordpress {
 		return $dto;
 	}
 
-	public static function getUTCDateTime( $datetime = 'now' ): DateTime {
-		$dto = new DateTime( $datetime );
-		$dto->setTimezone( new \DateTimeZone( 'UTC' ) );
-
-		return $dto;
+	public static function getDateTime( $datetime = 'now' ): DateTime {
+		return new DateTime( $datetime );
 	}
 
 	public static function getLocalDateTime( $timestamp ): DateTime {

--- a/src/Map/MapData.php
+++ b/src/Map/MapData.php
@@ -147,13 +147,13 @@ class MapData {
 	 **/
 	public static function get_settings( $cb_map_id ): array {
 		$map                = new Map( $cb_map_id );
-		$date_min           = Wordpress::getUTCDateTime();
+		$date_min           = Wordpress::getDateTime();
 		$date_min           = $date_min->format( 'Y-m-d' );
 		$max_days_in_future = $map->getMeta( 'availability_max_days_to_show' );
 		if ( ! is_numeric( $max_days_in_future ) || $max_days_in_future < 1 ) {
 			$max_days_in_future = 11;
 		}
-		$date_max = Wordpress::getUTCDateTime( $date_min . ' + ' . $max_days_in_future . ' days' );
+		$date_max = Wordpress::getDateTime( $date_min . ' + ' . $max_days_in_future . ' days' );
 		$date_max = $date_max->format( 'Y-m-d' );
 		$maxdays  = $map->getMeta( 'availability_max_day_count' );
 

--- a/src/Map/MapItemAvailable.php
+++ b/src/Map/MapItemAvailable.php
@@ -57,9 +57,9 @@ class MapItemAvailable {
 		$endDay   = new Day( $date_end );
 
 		$filter_period = new DatePeriod(
-			Wordpress::getUTCDateTime( $date_start ),
+			Wordpress::getDateTime( $date_start ),
 			new DateInterval( 'P1D' ),
-			Wordpress::getUTCDateTime( $date_end . ' +1 day' )
+			Wordpress::getDateTime( $date_end . ' +1 day' )
 		);
 
 		foreach ( $locations as $location_id => &$location ) {

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -326,7 +326,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 	 * @return string
 	 */
 	private function sanitizeTimeField( $fieldName ): string {
-		$time       = Wordpress::getUTCDateTime();
+		$time       = Wordpress::getDateTime();
 		$fieldValue = $this->getStartDate();
 		if ( $fieldName === 'end-time' ) {
 			$fieldValue = $this->getRawEndDate();
@@ -413,12 +413,12 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 
 	public function getFormattedStartDate(): string {
 		$date_format = commonsbooking_sanitizeHTML( get_option( 'date_format' ) );
-		return date_i18n( $date_format, $this->getStartDate() );
+		return wp_date( $date_format, $this->getStartDate() );
 	}
 
 	public function getFormattedEndDate(): string {
 		$date_format = commonsbooking_sanitizeHTML( get_option( 'date_format' ) );
-		return date_i18n( $date_format, $this->getRawEndDate() );
+		return wp_date( $date_format, $this->getRawEndDate() );
 	}
 
 	/**
@@ -457,9 +457,9 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		$repetitionStart = $this->getStartDate();
 		$repetitionEnd   = $this->getEndDate();
 
-		$date_start = date_i18n( $date_format, $repetitionStart );
-		$time_start = date_i18n( $time_format, $repetitionStart );
-		$time_end   = date_i18n( $time_format, $repetitionEnd );
+		$date_start = wp_date( $date_format, $repetitionStart );
+		$time_start = wp_date( $time_format, $repetitionStart );
+		$time_end   = wp_date( $time_format, $repetitionEnd );
 
 		if ( $this->isFullDay() ) {
 			return $date_start;
@@ -479,7 +479,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		}
 
 		if ( $grid > 0 ) { // if grid is set to hourly (grid = 1) or a multiple of an hour
-			$time_end = date_i18n( $time_format, $repetitionStart + ( 60 * 60 * $grid ) );
+			$time_end = wp_date( $time_format, $repetitionStart + ( 60 * 60 * $grid ) );
 		}
 
 		return $date_start . ' ' . $time_start . ' - ' . $time_end;
@@ -496,9 +496,9 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		$date_format = commonsbooking_sanitizeHTML( get_option( 'date_format' ) );
 		$time_format = commonsbooking_sanitizeHTML( get_option( 'time_format' ) );
 
-		$date_end   = date_i18n( $date_format, $this->getRawEndDate() );
-		$time_end   = date_i18n( $time_format, $this->getRawEndDate() + 60 ); // we add 60 seconds because internal timestamp is set to hh:59
-		$time_start = date_i18n( $time_format, $this->getStartDate() );
+		$date_end   = wp_date( $date_format, $this->getRawEndDate() );
+		$time_end   = wp_date( $time_format, $this->getRawEndDate() + 60 ); // we add 60 seconds because internal timestamp is set to hh:59
+		$time_start = wp_date( $time_format, $this->getStartDate() );
 
 		if ( $this->isFullDay() ) {
 			return $date_end;
@@ -515,7 +515,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 		}
 
 		if ( $grid > 0 ) { // if grid is set to hourly (grid = 1) or a multiple of an hour
-			$time_start = date_i18n( $time_format, $this->getRawEndDate() + 1 - ( 60 * 60 * $grid ) );
+			$time_start = wp_date( $time_format, $this->getRawEndDate() + 1 - ( 60 * 60 * $grid ) );
 		}
 
 		return $date_end . ' ' . $time_start . ' - ' . $time_end;

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -156,12 +156,12 @@ class Calendar {
 					$availabilitySlot = new stdClass();
 
 					// Init DateTime object for start
-					$dateTimeStart = Wordpress::getUTCDateTime( 'now' );
+					$dateTimeStart = Wordpress::getDateTime( 'now' );
 					$dateTimeStart->setTimestamp( $slot['timestampstart'] );
 					$availabilitySlot->start = $dateTimeStart->format( 'Y-m-d\TH:i:sP' );
 
 					// Init DateTime object for end
-					$dateTimeend = Wordpress::getUTCDateTime( 'now' );
+					$dateTimeend = Wordpress::getDateTime( 'now' );
 					$dateTimeend->setTimestamp( $slot['timestampend'] );
 					$availabilitySlot->end = $dateTimeend->format( 'Y-m-d\TH:i:sP' );
 

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -86,7 +86,7 @@ class Day {
 	 * @throws Exception
 	 */
 	public function getDateObject(): DateTime {
-		return Wordpress::getUTCDateTime( $this->getDate() );
+		return Wordpress::getDateTime( $this->getDate() );
 	}
 
 	/**

--- a/src/Model/Restriction.php
+++ b/src/Model/Restriction.php
@@ -103,10 +103,10 @@ class Restriction extends CustomPost {
 	 */
 	public function getEndTimeDateTime( $endDateString = null ): DateTime {
 		$endTimeString = $this->getMeta( self::META_END );
-		$endDate       = Wordpress::getUTCDateTime();
+		$endDate       = Wordpress::getDateTime();
 
 		if ( $endTimeString ) {
-			$endTime = Wordpress::getUTCDateTime();
+			$endTime = Wordpress::getDateTime();
 			$endTime->setTimestamp( (int) $endTimeString );
 			$endDate->setTime( (int) $endTime->format( 'H' ), (int) $endTime->format( 'i' ) );
 		} else {
@@ -206,7 +206,7 @@ class Restriction extends CustomPost {
 	 */
 	public function getStartTimeDateTime(): DateTime {
 		$startDateString = $this->getMeta( self::META_START );
-		$startDate       = Wordpress::getUTCDateTime();
+		$startDate       = Wordpress::getDateTime();
 		$startDate->setTimestamp( (int) $startDateString );
 
 		return $startDate;
@@ -229,7 +229,7 @@ class Restriction extends CustomPost {
 	 */
 	public function getEndDateDateTime(): DateTime {
 		$endDateString = intval( $this->getMeta( self::META_END ) );
-		$endDate       = Wordpress::getUTCDateTime();
+		$endDate       = Wordpress::getDateTime();
 		$endDate->setTimestamp( $endDateString );
 
 		return $endDate;

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -249,8 +249,8 @@ class Timeframe extends CustomPost {
 		$format = self::getDateFormat();
 		$today  = strtotime( 'now' );
 
-		$startDateFormatted = date_i18n( $format, $startDate );
-		$endDateFormatted   = date_i18n( $format, $endDate );
+		$startDateFormatted = wp_date( $format, $startDate );
+		$endDateFormatted   = wp_date( $format, $endDate );
 
 		$label           = commonsbooking_sanitizeHTML( __( 'Available here', 'commonsbooking' ) );
 		$availableString = '';
@@ -1062,7 +1062,7 @@ class Timeframe extends CustomPost {
 		if ( $this->isFullDay() ) {
 			return Wordpress::getUTCDateTimeByTimestamp( $startDateString );
 		}
-		return Wordpress::convertTimestampToUTCDatetime( intval( $startDateString ) );
+		return intval( $startDateString );
 	}
 
 	/**
@@ -1140,7 +1140,7 @@ class Timeframe extends CustomPost {
 	 */
 	public function getEndTimeDateTime( $endDateString = null ): DateTime {
 		$endTimeString = $this->getEndTime();
-		$endDate       = Wordpress::getUTCDateTime();
+		$endDate       = Wordpress::getDateTime();
 
 		if ( $endTimeString ) {
 			$endTime = Wordpress::getUTCDateTimeByTimestamp( strtotime( $endTimeString ) );

--- a/src/Repository/BookingCodes.php
+++ b/src/Repository/BookingCodes.php
@@ -302,10 +302,10 @@ class BookingCodes {
 		if ( ! $timeframe->bookingCodesApplicable() ) {
 			return false;
 		}
-		$begin = Wordpress::getUTCDateTime();
+		$begin = Wordpress::getDateTime();
 		$begin->setTimestamp( $timeframe->getStartDate() );
 		if ( $timeframe->getRawEndDate() ) {
-			$end = Wordpress::getUTCDateTime();
+			$end = Wordpress::getDateTime();
 			$end->setTimestamp( $timeframe->getRawEndDate() );
 			// set $end's time > 00:00:00 such that DatePeriod-iteration will include $end:
 			$end->setTime( 0, 0, 1 );

--- a/src/Service/TimeframeExport.php
+++ b/src/Service/TimeframeExport.php
@@ -537,8 +537,8 @@ class TimeframeExport {
 	 */
 	protected static function getPeriod( $start, $end ) {
 		// Timerange
-		$begin = Wordpress::getUTCDateTime( $start );
-		$end   = Wordpress::getUTCDateTime( $end );
+		$begin = Wordpress::getDateTime( $start );
+		$end   = Wordpress::getDateTime( $end );
 
 		$interval = DateInterval::createFromDateString( '1 day' );
 

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -401,7 +401,7 @@ HTML;
 		// This settings is the amount of booking codes that should be shown to the user
 		$bcToShow = Settings::getOption( 'commonsbooking_options_bookingcodes', 'bookingcodes-listed-timeframe' );
 		if ( $bcToShow > 0 ) {
-			$tsStart      = max( Wordpress::getUTCDateTime( 'today' )->getTimestamp(), $timeframe->getStartDate() );
+			$tsStart      = max( Wordpress::getDateTime( 'today' )->getTimestamp(), $timeframe->getStartDate() );
 			$tsEnd        = strtotime( ' +' . ( $bcToShow - 1 ) . ' days', $tsStart );
 			$bookingCodes = \CommonsBooking\Repository\BookingCodes::getCodes( $timeframeId, $tsStart, $tsEnd );
 

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -210,9 +210,9 @@ class Calendar {
 			$print .= "<th class='sortless' colspan='" . $colspan . "'>";
 
 			if ( $colspan > 3 ) {
-				$print .= date_i18n( 'F', strtotime( get_date_from_gmt( $month ) ) ) . '</th>';
+				$print .= wp_date( 'F', strtotime( get_date_from_gmt( $month ) ) ) . '</th>';
 			} else {
-				$print .= date_i18n( 'M', strtotime( get_date_from_gmt( $month ) ) ) . '</th>';
+				$print .= wp_date( 'M', strtotime( get_date_from_gmt( $month ) ) ) . '</th>';
 			}
 		}
 

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -224,7 +224,8 @@ class Booking extends Timeframe {
 	 * @param string|null $repetitionEnd
 	 * @param string|null $requestedPostName
 	 * @param string|null $postType
-	 *
+	 * @param int         $overbookedDays
+	 * @param bool        $timeZoneConversion because the litepicker returns a timezone agnostic timestamp, we need to convert it to true UNIX times. When calling it with the correct UNIX timestamp, we want to skip conversion.
 	 * @return int - the post id of the created booking
 	 * @throws BookingDeniedException - if the booking is not possible, message contains translated text for the user
 	 */
@@ -238,7 +239,8 @@ class Booking extends Timeframe {
 		?string $repetitionEnd,
 		?string $requestedPostName,
 		?string $postType,
-		int $overbookedDays = 0
+		int $overbookedDays = 0,
+		bool $timeZoneConversion = true
 	): int {
 
 		if ( isset( $_POST['calendar-download'] ) ) {
@@ -270,6 +272,16 @@ class Booking extends Timeframe {
 		$locationId      = (int) $locationId;
 		$repetitionStart = (int) $repetitionStart;
 		$repetitionEnd   = (int) $repetitionEnd;
+
+		if ( $timeZoneConversion ) {
+			// convert localized timestamp to UNIX timestamp
+			$dt = new \DateTime( $repetitionStart );
+			// gets the offset from the current timezone to GMT (why not UTC, I don't know)
+			$offset = wp_timezone()->getOffset( $dt );
+			// subtract the offset, now we have a UNIX timestamp
+			$repetitionStart = $repetitionStart - $offset;
+			$repetitionEnd   = $repetitionEnd - $offset;
+		}
 
 		if ( $post_ID != null && ! get_post( $post_ID ) ) {
 			throw new BookingDeniedException(

--- a/tests/php/BaseTestCase.php
+++ b/tests/php/BaseTestCase.php
@@ -12,6 +12,7 @@ class BaseTestCase extends TestCase {
 		// Default case: Tests should work offline
 		GeoHelperTest::setUpGeoHelperMock( $this );
 		date_default_timezone_set( 'Europe/Berlin');
+		update_option('timezone_string', 'Europe/Berlin');
 	}
 
 	protected function tearDown(): void

--- a/tests/php/BaseTestCase.php
+++ b/tests/php/BaseTestCase.php
@@ -11,15 +11,12 @@ class BaseTestCase extends TestCase {
 
 		// Default case: Tests should work offline
 		GeoHelperTest::setUpGeoHelperMock( $this );
-		date_default_timezone_set( 'Europe/Berlin');
-		update_option('timezone_string', 'Europe/Berlin');
+		date_default_timezone_set( 'Europe/Berlin' );
+		update_option( 'timezone_string', 'Europe/Berlin' );
 	}
 
-	protected function tearDown(): void
-	{
+	protected function tearDown(): void {
 		date_default_timezone_set( 'UTC' );
 		parent::tearDown();
 	}
-
-
 }

--- a/tests/php/BaseTestCase.php
+++ b/tests/php/BaseTestCase.php
@@ -11,5 +11,14 @@ class BaseTestCase extends TestCase {
 
 		// Default case: Tests should work offline
 		GeoHelperTest::setUpGeoHelperMock( $this );
+		date_default_timezone_set( 'Europe/Berlin');
 	}
+
+	protected function tearDown(): void
+	{
+		date_default_timezone_set( 'UTC' );
+		parent::tearDown();
+	}
+
+
 }

--- a/tests/php/Model/BookingTest.php
+++ b/tests/php/Model/BookingTest.php
@@ -754,7 +754,9 @@ class BookingTest extends CustomPostTypeTest {
 			$beginningTime->getTimestamp(),
 			$endingTime->getTimestamp(),
 			null,
-			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID,
+			0,
+			false
 		);
 		$this->testBookingSpanningOverTwoSlots = new Booking(
 			$testBookingSpanningOverTwoSlotsID

--- a/tests/php/Wordpress/CustomPostType/BookingTest.php
+++ b/tests/php/Wordpress/CustomPostType/BookingTest.php
@@ -36,7 +36,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 		// add this to the array so it can be destroyed later
 		$this->bookingIds[] = $bookingId;
@@ -59,7 +61,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			$postName,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $newBookingId;
 
@@ -82,7 +86,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			$postName,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $canceledId;
 
@@ -109,7 +115,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( '+1 day' ),
 			strtotime( '+2 days' ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $bookingId;
 
@@ -128,7 +136,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( '+1 day' ),
 			strtotime( '+2 days' ),
 			$postName,
-			null
+			null,
+			0,
+			false
 		);
 	}
 
@@ -149,7 +159,8 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( '+5 day', strtotime( self::CURRENT_DATE ) ),
 			null,
 			null,
-			3
+			3,
+			false
 		);
 		// add this to the array so it can be destroyed later
 		$this->bookingIds[] = $bookingId;
@@ -172,7 +183,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+5 day', strtotime( self::CURRENT_DATE ) ),
 			$postName,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $newBookingId;
 
@@ -199,7 +212,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 	}
 	public function testBookingWithoutItem() {
@@ -215,7 +230,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 	}
 	public function testBookingWithoutStart() {
@@ -231,7 +248,9 @@ class BookingTest extends CustomPostTypeTest {
 			null,
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 	}
 	public function testBookingWithoutEnd() {
@@ -247,7 +266,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			null,
 			null,
-			null
+			null,
+			0,
+			false
 		);
 	}
 	public function testBookingOverlapping() {
@@ -264,7 +285,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 	}
 
@@ -279,7 +302,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 		// add this to the array so it can be destroyed later
 		$this->bookingIds[] = $bookingId;
@@ -296,7 +321,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $sameBookingId;
 
@@ -323,7 +350,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			null,
-			'6'
+			'6',
+			0,
+			false
 		);
 		$postName  = get_post( $bookingId )->post_name;
 
@@ -343,7 +372,9 @@ class BookingTest extends CustomPostTypeTest {
 			strtotime( self::CURRENT_DATE ),
 			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
 			$postName,
-			'6'
+			'6',
+			0,
+			false
 		);
 	}
 
@@ -492,7 +523,9 @@ class BookingTest extends CustomPostTypeTest {
 			$repetitionStart,
 			$repetitionEnd,
 			null,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $user1BookingId;
 		$postName           = get_post( $user1BookingId )->post_name;
@@ -505,7 +538,9 @@ class BookingTest extends CustomPostTypeTest {
 			$repetitionStart,
 			$repetitionEnd,
 			$postName,
-			null
+			null,
+			0,
+			false
 		);
 
 		wp_set_current_user( $this->createSecondSubscriber() );
@@ -521,7 +556,9 @@ class BookingTest extends CustomPostTypeTest {
 				$repetitionStart,
 				$repetitionEnd,
 				null,
-				null
+				null,
+				0,
+				false
 			);
 			$this->bookingIds[] = $result;
 		} catch ( \CommonsBooking\Exception\BookingDeniedException $e ) {
@@ -551,7 +588,9 @@ class BookingTest extends CustomPostTypeTest {
 			$repetitionStart,
 			$repetitionEnd,
 			null,
-			null
+			null,
+			0,
+			false
 		);
 		$this->bookingIds[] = $user1BookingId;
 
@@ -568,7 +607,9 @@ class BookingTest extends CustomPostTypeTest {
 				$repetitionStart,
 				$repetitionEnd,
 				null,
-				null
+				null,
+				0,
+				false
 			);
 			$this->bookingIds[] = $result;
 		} catch ( \CommonsBooking\Exception\BookingDeniedException $e ) {


### PR DESCRIPTION
I am trying to do a minimal fix 

- [ ] Fix the timezone problem by making sure a Unix timestamp is always saved instead of the localized timestamp
- [ ] Write migration functions to convert existing timestamps into unix timestamps
- [ ] Functions that expect a localized timestamps will get a helper conversion function

My findings so far:
- Litepicker passes a Unix timestamp to handleBookingRequest. It does not consider timezone offset, so 6AM selected in the Litepicker becomes a 6AM UTC timestamp, even though timezone needs to be applied too.
- restrictions also get saved with this "localized timestamp" (this is where I quit frustrated (for now))