### PR TITLE
fix #1388 timezone bug in GBFS

### DIFF
--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -3,6 +3,7 @@
 
 namespace CommonsBooking\API\GBFS;
 
+use CommonsBooking\Helper\Wordpress;
 use CommonsBooking\Model\Calendar;
 use CommonsBooking\Model\Day;
 use CommonsBooking\Model\Location;
@@ -59,12 +60,12 @@ class StationStatus extends BaseRoute {
 	 */
 	private function getItemCountAtLocation( $locationId ): int {
 		$items            = Item::getByLocation( $locationId, true );
-		$nowDT            = new \DateTime();
+		$nowDT            = Wordpress::getUTCDateTimeByTimestamp( current_time( 'timestamp' ) );
 		$availableCounter = 0;
 		foreach ( $items as $item ) {
 			// we have to make our calendar span at least one day, otherwise we get no results
 			$itemCalendar      = new Calendar(
-				new Day( date( 'Y-m-d', time() ) ),
+				new Day( date( 'Y-m-d', strtotime( '-1 day' ) ) ),
 				new Day( date( 'Y-m-d', strtotime( '+1 day' ) ) ),
 				[ $locationId ],
 				[ $item->ID ]


### PR DESCRIPTION
Why this works: The availability slots work with localized timestamps /wo a timezone attached. comparing them with a correct timezone timestamped does not work because of the timezone offset. Therefore, we also put the now timestamp into the localized timestamp but without timezone to make them comparable.

We also extend the calendar range by 1 day so that we can be sure all timeframes are retrieved (maybe not necessary). 

closes #1388
