### PR TITLE
docs: remove bug info, add schema version and fix info

### DIFF
--- a/docs/de/documentation/api/commonsbooking-api.md
+++ b/docs/de/documentation/api/commonsbooking-api.md
@@ -29,6 +29,10 @@ Die API erreichst du über _Einstellungen_ -> _CommonsBooking_ -> Tab: _API / Ex
   * Push-URL: Hier könnt ihr die URL des empfangenden Systems eingeben. CommonsBooking wird diese URL bei jeder Änderung der Daten aufrufen, sodass das entfernte System dann über eine Änderung der Daten informiert und diese über einen separaten API-Call abrufen kann. So kann ein Datenaustausch in Echtzeit ermöglicht werden.
   * API-Schlüssel: Hier könnt ihr einen selbstgewählten API-Schlüssel eingeben. Wenn der Schlüssel gesetzt ist, muss das abfragende System in jeder Abfrage den Parameter apikey= _[Schlüssel]_ mitliefern.
 
+## Artikel von der API ausschliessen
+
+Wenn Artikel nicht in der API erscheinen sollen, müssen diese explizit ausgeschlossen werden. Diese Einstellungen kann auf Artikelebene vorgenommen werden, wenn dort der entsprechende Haken gesetzt ist, tauchen diese Artikel nicht in den API Routen auf.
+
 ##  Spezifikation der API-Routen
 
 **Verfügbarkeit**

--- a/docs/de/documentation/api/gbfs.md
+++ b/docs/de/documentation/api/gbfs.md
@@ -1,17 +1,15 @@
 # GBFS
 
-::: danger Fehler in der API
-Mit [Issue 1388](https://github.com/wielebenwir/commonsbooking/issues/1388) ist ein Fehler in der API dokumentiert. Die zeitliche Verfügbarkeit ist u.U. also nicht korrekt.
-:::
-
-Seit 2.5
-
 Diese Schnittstelle stellt Daten der [Standorte](../first-steps/create-location),
 [Artikel](../first-steps/create-item) und deren Verfügbarkeit über die
 [Zeitrahmen](../first-steps/booking-timeframes-manage) in einem stadardisierten Schema bereit.
-Die folgenden Endpunkte der _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) Schema werden unterstützt:
+Aktuell wird die Version X.X der _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) wird unterstützt und die folgenden Endpunkte werden vom Plugin exponiert:
 
 * station_status
 * station_information
 * system_information
 * gbfs.json (Discovery)
+
+::: info Behobenes Problem
+Seit April 2026 (Version X.X) ist der [Fehler zur Bereitstellung der zeitlichen Verfügbarkeit](https://github.com/wielebenwir/commonsbooking/issues/1388) behoben.
+:::

--- a/docs/de/documentation/api/gbfs.md
+++ b/docs/de/documentation/api/gbfs.md
@@ -3,13 +3,15 @@
 Diese Schnittstelle stellt Daten der [Standorte](../first-steps/create-location),
 [Artikel](../first-steps/create-item) und deren Verfügbarkeit über die
 [Zeitrahmen](../first-steps/booking-timeframes-manage) in einem stadardisierten Schema bereit.
-Aktuell wird die Version X.X der _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) wird unterstützt und die folgenden Endpunkte werden vom Plugin exponiert:
+Aktuell wird die Version 3.1-RC2 der _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) unterstützt und die folgenden Endpunkte werden vom Plugin exponiert:
 
 * station_status
 * station_information
 * system_information
+* vehicle_status
+* vehicle_availability
 * gbfs.json (Discovery)
 
 ::: info Behobenes Problem
-Seit April 2026 (Version X.X) ist der [Fehler zur Bereitstellung der zeitlichen Verfügbarkeit](https://github.com/wielebenwir/commonsbooking/issues/1388) behoben.
+Seit Juni 2026 (Version 2.11) ist der [Fehler zur Bereitstellung der zeitlichen Verfügbarkeit](https://github.com/wielebenwir/commonsbooking/issues/1388) behoben.
 :::

--- a/docs/de/documentation/api/gbfs.md
+++ b/docs/de/documentation/api/gbfs.md
@@ -3,14 +3,19 @@
 Diese Schnittstelle stellt Daten der [Standorte](../first-steps/create-location),
 [Artikel](../first-steps/create-item) und deren Verfügbarkeit über die
 [Zeitrahmen](../first-steps/booking-timeframes-manage) in einem stadardisierten Schema bereit.
-Aktuell wird die Version 3.1-RC2 der _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) unterstützt und die folgenden Endpunkte werden vom Plugin exponiert:
+Aktuell wird die Version 3.1-RC3 der _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) unterstützt und die folgenden Endpunkte werden vom Plugin exponiert:
 
-* station_status
-* station_information
-* system_information
-* vehicle_status
-* vehicle_availability
+* station_status.json
+* station_information.json
+* system_information.json
+* vehicle_status.json
+* vehicle_availability.json
+* vehicle_types.json
 * gbfs.json (Discovery)
+
+## Zu vehicle_types.json
+
+Da über CommonsBooking hauptsächlich Lastenräder verliehen werden, gibt die API standardmäßig den `form_factor` als `cargo_bicycle` zurück. Da `propulsion_type` ein Pflichtfeld ist, wird hier standardmäßig `human` gesetzt. Wenn das nicht der Fall wäre, müssten noch viel mehr zusätzliche Informationen zum Antrieb zur Verfügung gestellt werden.
 
 ::: info Behobenes Problem
 Seit Juni 2026 (Version 2.11) ist der [Fehler zur Bereitstellung der zeitlichen Verfügbarkeit](https://github.com/wielebenwir/commonsbooking/issues/1388) behoben.

--- a/docs/en/documentation/api/commonsbooking-api.md
+++ b/docs/en/documentation/api/commonsbooking-api.md
@@ -26,6 +26,10 @@ You can access the API via _Settings_ -> _CommonsBooking_ -> Tab: _API / Export_
   * Push URL: Here you can enter the URL of the receiving system. CommonsBooking will call this URL whenever the data changes, so that the remote system is informed about a data change and can retrieve it via a separate API call. This enables real-time data exchange.
   * API Key: Here you can enter a custom API key. If the key is set, the requesting system must provide the parameter apikey= _[key]_ in every query.
 
+## Excluding items from the API
+
+If you do not want certain items to appear in the API, they must be explicitly excluded. These settings can be configured at item level; if the relevant checkbox is ticked, these items will not appear in the API routes.
+
 ## API route specification
 
 **Availability**

--- a/docs/en/documentation/api/gbfs.md
+++ b/docs/en/documentation/api/gbfs.md
@@ -1,19 +1,21 @@
 # GBFS
 
-
-Since 2.5
-
 This interface provides data of [locations](../first-steps/create-location),
 [items](../first-steps/create-item) and their availability via
 [timeframes](../first-steps/booking-timeframes-manage) in a standardized schema.
-Currently, version 3.1-RC2 of the _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) is supported with the following routes:
+Currently, version 3.1-RC3 of the _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) is supported with the following routes:
 
-* station_status
-* station_information
-* system_information
-* vehicle_status
-* vehicle_availability
+* station_status.json
+* station_information.json
+* system_information.json
+* vehicle_status.json
+* vehicle_availability.json
+* vehicle_types.json
 * gbfs.json (Discovery)
+
+## Regarding vehicle_types.json
+
+Since CommonsBooking is primarily used to rent out cargo bikes, the API returns `cargo_bicycle` as the default value for `form_factor`. As `propulsion_type` is a required field, the default value here is set to `human`. If this were not the case, much more additional information about the propulsion method would need to be provided.
 
 ::: info Fixed Issue
 Since June 2026 (version 2.11) the [issue regarding a wrong display of availability](https://github.com/wielebenwir/commonsbooking/issues/1388) is fixed.

--- a/docs/en/documentation/api/gbfs.md
+++ b/docs/en/documentation/api/gbfs.md
@@ -1,17 +1,19 @@
 # GBFS
 
-::: danger API bug
-A bug in the API is documented in [Issue 1388](https://github.com/wielebenwir/commonsbooking/issues/1388). The temporal availability may therefore not be correct.
-:::
 
 Since 2.5
 
 This interface provides data of [locations](../first-steps/create-location),
 [items](../first-steps/create-item) and their availability via
 [timeframes](../first-steps/booking-timeframes-manage) in a standardized schema.
-The following endpoints of the _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) schema are supported:
+Currently, version 3.1-RC2 of the _General Bikeshare Feed Specification_ ([GBFS](https://www.gbfs.org/documentation/)) is supported with the following routes:
 
 * station_status
 * station_information
 * system_information
+* vehicle_status
+* vehicle_availability
 * gbfs.json (Discovery)
+
+::: info Fixed Issue
+Since June 2026 (version 2.11) the [issue regarding a wrong display of availability](https://github.com/wielebenwir/commonsbooking/issues/1388) is fixed.


### PR DESCRIPTION
@hansmorb was hälst du von folgender Anpassung der Docs? Sobald die Version des GBFS feststeht und die Version des Release in dem es kommt kann dieser Branch gepusht werden.

Ich denke mal beide Änderungen (Bugfix, Unterstützung der neuen GBFS-Version) kommen in einem Release? Wobei man den Fix auch vorher deployen könnte. Ich meine nur etwas gesehen zu haben das du etwas für 3.1 deployed hast #2118 (wenn auch noch nicht alle Änderungen).