### PR TITLE
#2097 GBFS add vehicle status and vehicle availability route

### DIFF
--- a/includes/gbfs-json-schema/vehicle_availability.json
+++ b/includes/gbfs-json-schema/vehicle_availability.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/vehicle_availability.json",
+  "description": "Describes the vehicle availabilities of the system.",
+  "type": "object",
+  "properties": {
+    "last_updated": {
+      "description": "Last time the data in the feed was updated in RFC3339 format.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "ttl": {
+      "description": "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+      "type": "integer",
+      "minimum": 0
+    },
+    "version": {
+      "description": "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
+      "type": "string",
+      "const": "3.1-RC2"
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "vehicles": {
+          "type": "array",
+          "description": "Contains one object per vehicle.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "vehicle_id": {
+                "type": "string",
+                "description": "Identifier of a vehicle"
+              },
+              "vehicle_type_id": {
+                "type": "string",
+                "description": "Unique identifier of a vehicle type as defined in vehicle_types.json"
+              },
+              "station_id": {
+                "type": "string",
+                "description": " The id of the station where this vehicle is located when available"
+              },
+              "pricing_plan_id": {
+                "type": "string",
+                "description": "The plan_id of the pricing plan this vehicle is eligible for"
+              },
+              "vehicle_equipment": {
+                "type": "array",
+                "description": "List of vehicle equipment provided by the operator",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "availabilities": {
+                "type": "array",
+                "description": "Array of time slots during which the specified vehicle is available.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "from": {
+                      "type": "string",
+                      "description": "Start date and time of available time slot.",
+                      "format": "date-time"
+                    },
+                    "until": {
+                      "type": "string",
+                      "description": "End date and time of available time slot.",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": ["from"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "vehicle_id",
+              "station_id",
+              "availabilities"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["vehicles"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["last_updated", "ttl", "version", "data"],
+  "additionalProperties": false
+}

--- a/includes/gbfs-json-schema/vehicle_status.json
+++ b/includes/gbfs-json-schema/vehicle_status.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id":
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/vehicle_status.json",
+  "description":
+    "Describes the vehicles that are available for rent (as of v3.0, formerly free_bike_status).",
+  "type": "object",
+  "properties": {
+    "last_updated": {
+      "description":
+        "Last time the data in the feed was updated in RFC3339 format.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "ttl": {
+      "description":
+        "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+      "type": "integer",
+      "minimum": 0
+    },
+    "version": {
+      "description":
+        "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
+      "type": "string",
+      "const": "3.1-RC2"
+    },
+    "data": {
+      "description":
+        "Array that contains one object per vehicle as defined below.",
+      "type": "object",
+      "properties": {
+        "vehicles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "vehicle_id": {
+                "description": "Rotating (as of v2.0) identifier of a vehicle.",
+                "type": "string"
+              },
+              "lat": {
+                "description": "The latitude of the vehicle.",
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
+              },
+              "lon": {
+                "description": "The longitude of the vehicle.",
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
+              },
+              "is_reserved": {
+                "description": "Is the vehicle currently reserved?",
+                "type": "boolean"
+              },
+              "is_disabled": {
+                "description": "Is the vehicle currently disabled (broken)?",
+                "type": "boolean"
+              },
+              "rental_uris": {
+                "description": "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
+                "type": "object",
+                "properties": {
+                  "android": {
+                    "description": "URI that can be passed to an Android app with an intent (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "ios": {
+                    "description": "URI that can be used on iOS to launch the rental app for this vehicle (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "web": {
+                    "description": "URL that can be used by a web browser to show more information about renting this vehicle (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "vehicle_type_id": {
+                "description": "The vehicle_type_id of this vehicle (added in v2.1-RC).",
+                "type": "string"
+              },
+              "last_reported": {
+                "description": "The last time this vehicle reported its status to the operator's backend in RFC3339 format (added in v2.1-RC).",
+                "type": "string",
+                "format": "date-time"
+              },
+              "current_range_meters": {
+                "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
+                "type": "number",
+                "minimum": 0
+              },
+              "current_fuel_percent": {
+                "description": "This value represents the current percentage, expressed from 0 to 1, of fuel or battery power remaining in the vehicle. Added in v2.3-RC.",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "station_id": {
+                "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",
+                "type": "string"
+              },
+              "home_station_id": {
+                "description": "The station_id of the station this vehicle must be returned to (added in v2.3-RC).",
+                "type": "string"
+              },
+              "pricing_plan_id": {
+                "description": "The plan_id of the pricing plan this vehicle is eligible for (added in v2.2).",
+                "type": "string"
+              },
+              "vehicle_equipment": {
+                "description": "List of vehicle equipment provided by the operator in addition to the accessories already provided in the vehicle. Added in v2.3.",
+                "type": "array",
+                "items": {
+                  "enum": ["child_seat_a", "child_seat_b", "child_seat_c", "winter_tires", "snow_chains"]
+                }
+              },
+              "available_until": {
+                "description": "The date and time when any rental of the vehicle must be completed. Added in v2.3.",
+                "type": "string",
+                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(([+-]([0-9]{2}):([0-9]{2}))|Z)$"
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["lat", "lon"],
+                "errorMessage": "Both 'lat' and 'lon' are required."
+              },
+              {
+                "required": ["station_id"],
+                "properties": {
+                  "lat": {
+                    "not": {}
+                  },
+                  "lon": {
+                    "not": {}
+                  }
+                },
+                "errorMessage": "'station_id' is required if 'lat' and 'lon' are not present."
+              }
+            ],
+            "required": ["vehicle_id", "is_reserved", "is_disabled"]
+          }
+        }
+      },
+      "required": ["vehicles"]
+    }
+  },
+  "required": ["last_updated", "ttl", "version", "data"]
+}

--- a/src/API/AvailabilityRoute.php
+++ b/src/API/AvailabilityRoute.php
@@ -38,12 +38,12 @@ class AvailabilityRoute extends BaseRoute {
 	/**
 	 * This retrieves bookable timeframes and the different items assigned, with their respective availability.
 	 *
-	 * @param bool $id The id of a {@see \CommonsBooking\Wordpress\CustomPostType\Item::post_type} post to search for
+	 * @param ?int $id The id of a {@see \CommonsBooking\Wordpress\CustomPostType\Item::post_type} post to search for
 	 *
 	 * @return array
 	 * @throws Exception
 	 */
-	public function getItemData( $id = false ): array {
+	public static function getItemData( $id = null ): array {
 		$calendar = new Calendar(
 			new Day( date( 'Y-m-d', time() ) ),
 			new Day( date( 'Y-m-d', strtotime( '+2 weeks' ) ) ), // TODO why two weeks? seems like a configurable option

--- a/src/API/GBFS/BaseRoute.php
+++ b/src/API/GBFS/BaseRoute.php
@@ -4,6 +4,7 @@
 namespace CommonsBooking\API\GBFS;
 
 use CommonsBooking\Repository\Location;
+use CommonsBooking\Repository\PostRepository;
 use Exception;
 use stdClass;
 use WP_REST_Request;
@@ -11,10 +12,15 @@ use WP_REST_Response;
 
 /**
  * Base class which implements retrieval of basic data attributes of
- * GBFS spec.
+ * GBFS spec. Derive from this class, when you want to have a route that iterates over CustomPosts.
  *
- * Note: When deriving from this class, implement \WP_REST_Controller::prepare_item_for_response,
- *       which is called in \BaseRoute::getItemData
+ * Note: When deriving from this class
+ *      - implement \WP_REST_Controller::prepare_item_for_response,
+ *        which is called in \BaseRoute::getItemData
+ *      - implement $rest_base
+ *      - implement $schemaUrl
+ *      - (if necessary) overwrite getRepository
+ *      - (if necessary) overwrite getListName
  */
 class BaseRoute extends \CommonsBooking\API\BaseRoute {
 
@@ -26,12 +32,12 @@ class BaseRoute extends \CommonsBooking\API\BaseRoute {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ): WP_REST_Response {
-		$response                 = new stdClass();
-		$response->data           = new stdClass();
-		$response->data->stations = $this->getItemData( $request );
-		$response->last_updated   = date( 'c' ); // ISO-8601 timestamp
-		$response->ttl            = 60;
-		$response->version        = '3.1-RC2';
+		$response                                = new stdClass();
+		$response->data                          = new stdClass();
+		$response->data->{static::getListName()} = $this->getItemData( $request );
+		$response->last_updated                  = date( 'c' ); // ISO-8601 timestamp
+		$response->ttl                           = 60;
+		$response->version                       = '3.1-RC2';
 
 		return $this->respond_with_validation( $response );
 	}
@@ -44,12 +50,12 @@ class BaseRoute extends \CommonsBooking\API\BaseRoute {
 	 * @return array
 	 */
 	public function getItemData( $request ): array {
-		$data      = [];
-		$locations = Location::get();
+		$data  = [];
+		$items = static::getRepository()::get();
 
-		foreach ( $locations as $location ) {
+		foreach ( $items as $item ) {
 			try {
-				$itemdata = $this->prepare_item_for_response( $location, $request );
+				$itemdata = $this->prepare_item_for_response( $item, $request );
 				$data[]   = $itemdata->data;
 			} catch ( Exception $exception ) {
 				if ( WP_DEBUG ) {
@@ -59,5 +65,24 @@ class BaseRoute extends \CommonsBooking\API\BaseRoute {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Overwrite this, if you don't iterate over stations but need the resulting items in a list with a different name
+	 *
+	 * @return string
+	 */
+	protected static function getListName(): string {
+		return 'stations';
+	}
+
+	/**
+	 * The post type that the route will iterate over.
+	 * By default, these are all the locations.
+	 *
+	 * @return PostRepository
+	 */
+	protected static function getRepository(): PostRepository {
+		return new Location();
 	}
 }

--- a/src/API/GBFS/Discovery.php
+++ b/src/API/GBFS/Discovery.php
@@ -49,6 +49,7 @@ class Discovery extends \CommonsBooking\API\BaseRoute {
 				'system_information',
 				'station_information',
 				'station_status',
+				'vehicle_status',
 			]
 		);
 		$feeds     = array_map( fn( $feed ) => $this->get_feed( $feed ), $raw_feeds );

--- a/src/API/GBFS/Discovery.php
+++ b/src/API/GBFS/Discovery.php
@@ -49,6 +49,7 @@ class Discovery extends \CommonsBooking\API\BaseRoute {
 				'system_information',
 				'station_information',
 				'station_status',
+				'vehicle_availability',
 				'vehicle_status',
 			]
 		);

--- a/src/API/GBFS/StationInformation.php
+++ b/src/API/GBFS/StationInformation.php
@@ -35,7 +35,7 @@ class StationInformation extends BaseRoute {
 	 */
 	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem                   = new stdClass();
-		$preparedItem->station_id       = $item->ID . '';
+		$preparedItem->station_id       = strval( $item->ID );
 		$preparedItem->name             = [
 			(object) [
 				'text' => $item->post_title,

--- a/src/API/GBFS/StationStatus.php
+++ b/src/API/GBFS/StationStatus.php
@@ -3,9 +3,6 @@
 
 namespace CommonsBooking\API\GBFS;
 
-use CommonsBooking\Helper\Wordpress;
-use CommonsBooking\Model\Calendar;
-use CommonsBooking\Model\Day;
 use CommonsBooking\Model\Location;
 use CommonsBooking\Repository\Item;
 use stdClass;
@@ -28,61 +25,26 @@ class StationStatus extends BaseRoute {
 	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'includes/gbfs-json-schema/station_status.json';
 
 	/**
-	 * @param Location $item
+	 * @param Location $location
 	 * @param $request
 	 *
 	 * @return WP_REST_Response
 	 * @throws \Exception
 	 */
-	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
+	public function prepare_item_for_response( $location, $request ): WP_REST_Response {
 		$preparedItem                         = new stdClass();
-		$preparedItem->station_id             = $item->ID . '';
-		$preparedItem->num_vehicles_available = $this->getItemCountAtLocation( $item->ID );
+		$preparedItem->station_id             = strval( $location->ID );
+		$preparedItem->num_vehicles_available = count(
+			array_filter(
+				Item::getByLocation( $location->ID, true ),
+				fn( $item ) => $item->isCurrentlyFreeAtLocation( $location->ID )
+			)
+		);
 		$preparedItem->is_installed           = true;
 		$preparedItem->is_renting             = true;
 		$preparedItem->is_returning           = true;
 		$preparedItem->last_reported          = date( 'c' ); // ISO-8601 timestamp
 
 		return new WP_REST_Response( $preparedItem );
-	}
-
-	/**
-	 * Will get the amount of items that are currently in the location
-	 * and marked as "green" (bookable right now by the user) for the current time.
-	 * This purposefully excludes items that have a Holiday Timeframe, are bookable in advance
-	 * or can only be booked through overbooking.
-	 * This is because the GBFS spec only accounts for items available in that instant.
-	 *
-	 * @param int $locationId
-	 *
-	 * @return int
-	 * @throws \Exception
-	 */
-	private function getItemCountAtLocation( $locationId ): int {
-		$items            = Item::getByLocation( $locationId, true );
-		$nowDT            = Wordpress::getUTCDateTimeByTimestamp( current_time( 'timestamp' ) );
-		$availableCounter = 0;
-		foreach ( $items as $item ) {
-			// we have to make our calendar span at least one day, otherwise we get no results
-			$itemCalendar      = new Calendar(
-				new Day( date( 'Y-m-d', strtotime( '-1 day' ) ) ),
-				new Day( date( 'Y-m-d', strtotime( '+1 day' ) ) ),
-				[ $locationId ],
-				[ $item->ID ]
-			);
-			$availabilitySlots = $itemCalendar->getAvailabilitySlots();
-			// we have to iterate over multiple slots because the calendar will give us more than we asked for
-			foreach ( $availabilitySlots as $availabilitySlot ) {
-				// match our exact current time to the slot
-				$startDT = new \DateTime( $availabilitySlot->start );
-				$endDT   = new \DateTime( $availabilitySlot->end );
-				if ( $nowDT >= $startDT && $nowDT <= $endDT ) {
-					++$availableCounter;
-					// break out of the loop, we only need one match of availability per item
-					break;
-				}
-			}
-		}
-		return $availableCounter;
 	}
 }

--- a/src/API/GBFS/VehicleAvailability.php
+++ b/src/API/GBFS/VehicleAvailability.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace CommonsBooking\API\GBFS;
+
+use CommonsBooking\API\AvailabilityRoute;
+use CommonsBooking\Repository\Item;
+use CommonsBooking\Repository\PostRepository;
+use stdClass;
+use WP_REST_Response;
+
+class VehicleAvailability extends BaseRoute {
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'vehicle_availability.json';
+
+	/**
+	 * Commons-API schema definition.
+	 *
+	 * @var string
+	 */
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'includes/gbfs-json-schema/vehicle_availability.json';
+
+	/**
+	 * @param \CommonsBooking\Model\Item $item
+	 * @param $request
+	 *
+	 * @return WP_REST_Response
+	 * @throws \Exception
+	 */
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
+		$preparedItem                 = new stdClass();
+		$preparedItem->vehicle_id     = strval( $item->getCloakedId() );
+		$preparedItem->station_id     = strval( $item->getLocation()?->ID ); // This is what you could consider the home location. Regardless if the item is there atm or not.
+		$preparedItem->availabilities = self::getAvailabilities( $item );
+
+		return new WP_REST_Response( $preparedItem );
+	}
+
+	private static function getAvailabilities( $item ): array {
+		$availabilities = AvailabilityRoute::getItemData( $item->ID );
+
+		if ( empty( $availabilities ) ) {
+			return [];
+		}
+
+		$firstAvailability = array_shift( $availabilities );
+		$slots             = [
+			(object) [
+				'from' => $firstAvailability->start,
+				'until' => $firstAvailability->end,
+			],
+		];
+
+		foreach ( $availabilities as $availability ) {
+			$gapSeconds = strtotime( $availability->start ) - strtotime( end( $slots )->until );
+
+			if ( $gapSeconds < 59 ) {
+				end( $slots )->until = $availability->end;
+			} else {
+				$slots[] = (object) [
+					'from' => $availability->start,
+					'until' => $availability->end,
+				];
+			}
+		}
+
+		return $slots;
+	}
+
+	protected static function getListName(): string {
+		return 'vehicles';
+	}
+
+
+	protected static function getRepository(): PostRepository {
+		// we iterate over posts with cb_item post type
+		return new Item();
+	}
+}

--- a/src/API/GBFS/VehicleAvailability.php
+++ b/src/API/GBFS/VehicleAvailability.php
@@ -32,9 +32,14 @@ class VehicleAvailability extends BaseRoute {
 	 * @throws \Exception
 	 */
 	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
+		$location = $item->getLocation();
+		if ( ! $location ) {
+			throw new \Exception( 'No location for item. (ID: ' . $item->ID . ')' );
+		}
+
 		$preparedItem                 = new stdClass();
 		$preparedItem->vehicle_id     = strval( $item->getCloakedId() );
-		$preparedItem->station_id     = strval( $item->getLocation()?->ID ); // This is what you could consider the home location. Regardless if the item is there atm or not.
+		$preparedItem->station_id     = strval( $location->ID ); // This is what you could consider the home location. Regardless if the item is there atm or not.
 		$preparedItem->availabilities = self::getAvailabilities( $item );
 
 		return new WP_REST_Response( $preparedItem );

--- a/src/API/GBFS/VehicleStatus.php
+++ b/src/API/GBFS/VehicleStatus.php
@@ -31,15 +31,20 @@ class VehicleStatus extends BaseRoute {
 	 * @throws \Exception
 	 */
 	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
+		$location = $item->getLocation();
+		if ( ! $location ) {
+			throw new \Exception( 'No location for item. (ID: ' . $item->ID . ')' );
+		}
+
 		$preparedItem              = new stdClass();
 		$preparedItem->vehicle_id  = strval( $item->getCloakedId() );
-		$preparedItem->station_id  = strval( $item->getLocation()?->ID );
+		$preparedItem->station_id  = strval( $location->ID );
 		$preparedItem->is_reserved = ! $item->isCurrentlyFreeAtLocation( intval( $preparedItem->station_id ) );
-		$preparedItem->is_disabled = $item->getLocation() === null;
+		$preparedItem->is_disabled = false; // This never happens, when the item is disabled it does not have a location and is therefore skipped
 		$preparedItem->rental_uris = (object) [
 			'web' => $item->getCloakedURL(),
 		];
-		// $preparedItem->available_until //TODO The date and time when any rental of the vehicle must be completed. The vehicle must be returned and made available for the next user by this time. If this field is empty, it indicates that the vehicle is available indefinitely. This field SHOULD be published by carsharing or other mobility systems where vehicles can be booked in advance for future travel.
+		// $preparedItem->available_until //TODO: The date and time when any rental of the vehicle must be completed. The vehicle must be returned and made available for the next user by this time. If this field is empty, it indicates that the vehicle is available indefinitely. This field SHOULD be published by carsharing or other mobility systems where vehicles can be booked in advance for future travel.
 
 		return new WP_REST_Response( $preparedItem );
 	}

--- a/src/API/GBFS/VehicleStatus.php
+++ b/src/API/GBFS/VehicleStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace CommonsBooking\API\GBFS;
+
+use CommonsBooking\Repository\Item;
+use CommonsBooking\Repository\PostRepository;
+use stdClass;
+use WP_REST_Response;
+
+class VehicleStatus extends BaseRoute {
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'vehicle_status.json';
+
+	/**
+	 * Commons-API schema definition.
+	 *
+	 * @var string
+	 */
+	protected $schemaUrl = COMMONSBOOKING_PLUGIN_DIR . 'includes/gbfs-json-schema/vehicle_status.json';
+
+	/**
+	 * @param \CommonsBooking\Model\Item $item
+	 * @param $request
+	 *
+	 * @return WP_REST_Response
+	 * @throws \Exception
+	 */
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
+		$preparedItem              = new stdClass();
+		$preparedItem->vehicle_id  = strval( $item->getCloakedId() );
+		$preparedItem->station_id  = strval( $item->getLocation()?->ID );
+		$preparedItem->is_reserved = ! $item->isCurrentlyFreeAtLocation( intval( $preparedItem->station_id ) );
+		$preparedItem->is_disabled = $item->getLocation() === null;
+		$preparedItem->rental_uris = (object) [
+			'web' => $item->getCloakedURL(),
+		];
+		// $preparedItem->available_until //TODO The date and time when any rental of the vehicle must be completed. The vehicle must be returned and made available for the next user by this time. If this field is empty, it indicates that the vehicle is available indefinitely. This field SHOULD be published by carsharing or other mobility systems where vehicles can be booked in advance for future travel.
+
+		return new WP_REST_Response( $preparedItem );
+	}
+
+	protected static function getListName(): string {
+		return 'vehicles';
+	}
+
+
+	protected static function getRepository(): PostRepository {
+		// we iterate over posts with cb_item post type
+		return new Item();
+	}
+}

--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -46,6 +46,14 @@ class Calendar {
 	protected array $timeframes;
 
 	/**
+	 * When this is enabled, @see Timeframe::META_BOOKING_START_DAY_OFFSET is ignored.
+	 * This is used for the API routes, where we want to show the actual availability of the items, regardless of the booking start day offset.
+	 *
+	 * @var bool
+	 */
+	protected bool $ignoreStartDayOffset = false;
+
+	/**
 	 * Calendar constructor.
 	 *
 	 * @param Day   $startDate
@@ -149,7 +157,7 @@ class Calendar {
 					}
 
 					// Skip timeframes that are not bookable today
-					if ( $timeframe->getFirstBookableDay() > $day->getDate() ) {
+					if ( ! $this->ignoreStartDayOffset && $timeframe->getFirstBookableDay() > $day->getDate() ) {
 						continue;
 					}
 
@@ -184,5 +192,9 @@ class Calendar {
 			}
 		}
 		return $slots;
+	}
+
+	public function setIgnoreStartDayOffset( bool $ignoreStartDayOffset ): void {
+		$this->ignoreStartDayOffset = $ignoreStartDayOffset;
 	}
 }

--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -30,6 +30,13 @@ class CustomPost {
 	protected $post;
 
 	/**
+	 * The post ID of the WordPress post
+	 *
+	 * @var int
+	 */
+	protected int $ID;
+
+	/**
 	 * @var string
 	 */
 	protected $date;
@@ -49,6 +56,7 @@ class CustomPost {
 		} else {
 			throw new Exception( 'Invalid post param. Needed WP_Post or ID (int)' );
 		}
+		$this->ID = $this->post->ID;
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -111,4 +111,37 @@ class Item extends BookablePost {
 		return $closestTimeframe?->getLocation();// why I used a deprecated method here: https://github.com/wielebenwir/commonsbooking/issues/507#issuecomment-4235848408
 	}
 
+	/**
+	 * Determines whether this item is currently free at a given location.
+	 * Free is the opposite of rented. Checks against live availability slots, so it excludes items with Holiday
+	 * Timeframes or overbooking-only availability, although they are technically not rented during these periods.
+	 *
+	 * This method will include items that may only be booked in advance (\CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS),
+	 * because they are technically available at this location. Just not for pickup right now.
+	 *
+	 * @param int $locationId
+	 *
+	 * @return bool true if the item is free right now, false otherwise
+	 * @throws \Exception
+	 */
+	public function isCurrentlyFreeAtLocation( int $locationId ): bool {
+		$nowDT        = Wordpress::getUTCDateTimeByTimestamp( current_time( 'timestamp' ) );
+		$itemCalendar = new Calendar(
+			new Day( date( 'Y-m-d', strtotime( '-1 day' ) ) ),
+			new Day( date( 'Y-m-d', strtotime( '+1 day' ) ) ),
+			[ $locationId ],
+			[ $this->ID ]
+		);
+		$itemCalendar->setIgnoreStartDayOffset( true );
+
+		foreach ( $itemCalendar->getAvailabilitySlots() as $availabilitySlot ) {
+			$startDT = new \DateTime( $availabilitySlot->start );
+			$endDT   = new \DateTime( $availabilitySlot->end );
+			if ( $nowDT >= $startDT && $nowDT <= $endDT ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -95,7 +95,7 @@ class Item extends BookablePost {
 	 * Inspired by: https://tier.engineering/How-we-anonymize-user-trips-on-public-APIs
 	 * Difference: We don't care about anonymity as much, because we don't offer A -> B trips.
 	 *
-	 * This function is probably not secure, wp_hash uses md5 encryption.
+	 * This function uses wp_hash to get a hashed identifier, this uses md5 hashing internally.
 	 *
 	 * @return string - a rotating ID for a vehicle
 	 */

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -4,6 +4,7 @@
 namespace CommonsBooking\Model;
 
 use CommonsBooking\Helper\Helper;
+use CommonsBooking\Helper\Wordpress;
 use CommonsBooking\Repository\Timeframe;
 use Exception;
 
@@ -81,6 +82,71 @@ class Item extends BookablePost {
 			true
 		);
 	}
+
+	/**
+	 * Will get a rotating ID by which the vehicle can be identified.
+	 * The ID rotates after every trip and can be used to publish a vehicle ID to the GBFS API.
+	 *
+	 * The GBFS spec demands, that a vehicle ID must be rotated after each trip so that the users cannot be profiled.
+	 * This needs to be deterministic and reversible.
+	 *
+	 * The ID should be reversible, so that we can get a deep link to the item that you found in the feed.
+	 *
+	 * Inspired by: https://tier.engineering/How-we-anonymize-user-trips-on-public-APIs
+	 * Difference: We don't care about anonymity as much, because we don't offer A -> B trips.
+	 *
+	 * This function is probably not secure, wp_hash uses md5 encryption.
+	 *
+	 * @return string - a rotating ID for a vehicle
+	 */
+	public function getCloakedId(): string {
+		$closestBooking = $this->getClosestBooking();
+		$secondHash     = $closestBooking->post_name ?? $this->post_name; // If there is a booking, hash that. Otherwise, get the post name of the item as second hash item
+
+		return wp_hash( $this->ID . $secondHash );
+	}
+
+	/**
+	 * Gets the permalink for an item as a cloaked URL to be published in the API.
+	 *
+	 * @return string
+	 */
+	public function getCloakedURL(): string {
+		return add_query_arg(
+			array(
+				\CommonsBooking\Repository\Item::QUERY_VEHICLE_ID => $this->getCloakedId(),
+				\CommonsBooking\Repository\Item::URL_SLUG => true,
+			),
+			get_site_url() . '/'
+		);
+	}
+
+	/**
+	 * Gets the closest Booking for a given Item.
+	 *
+	 * @return ?Booking the booking that is either past or currently active closest to the current time, null if no booking is present
+	 */
+	public function getClosestBooking(): ?Booking {
+
+		$location = $this->getLocation();
+		if ( $location === null ) {
+			return null;
+		}
+
+		$allBookings = \CommonsBooking\Repository\Booking::get(
+			[ $location->ID ],
+			[ $this->ID ],
+			null,
+			true,
+			null,
+			[ 'confirmed' ]
+		);
+
+		$closestBooking = \CommonsBooking\View\Calendar::getClosestBookableTimeFrameForToday( $allBookings );
+
+		return ( $closestBooking instanceof Booking ) ? $closestBooking : null; // This also checks if the value is null
+	}
+
 	/**
 	 * Will get the location that the item is currently stationed at and bookable.
 	 * Will take into account the current time, the item can have timeframes

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -81,4 +81,34 @@ class Item extends BookablePost {
 			true
 		);
 	}
+	/**
+	 * Will get the location that the item is currently stationed at and bookable.
+	 * Will take into account the current time, the item can have timeframes
+	 * at multiple locations but can only be at one location at a time.
+	 *
+	 * @return ?Location will return null when no Location was found
+	 */
+	public function getLocation(): ?Location {
+		$locations = \CommonsBooking\Repository\Location::getByItem( $this->ID, true );
+
+		if ( empty( $locations ) ) {
+			return null;
+		}
+
+		if ( count( $locations ) === 1 ) {
+			return reset( $locations );
+		}
+
+		$timeframes = [];
+		foreach ( $locations as $location ) {
+			$timeframes = array_merge(
+				$timeframes,
+				$location->getBookableTimeframesByItem( $this->ID, true )
+			);
+		}
+		$closestTimeframe = \CommonsBooking\View\Calendar::getClosestBookableTimeFrameForToday( $timeframes );
+
+		return $closestTimeframe?->getLocation();// why I used a deprecated method here: https://github.com/wielebenwir/commonsbooking/issues/507#issuecomment-4235848408
+	}
+
 }

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -124,7 +124,7 @@ class Item extends BookablePost {
 	/**
 	 * Gets the closest Booking for a given Item.
 	 *
-	 * @return ?Booking the booking that is either past or currently active closest to the current time, null if no booking is present
+	 * @return ?Booking the booking that is past and closest to the current time, null if no booking is present
 	 */
 	public function getClosestBooking(): ?Booking {
 
@@ -142,9 +142,30 @@ class Item extends BookablePost {
 			[ 'confirmed' ]
 		);
 
-		$closestBooking = \CommonsBooking\View\Calendar::getClosestBookableTimeFrameForToday( $allBookings );
+		$allBookings = array_filter( $allBookings, fn( $b ) => $b->isPast() );
 
-		return ( $closestBooking instanceof Booking ) ? $closestBooking : null; // This also checks if the value is null
+		if ( empty( $allBookings ) ) {
+			return null;
+		}
+
+		usort(
+			$allBookings,
+			function ( $a, $b ) {
+				$aStartDate = $a->getStartDate();
+				$bStartDate = $b->getStartDate();
+
+				if ( $aStartDate == $bStartDate ) {
+					$aStartTimeDT = $a->getStartTimeDateTime();
+					$bStartTimeDT = $b->getStartTimeDateTime();
+
+					return $aStartTimeDT <=> $bStartTimeDT;
+				}
+
+				return $aStartDate <=> $bStartDate;
+			}
+		);
+
+		return array_pop( $allBookings );
 	}
 
 	/**

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -28,46 +28,119 @@ class Timeframe extends CustomPost {
 	 */
 	public const ERROR_TYPE = 'timeframeValidationFailed';
 
+	/**
+	 * The error type that occurs, when a timeframe has bookings that have been orphaned. through items changing locations.
+	 * The user is notified about this, so that they can move the bookings using Service::MassOperations.
+	 */
 	public const ORPHANED_TYPE = 'timeframehasOrphanedBookings';
 
+	/**
+	 * The metafield that stores the timestamp (int) for when the timeframe starts.
+	 */
 	public const REPETITION_START = 'repetition-start';
 
+	/**
+	 * The metafield that stores the timestamp (int) for when the timeframe ends.
+	 */
 	public const REPETITION_END = 'repetition-end';
 
+	/**
+	 * The meta field for what kind of selection type is used to select the item.
+	 * Value is either one of self::SELECTION_MANUAL_ID , self::SELECTION_CATEGORY_ID or self::SELECTION_ALL_ID
+	 */
 	public const META_ITEM_SELECTION_TYPE = 'item-select';
 
+	/**
+	 * The metafield for the item post id associated with the timeframe.
+	 */
 	public const META_ITEM_ID = 'item-id';
 
+	/**
+	 * The metafield where a serialized array of post IDs (multiple) of items associated with the timeframe is stored
+	 */
 	public const META_ITEM_ID_LIST = 'item-id-list';
 
+	/**
+	 * The metafield where a serialized array of term_ids that make up the categories from which the items associated with the timeframe are stored.
+	 */
 	public const META_ITEM_CATEGORY_IDS = 'item-category-ids';
 
+	/**
+	 * The meta field for what kind of selection type is used to select the location.
+	 * Value is either one of self::SELECTION_MANUAL_ID , self::SELECTION_CATEGORY_ID or self::SELECTION_ALL_ID
+	 */
 	public const META_LOCATION_SELECTION_TYPE = 'location-select';
 
+	/**
+	 * The metafield for the location post id associated with the timeframe.
+	 */
 	public const META_LOCATION_ID = 'location-id';
 
+	/**
+	 * The metafield where a serialized array of post IDs (multiple) of locations associated with the timeframe is stored
+	 */
 	public const META_LOCATION_ID_LIST = 'location-id-list';
 
+	/**
+	 * The metafield where a serialized array of term_ids that make up the categories from which the locaations associated with the timeframe are stored.
+	 */
 	public const META_LOCATION_CATEGORY_IDS = 'location-category-ids';
 
+	/**
+	 * Metafield for what type of repetition the timeframe uses.
+	 * For possible values @see Timeframe::getRepetition()
+	 */
 	public const META_REPETITION = 'timeframe-repetition';
 
+	/**
+	 * Metafield for how many days in advance the item on that timeframe can be booked.
+	 * When this is limited to for example 30 days, only the next 30 days can be booked.
+	 */
 	public const META_TIMEFRAME_ADVANCE_BOOKING_DAYS = 'timeframe-advance-booking-days';
 
+	/**
+	 * Metafield for the maximum length in days a booking on this timeframe may have.
+	 */
 	public const META_MAX_DAYS = 'timeframe-max-days';
 
+	/**
+	 * A possible meta_value for META_ITEM_SELECTION_TYPE and META_LOCATION_SELECTION_TYPE
+	 * This value implies, that posts are individually selected from a list of posts.
+	 */
 	public const SELECTION_MANUAL_ID = 0;
 
+	/**
+	 * A possible meta_value for META_ITEM_SELECTION_TYPE and META_LOCATION_SELECTION_TYPE
+	 * This value implies, that the user selects a category of posts that the timeframe applies to.
+	 */
 	public const SELECTION_CATEGORY_ID = 1;
 
+	/**
+	 * A possible meta_value for META_ITEM_SELECTION_TYPE and META_LOCATION_SELECTION_TYPE
+	 * This value implies, that the timeframe applies to all items / locations of the instance.
+	 */
 	public const SELECTION_ALL_ID = 2;
 
+	/**
+	 * A metafield with an on/off value determining if booking codes shall be created for the timeframe (only bookable timeframes).
+	 */
 	public const META_CREATE_BOOKING_CODES = 'create-booking-codes';
 
+	/**
+	 * A metafield that defines how many days in advance the user HAS to book an item. This means, that the location often needs some kind of
+	 * booking ahead, and that an item cannot be booked at the same day. Integer value in days.
+	 */
 	public const META_BOOKING_START_DAY_OFFSET = 'booking-startday-offset';
 
+	/**
+	 * A metafield with an on/off value determining if the booking codes generated in the timeframe shall also be shown to the user.
+	 */
 	public const META_SHOW_BOOKING_CODES = 'show-booking-codes';
 
+	/**
+	 * A metafield that stores a serialized array of strings with slugs of user roles that are allowed to book this item. When this is empty,
+	 * all user roles may book this item.
+	 */
 	public const META_ALLOWED_USER_ROLES = 'allowed_user_roles';
 
 	/**
@@ -75,7 +148,10 @@ class Timeframe extends CustomPost {
 	 * Example: 2020-01-01,2020-01-02,2020-01-03
 	 */
 	public const META_MANUAL_SELECTION = 'timeframe_manual_date';
-	const MAX_DAYS_DEFAULT             = 3;
+	/**
+	 * The default value for self::META_MAX_DAYS.
+	 */
+	const MAX_DAYS_DEFAULT = 3;
 
 	/**
 	 * null means the data is not fetched yet

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -831,6 +831,9 @@ class Plugin {
 
 		// iCal rewrite
 		iCalendar::initRewrite();
+
+		// permalink resolution rewrite
+		\CommonsBooking\Repository\Item::initRewrite();
 	}
 
 	/**
@@ -918,6 +921,7 @@ class Plugin {
 					new \CommonsBooking\API\GBFS\Discovery(),
 					new \CommonsBooking\API\GBFS\StationInformation(),
 					new \CommonsBooking\API\GBFS\StationStatus(),
+					new \CommonsBooking\API\GBFS\VehicleStatus(),
 					new \CommonsBooking\API\GBFS\SystemInformation(),
 
 				];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -921,6 +921,7 @@ class Plugin {
 					new \CommonsBooking\API\GBFS\Discovery(),
 					new \CommonsBooking\API\GBFS\StationInformation(),
 					new \CommonsBooking\API\GBFS\StationStatus(),
+					new \CommonsBooking\API\GBFS\VehicleAvailability(),
 					new \CommonsBooking\API\GBFS\VehicleStatus(),
 					new \CommonsBooking\API\GBFS\SystemInformation(),
 

--- a/src/Repository/BookablePost.php
+++ b/src/Repository/BookablePost.php
@@ -217,9 +217,9 @@ abstract class BookablePost extends PostRepository {
 	 * @param array $args WP Post args
 	 * @param bool  $bookable
 	 *
-	 * @return array
+	 * @return \CommonsBooking\Model\Location[]|\CommonsBooking\Model\Item[]
 	 */
-	public static function get( array $args = array(), bool $bookable = false ) {
+	public static function get( array $args = array(), bool $bookable = false ): array {
 		$posts             = [];
 		$args['post_type'] = static::getPostType();
 		$args['nopaging']  = true;
@@ -273,7 +273,7 @@ abstract class BookablePost extends PostRepository {
 	 * @param $relatedType
 	 * @param bool $bookable
 	 *
-	 * @return int[] Array of post ids
+	 * @return \CommonsBooking\Model\Location[] | \CommonsBooking\Model\Item[]
 	 * @throws Exception
 	 */
 	protected static function getByRelatedPost( $postId, $originType, $relatedType, bool $bookable = false ): array {

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -351,8 +351,8 @@ class Booking extends PostRepository {
 	 * Returns bookings. This uses the CommonsBooking\Repository\Timeframe::get() method which
 	 * is not based on the WP_Query class but will perform its own SQL query.
 	 *
-	 * @param array       $locations
-	 * @param array       $items
+	 * @param array       $locations an array of post IDs
+	 * @param array       $items an array of post IDs
 	 * @param string|null $date Date-String in format YYYY-mm-dd
 	 * @param bool        $returnAsModel if true, returns booking model, if false return int array (defaults to false)
 	 * @param int|null    $minTimestamp

--- a/src/Repository/Item.php
+++ b/src/Repository/Item.php
@@ -5,6 +5,8 @@ namespace CommonsBooking\Repository;
 use Exception;
 
 class Item extends BookablePost {
+	public const URL_SLUG         = COMMONSBOOKING_PLUGIN_SLUG . '_get_vehicle';
+	public const QUERY_VEHICLE_ID = COMMONSBOOKING_PLUGIN_SLUG . '_vehicle_cloaked_id';
 
 	/**
 	 * Returns array with items at location based on bookable timeframes.
@@ -21,10 +23,70 @@ class Item extends BookablePost {
 	}
 
 	/**
+	 * Allows resolving cloaked vehicle IDs published by the GBFS API back to the corresponding items
+	 *
+	 * @return void
+	 */
+	public static function initRewrite() {
+		add_action(
+			'wp_loaded',
+			function () {
+				add_rewrite_rule( self::URL_SLUG, 'index.php?' . self::URL_SLUG . '=1', 'top' );
+			}
+		);
+
+		add_filter(
+			'query_vars',
+			function ( $query_vars ) {
+				$query_vars[] = self::URL_SLUG;
+				return $query_vars;
+			}
+		);
+
+		add_action(
+			'parse_request',
+			function ( &$wp ) {
+
+				if (
+					! array_key_exists( self::URL_SLUG, $wp->query_vars ) ||
+					! isset( $_GET[ self::QUERY_VEHICLE_ID ] ) ||
+					empty( $_GET[ self::QUERY_VEHICLE_ID ] )
+				) {
+					return;
+				}
+				$cloakedId = sanitize_text_field( wp_unslash( $_GET[ self::QUERY_VEHICLE_ID ] ) );
+				$item      = Item::getByCloakedId( $cloakedId );
+				if ( $item === null ) {
+					die( 'invalid vehicle id' );
+				}
+				$url = get_permalink( $item->ID );
+				wp_redirect( $url );
+				exit;
+			}
+		);
+	}
+
+	/**
 	 * @return string
 	 */
 	protected static function getPostType(): string {
 		return \CommonsBooking\Wordpress\CustomPostType\Item::getPostType();
+	}
+
+	/**
+	 * Gets an individual item from a cloaked ID. The GBFS API uses this to provide
+	 * deep-links with rotating vehicle IDs.
+	 *
+	 * @param string $cloakedId
+	 * @return \CommonsBooking\Model\Item|null
+	 */
+	public static function getByCloakedId( string $cloakedId ): ?\CommonsBooking\Model\Item {
+		foreach ( self::get() as $item ) {
+			if ( $item->getCloakedId() == $cloakedId ) {
+				return $item;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/src/Repository/Location.php
+++ b/src/Repository/Location.php
@@ -13,7 +13,7 @@ class Location extends BookablePost {
 	 *
 	 * @param bool $bookable
 	 *
-	 * @return array
+	 * @return \CommonsBooking\Model\Location[]
 	 * @throws Exception
 	 */
 	public static function getByItem( $itemId, bool $bookable = false ): array {

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -57,4 +57,6 @@ abstract class PostRepository {
 			return $post;
 		}
 	}
+
+	abstract public static function get( array $args = array() ): array;
 }

--- a/src/View/Booking.php
+++ b/src/View/Booking.php
@@ -344,9 +344,15 @@ class Booking extends View {
 
 		try {
 			$itemModel = new \CommonsBooking\Model\Item( $itemID );
-			$location  = \CommonsBooking\Repository\Location::getByItem( $itemID, true );
-			// pick the first location, no matter what
-			$location  = reset( $location );
+			$location  = $itemModel->getLocation();
+			if ( ! $location ) {
+				// This won't be displayed anywhere
+				wp_send_json_error(
+					array(
+						'message' => 'No location found for this item.',
+					)
+				);
+			}
 			$timeframe = Timeframe::getBookable(
 				[ $location->ID ],
 				[ $itemID ],
@@ -363,22 +369,13 @@ class Booking extends View {
 				)
 			);
 		}
-		if ( $location ) {
-			wp_send_json(
-				array(
-					'success'     => true,
-					'locationID'  => $location->ID,
-					'fullDay'     => $timeframe->isFullDay(),
-				)
-			);
-		} else {
-			// This won't be displayed anywhere
-			wp_send_json_error(
-				array(
-					'message' => 'No location found for this item.',
-				)
-			);
-		}
+		wp_send_json(
+			array(
+				'success'     => true,
+				'locationID'  => $location->ID,
+				'fullDay'     => $timeframe->isFullDay(),
+			)
+		);
 	}
 
 	/**

--- a/tests/php/API/GBFS/StationInformationRouteTest.php
+++ b/tests/php/API/GBFS/StationInformationRouteTest.php
@@ -53,7 +53,7 @@ class StationInformationRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->locationId = $this->createLocation( 'Test Location', 'publish' );
 		$this->itemId     = $this->createItem( 'TestItem', 'publish' );
 
-		$this->timeframe = $this->createTimeframe(
+		$this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
 			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),

--- a/tests/php/API/GBFS/StationStatusRouteTest.php
+++ b/tests/php/API/GBFS/StationStatusRouteTest.php
@@ -84,7 +84,7 @@ class StationStatusRouteTest extends CB_REST_Route_UnitTestCase {
 			2
 		);
 
-		// with offset → unavailable
+		// with offset → still counted as available because it is not booked
 		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
 		$response = rest_do_request( $request );
 		$data     = $response->get_data()->data;
@@ -97,9 +97,9 @@ class StationStatusRouteTest extends CB_REST_Route_UnitTestCase {
 				}
 			)
 		);
-		$this->assertEquals( 0, $relevantStation->num_vehicles_available );
+		$this->assertEquals( 1, $relevantStation->num_vehicles_available );
 
-		// remove offset → available
+		// remove offset → still available
 		update_post_meta( $timeframeID, \CommonsBooking\Model\Timeframe::META_BOOKING_START_DAY_OFFSET, 0 );
 
 		$response        = rest_do_request( $request );
@@ -123,7 +123,7 @@ class StationStatusRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->locationId = $this->createLocation( 'Testlocation', 'publish' );
 		$this->itemId     = $this->createItem( 'TestItem', 'publish' );
 
-		$this->timeframe = $this->createTimeframe(
+		$this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
 			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),

--- a/tests/php/API/GBFS/SystemInformationRouteTest.php
+++ b/tests/php/API/GBFS/SystemInformationRouteTest.php
@@ -4,9 +4,6 @@ namespace CommonsBooking\Tests\API\GBFS;
 
 use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
 
-/**
- * TODO: add result unit test
- */
 class SystemInformationRouteTest extends CB_REST_Route_UnitTestCase {
 
 	protected $ENDPOINT = '/commonsbooking/v1/system_information.json';

--- a/tests/php/API/GBFS/VehicleAvailabilityRouteTest.php
+++ b/tests/php/API/GBFS/VehicleAvailabilityRouteTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\Model\Timeframe;
+use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use SlopeIt\ClockMock\ClockMock;
+
+class VehicleAvailabilityRouteTest extends CB_REST_Route_UnitTestCase {
+
+	protected $ENDPOINT = '/commonsbooking/v1/vehicle_availability.json';
+	private $start;
+	private $end;
+	private $timeframe;
+
+	public function testDailyAvailability() {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data()->data;
+		$this->assertNotEmpty( $data->vehicles );
+		$this->assertCount( 1, $data->vehicles );
+		$availabilities = $data->vehicles[0]->availabilities;
+		$this->assertCount( 1, $availabilities );
+
+		$startDT = new \DateTime( $availabilities[0]->from );
+		$today   = new \DateTime( self::CURRENT_DATE );
+
+		$this->assertEqualsWithDelta( $today->getTimestamp(), $startDT->getTimestamp(), 1.0 );
+	}
+
+	public function testHourlyAvailability() {
+		delete_post_meta( $this->timeframe, 'full-day', 'on' );
+		update_post_meta( $this->timeframe, 'grid', 1 ); // hourly grid
+		update_post_meta( $this->timeframe, 'start-time', '08:00 AM' );
+		update_post_meta( $this->timeframe, 'end-time', '01:00 PM' );
+
+		$startDT = new \DateTime();
+		$startDT->modify( '08:00 AM' );
+		$endDT = new \DateTime();
+		$endDT->modify( '01:00 PM' );
+		$endDT->modify( '-1 second' ); // timeframes always have one second cut
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data()->data;
+		$this->assertNotEmpty( $data->vehicles );
+		$this->assertCount( 1, $data->vehicles );
+		$availabilities = $data->vehicles[0]->availabilities;
+		$this->assertCount( 2, $availabilities ); // today and tomorrow
+		$this->assertEquals( $startDT->format( 'c' ), $availabilities[0]->from );
+		$this->assertEquals( $endDT->format( 'c' ), $availabilities[0]->until );
+	}
+
+	public function testVehicleIDChanges() {
+		// test, that the vehicle ID rotates after each trip
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data()->data;
+		$id   = $data->vehicles[0]->vehicle_id;
+
+		// add a trip
+		$this->createConfirmedBookingStartingToday( $this->locationId, $this->itemId );
+
+		// after the trip, the vehicle ID should have changed
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data()->data;
+
+		$this->assertNotEquals( $id, $data->vehicles[0]->vehicle_id );
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$this->locationId = $this->createLocation( 'Testlocation', 'publish', [] );
+		$this->itemId     = $this->createItem( 'TestItem', 'publish' );
+
+		$mocked      = new \DateTimeImmutable( self::CURRENT_DATE );
+		$this->start = $mocked->modify( '-1 days' );
+		$this->end   = $mocked->modify( '+1 days' );
+
+		$this->timeframe = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			$this->start->getTimestamp(),
+			$this->end->getTimestamp()
+		);
+	}
+
+	public function tearDown(): void {
+		ClockMock::reset();
+		parent::tearDown();
+	}
+}

--- a/tests/php/API/GBFS/VehicleAvailabilityRouteTest.php
+++ b/tests/php/API/GBFS/VehicleAvailabilityRouteTest.php
@@ -65,8 +65,13 @@ class VehicleAvailabilityRouteTest extends CB_REST_Route_UnitTestCase {
 		$data = $response->get_data()->data;
 		$id   = $data->vehicles[0]->vehicle_id;
 
-		// add a trip
-		$this->createConfirmedBookingStartingToday( $this->locationId, $this->itemId );
+		// add a trip in the past
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-2 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) )
+		);
 
 		// after the trip, the vehicle ID should have changed
 		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );

--- a/tests/php/API/GBFS/VehicleAvailabilityRouteTest.php
+++ b/tests/php/API/GBFS/VehicleAvailabilityRouteTest.php
@@ -4,6 +4,7 @@ namespace CommonsBooking\Tests\API\GBFS;
 
 use CommonsBooking\Model\Timeframe;
 use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use SlopeIt\ClockMock\ClockMock;
 
 class VehicleAvailabilityRouteTest extends CB_REST_Route_UnitTestCase {
@@ -22,6 +23,60 @@ class VehicleAvailabilityRouteTest extends CB_REST_Route_UnitTestCase {
 		$data = $response->get_data()->data;
 		$this->assertNotEmpty( $data->vehicles );
 		$this->assertCount( 1, $data->vehicles );
+		$availabilities = $data->vehicles[0]->availabilities;
+		$this->assertCount( 1, $availabilities );
+
+		$startDT = new \DateTime( $availabilities[0]->from );
+		$today   = new \DateTime( self::CURRENT_DATE );
+
+		$this->assertEqualsWithDelta( $today->getTimestamp(), $startDT->getTimestamp(), 1.0 );
+	}
+
+	public function testAvailabilityWithOffset() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		// delete other timeframe so it doesn't mess with our tests
+		wp_delete_post( $this->timeframe, true );
+		$otherLocationId = $this->createLocation( 'Other Location', );
+		$otherItemId     = $this->createItem( 'Other Item', );
+
+		$timeframeID = $this->createTimeframe(
+			$otherLocationId,
+			$otherItemId,
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+10 days', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'on',
+			'd',
+			0,
+			'8:00 AM',
+			'12:00 PM',
+			'publish',
+			[],
+			'',
+			CustomPostTypeTest::USER_ID,
+			3,
+			30,
+			2
+		);
+
+		// with offset → not available right now
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data()->data;
+
+		$availabilities = $data->vehicles[0]->availabilities;
+
+		$startDT = new \DateTime( $availabilities[0]->from );
+		$today   = new \DateTime( self::CURRENT_DATE );
+
+		$this->assertNotEqualsWithDelta( $today->getTimestamp(), $startDT->getTimestamp(), 1.0 );
+
+		// remove offset → now available today
+		update_post_meta( $timeframeID, \CommonsBooking\Model\Timeframe::META_BOOKING_START_DAY_OFFSET, 0 );
+
+		$response       = rest_do_request( $request );
+		$data           = $response->get_data()->data;
 		$availabilities = $data->vehicles[0]->availabilities;
 		$this->assertCount( 1, $availabilities );
 

--- a/tests/php/API/GBFS/VehicleStatusRouteTest.php
+++ b/tests/php/API/GBFS/VehicleStatusRouteTest.php
@@ -30,6 +30,12 @@ class VehicleStatusRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->assertTrue( $data->vehicles[0]->is_reserved );
 	}
 
+	/**
+	 * This does not test is_disabled for when there is no timeframe.
+	 * This is, because there is no way for us to get a location for an item
+	 * when there is no active timeframe.
+	 * @return void
+	 */
 	public function testIsDisabled() {
 		// base case, not disabled
 		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
@@ -38,14 +44,14 @@ class VehicleStatusRouteTest extends CB_REST_Route_UnitTestCase {
 		$data = $response->get_data()->data;
 		$this->assertFalse( $data->vehicles[0]->is_disabled );
 
-		// timeframe expired: is disabled
+		// timeframe expired: item vanishes from feed
 		$future = $this->end->modify( '+1 day' );
 		ClockMock::freeze( $future );
 		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
 		$response = rest_do_request( $request );
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data()->data;
-		$this->assertTrue( $data->vehicles[0]->is_disabled );
+		$this->assertEmpty( $data->vehicles );
 	}
 
 	public function setUp(): void {

--- a/tests/php/API/GBFS/VehicleStatusRouteTest.php
+++ b/tests/php/API/GBFS/VehicleStatusRouteTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use SlopeIt\ClockMock\ClockMock;
+
+class VehicleStatusRouteTest extends CB_REST_Route_UnitTestCase {
+
+	protected $ENDPOINT = '/commonsbooking/v1/vehicle_status.json';
+	private $start;
+	private $end;
+	private $timeframe;
+
+	public function testIsReserved() {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data()->data;
+
+		$this->assertFalse( $data->vehicles[0]->is_reserved );
+
+		$this->createConfirmedBookingStartingToday();
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data()->data;
+		$this->assertTrue( $data->vehicles[0]->is_reserved );
+	}
+
+	public function testIsDisabled() {
+		// base case, not disabled
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data()->data;
+		$this->assertFalse( $data->vehicles[0]->is_disabled );
+
+		// timeframe expired: is disabled
+		$future = $this->end->modify( '+1 day' );
+		ClockMock::freeze( $future );
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data()->data;
+		$this->assertTrue( $data->vehicles[0]->is_disabled );
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$this->locationId = $this->createLocation( 'Testlocation', 'publish', [] );
+		$this->itemId     = $this->createItem( 'TestItem', 'publish' );
+
+		$mocked      = new \DateTimeImmutable( self::CURRENT_DATE );
+		$this->start = $mocked->modify( '-1 days' );
+		$this->end   = $mocked->modify( '+1 days' );
+
+		$this->timeframe = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			$this->start->getTimestamp(),
+			$this->end->getTimestamp()
+		);
+	}
+
+	public function tearDown(): void {
+		ClockMock::reset();
+		parent::tearDown();
+	}
+}

--- a/tests/php/Model/CalendarTest.php
+++ b/tests/php/Model/CalendarTest.php
@@ -92,6 +92,22 @@ class CalendarTest extends CustomPostTypeTest {
 			],
 		];
 		$this->assertEquals( $expectedSlotObject, $availabilitySlots );
+
+		// book the other day too, assert an empty
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( $tomorrow ),
+			$tomorrowEnd
+		);
+		// recreate the calendar object to get the updated availability
+		$this->calendar = new Calendar(
+			new Day( $today, [ $this->locationId ], [ $this->itemId ] ),
+			new Day( $tomorrow, [ $this->locationId ], [ $this->itemId ] ),
+			[ $this->locationId ],
+			[ $this->itemId ]
+		);
+		$this->assertEmpty( $this->calendar->getAvailabilitySlots() );
 	}
 
 	public function testGetAvailabilitySlotsWithHourlyTimeframe() {

--- a/tests/php/Model/ItemTest.php
+++ b/tests/php/Model/ItemTest.php
@@ -55,6 +55,65 @@ class ItemTest extends CustomPostTypeTest {
 	}
 	*/
 
+	public function testGetLocation() {
+		$dt = new \DateTime( self::CURRENT_DATE );
+		ClockMock::freeze( $dt );
+
+		// just one item that is currently bookable
+		$this->assertEquals( $this->locationId, $this->itemModel->getLocation()->ID );
+
+		// in two weeks, the timeframe is expired, so the item will not be at the location anymore
+		$dt->modify( '+2 weeks' );
+		ClockMock::freeze( $dt );
+		$this->assertNull( $this->itemModel->getLocation() );
+
+		// item that is in location A monday-thursday and in location B friday-sunday. Position should change depending on the day of the week
+		$locationA       = $this->createLocation( 'location a' );
+		$locationB       = $this->createLocation( 'location b' );
+		$movingItem      = $this->createItem( 'location changing item' );
+		$movingItemModel = new Item( $movingItem );
+		$tf1             = new Timeframe(
+			$this->createTimeframe(
+				$locationA,
+				$movingItem,
+				strtotime( '-1 day', strtotime( \CommonsBooking\Tests\Wordpress\CustomPostTypeTest::CURRENT_DATE ) ),
+				strtotime( '+14 days', strtotime( \CommonsBooking\Tests\Wordpress\CustomPostTypeTest::CURRENT_DATE ) ),
+				\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+				'',
+				'w',
+				0,
+				'8:00 AM',
+				'12:00 PM',
+				'publish',
+				[ '1','2','3','4' ]
+			)
+		);
+		$tf2             = new Timeframe(
+			$this->createTimeframe(
+				$locationB,
+				$movingItem,
+				strtotime( '-1 day', strtotime( \CommonsBooking\Tests\Wordpress\CustomPostTypeTest::CURRENT_DATE ) ),
+				strtotime( '+14 days', strtotime( \CommonsBooking\Tests\Wordpress\CustomPostTypeTest::CURRENT_DATE ) ),
+				\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+				'',
+				'w',
+				0,
+				'8:00 AM',
+				'12:00 PM',
+				'publish',
+				[ '5','6','7' ]
+			)
+		);
+		$this->assertFalse( $tf1->overlaps( $tf2 ) );
+		$dt = new \DateTime( self::CURRENT_DATE );
+		$dt->modify( 'monday' );
+		ClockMock::freeze( $dt );
+		$this->assertEquals( $locationA, $movingItemModel->getLocation()->ID );
+		$dt->modify( 'friday' );
+		ClockMock::freeze( $dt );
+		$this->assertEquals( $locationB, $movingItemModel->getLocation()->ID );
+	}
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->restrictionIds[] = $this->createRestriction(

--- a/tests/php/Model/ItemTest.php
+++ b/tests/php/Model/ItemTest.php
@@ -6,6 +6,7 @@ use CommonsBooking\Model\Item;
 use CommonsBooking\Model\Restriction;
 use CommonsBooking\Model\Timeframe;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use SlopeIt\ClockMock\ClockMock;
 
 class ItemTest extends CustomPostTypeTest {
 
@@ -112,6 +113,69 @@ class ItemTest extends CustomPostTypeTest {
 		$dt->modify( 'friday' );
 		ClockMock::freeze( $dt );
 		$this->assertEquals( $locationB, $movingItemModel->getLocation()->ID );
+	}
+
+	public function testGetCloakedID() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		$cloakedID = $this->itemModel->getCloakedId();
+		$this->assertIsString( $cloakedID );
+		// create a booking, assert that it has changed
+		$this->createConfirmedBookingEndingToday();
+		$cloakedIDWithBooking = $this->itemModel->getCloakedId();
+		$this->assertNotEquals( $cloakedID, $cloakedIDWithBooking );
+		$booking                  = $this->createConfirmedBookingStartingToday();
+		$cloakedIDwithTwoBookings = $this->itemModel->getCloakedId();
+		$this->assertNotEquals( $cloakedIDWithBooking, $cloakedIDwithTwoBookings );
+
+		// delete second booking, ID should revert to previous one
+		wp_delete_post( $booking, true );
+		$this->assertEquals( $cloakedIDWithBooking, $this->itemModel->getCloakedId() );
+	}
+
+	public function testGetClosestBooking() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		// no booking present
+		$this->assertNull( $this->itemModel->getClosestBooking() );
+
+		// one past booking
+		$bookingEndingToday = $this->createConfirmedBookingEndingToday();
+		$closestBooking     = $this->itemModel->getClosestBooking();
+		$this->assertEquals( $bookingEndingToday, $closestBooking->ID );
+
+		// newer booking in front of that
+		$bookingStartingToday = $this->createConfirmedBookingStartingToday();
+		$closestBooking       = $this->itemModel->getClosestBooking();
+		$this->assertEquals( $bookingStartingToday, $closestBooking->ID );
+
+		// booking in future (should not affect)
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '+3 days' ),
+			strtotime( '+4 days' )
+		);
+		$this->assertEquals( $bookingStartingToday, $this->itemModel->getClosestBooking()->ID );
+	}
+
+	// Test case where last booking is way in the past but other booking is in the nearer future. Should still return booking in the past
+	public function testGetClosestBooking_notIncludingFutureBookings() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		// one past booking
+		$pastBooking = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-7 days' ),
+			strtotime( '-5 days' )
+		);
+		// one future booking
+		$bookingStartingTomorrow = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '+1 day' ),
+			strtotime( '+2 days' )
+		);
+		$closestBooking          = $this->itemModel->getClosestBooking();
+		$this->assertEquals( $pastBooking, $closestBooking->ID );
 	}
 
 	public function testIsCurrentlyFreeAtLocation() {

--- a/tests/php/Model/ItemTest.php
+++ b/tests/php/Model/ItemTest.php
@@ -114,6 +114,63 @@ class ItemTest extends CustomPostTypeTest {
 		$this->assertEquals( $locationB, $movingItemModel->getLocation()->ID );
 	}
 
+	public function testIsCurrentlyFreeAtLocation() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		// Item has a bookable timeframe including today, should be free
+		$this->assertTrue( $this->itemModel->isCurrentlyFreeAtLocation( $this->locationId ) );
+
+		// A confirmed booking starting today means the item is now rented
+		$this->createConfirmedBookingStartingToday();
+		$this->assertFalse( $this->itemModel->isCurrentlyFreeAtLocation( $this->locationId ) );
+
+		// In two weeks, the timeframe is expired, should no longer be free
+		$dt = new \DateTime( self::CURRENT_DATE );
+		$dt->modify( '+2 weeks' );
+		ClockMock::freeze( $dt );
+		$this->assertFalse( $this->itemModel->isCurrentlyFreeAtLocation( $this->locationId ) );
+
+		// Wrong location should not be free
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		$otherLocationId = $this->createLocation( 'other location' );
+		$this->assertFalse( $this->itemModel->isCurrentlyFreeAtLocation( $otherLocationId ) );
+	}
+
+	public function testIsCurrentlyFreeAtLocation_withBookingOffset() {
+		$otherLocationId = $this->createLocation( 'Other Location' );
+		$otherItemId     = $this->createItem( 'Other Item' );
+		$otherItemModel  = new Item( $otherItemId );
+
+		$timeframeId = $this->createTimeframe(
+			$otherLocationId,
+			$otherItemId,
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+10 days', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'on',
+			'd',
+			0,
+			'8:00 AM',
+			'12:00 PM',
+			'publish',
+			[],
+			'',
+			CustomPostTypeTest::USER_ID,
+			3,   // booking start day offset
+			30,
+			2
+		);
+
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		// With offset → item is still free, it's just not possible to pick it up right now
+		$this->assertTrue( $otherItemModel->isCurrentlyFreeAtLocation( $otherLocationId ) );
+
+		// Remove offset → still free, no change in rental status
+		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_BOOKING_START_DAY_OFFSET, 0 );
+		$this->assertTrue( $otherItemModel->isCurrentlyFreeAtLocation( $otherLocationId ) );
+	}
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->restrictionIds[] = $this->createRestriction(

--- a/tests/php/Model/ItemTest.php
+++ b/tests/php/Model/ItemTest.php
@@ -120,16 +120,19 @@ class ItemTest extends CustomPostTypeTest {
 		$cloakedID = $this->itemModel->getCloakedId();
 		$this->assertIsString( $cloakedID );
 		// create a booking, assert that it has changed
-		$this->createConfirmedBookingEndingToday();
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-2 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) )
+		);
 		$cloakedIDWithBooking = $this->itemModel->getCloakedId();
 		$this->assertNotEquals( $cloakedID, $cloakedIDWithBooking );
+
+		// this booking is not in the past, trip has not ended. Therefore it should not affect the ID
 		$booking                  = $this->createConfirmedBookingStartingToday();
 		$cloakedIDwithTwoBookings = $this->itemModel->getCloakedId();
-		$this->assertNotEquals( $cloakedIDWithBooking, $cloakedIDwithTwoBookings );
-
-		// delete second booking, ID should revert to previous one
-		wp_delete_post( $booking, true );
-		$this->assertEquals( $cloakedIDWithBooking, $this->itemModel->getCloakedId() );
+		$this->assertEquals( $cloakedIDWithBooking, $cloakedIDwithTwoBookings );
 	}
 
 	public function testGetClosestBooking() {
@@ -138,14 +141,24 @@ class ItemTest extends CustomPostTypeTest {
 		$this->assertNull( $this->itemModel->getClosestBooking() );
 
 		// one past booking
-		$bookingEndingToday = $this->createConfirmedBookingEndingToday();
-		$closestBooking     = $this->itemModel->getClosestBooking();
-		$this->assertEquals( $bookingEndingToday, $closestBooking->ID );
+		$bookingInPast  = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-4 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '-3 days', strtotime( self::CURRENT_DATE ) )
+		);
+		$closestBooking = $this->itemModel->getClosestBooking();
+		$this->assertEquals( $bookingInPast, $closestBooking->ID );
 
 		// newer booking in front of that
-		$bookingStartingToday = $this->createConfirmedBookingStartingToday();
-		$closestBooking       = $this->itemModel->getClosestBooking();
-		$this->assertEquals( $bookingStartingToday, $closestBooking->ID );
+		$newerBooking   = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-2 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) )
+		);
+		$closestBooking = $this->itemModel->getClosestBooking();
+		$this->assertEquals( $newerBooking, $closestBooking->ID );
 
 		// booking in future (should not affect)
 		$this->createBooking(
@@ -154,7 +167,7 @@ class ItemTest extends CustomPostTypeTest {
 			strtotime( '+3 days' ),
 			strtotime( '+4 days' )
 		);
-		$this->assertEquals( $bookingStartingToday, $this->itemModel->getClosestBooking()->ID );
+		$this->assertEquals( $newerBooking, $this->itemModel->getClosestBooking()->ID );
 	}
 
 	// Test case where last booking is way in the past but other booking is in the nearer future. Should still return booking in the past
@@ -176,6 +189,31 @@ class ItemTest extends CustomPostTypeTest {
 		);
 		$closestBooking          = $this->itemModel->getClosestBooking();
 		$this->assertEquals( $pastBooking, $closestBooking->ID );
+	}
+
+	public function testGetClosestBooking_picksMostRecentPastBooking() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-14 days' ),
+			strtotime( '-12 days' )
+		);
+		$recentPastBooking = $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-3 days' ),
+			strtotime( '-1 day' )
+		);
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '+1 day' ),
+			strtotime( '+2 days' )
+		);
+
+		$closestBooking = $this->itemModel->getClosestBooking();
+		$this->assertEquals( $recentPastBooking, $closestBooking->ID );
 	}
 
 	public function testIsCurrentlyFreeAtLocation() {

--- a/tests/php/Repository/ItemTest.php
+++ b/tests/php/Repository/ItemTest.php
@@ -4,19 +4,37 @@ namespace CommonsBooking\Tests\Repository;
 
 use CommonsBooking\Repository\Item;
 use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use SlopeIt\ClockMock\ClockMock;
 
 class ItemTest extends CustomPostTypeTest {
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		// Create timeframe with location and item, so that we can search vor it
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		// Create timeframe with location and item, so that we can search for it
 		$this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( 'midnight' ),
-			strtotime( '+90 days' )
+			strtotime( 'midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+90 days', strtotime( self::CURRENT_DATE ) )
 		);
+	}
+
+	public function testGetByCloakedId(): void {
+		$itemModel = new \CommonsBooking\Model\Item( $this->itemId );
+
+		// basic test, without any booking
+		$cloakedId = $itemModel->getCloakedId();
+		$this->assertEquals( $this->itemId, Item::getByCloakedId( $cloakedId )->ID );
+
+		// with booking
+		$this->createConfirmedBookingEndingToday();
+		$bookingCloakedId = $itemModel->getCloakedId();
+		$this->assertNotEquals( $bookingCloakedId, $cloakedId );
+		$this->assertEquals( $this->itemId, Item::getByCloakedId( $bookingCloakedId )->ID );
+
+		// test for invalid cloaked id
+		$this->assertNull( Item::getByCloakedId( 'invalid-cloaked-id' ) );
 	}
 
 	public function testGetByLocation(): void {

--- a/tests/php/Repository/ItemTest.php
+++ b/tests/php/Repository/ItemTest.php
@@ -27,8 +27,13 @@ class ItemTest extends CustomPostTypeTest {
 		$cloakedId = $itemModel->getCloakedId();
 		$this->assertEquals( $this->itemId, Item::getByCloakedId( $cloakedId )->ID );
 
-		// with booking
-		$this->createConfirmedBookingEndingToday();
+		// with booking in past
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-2 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) )
+		);
 		$bookingCloakedId = $itemModel->getCloakedId();
 		$this->assertNotEquals( $bookingCloakedId, $cloakedId );
 		$this->assertEquals( $this->itemId, Item::getByCloakedId( $bookingCloakedId )->ID );


### PR DESCRIPTION
This PR implements the vehicle_status and vehicle_availability route of the GBFS API. 

closes #2097
