### PR TITLE
Draft: add visual booking confirmation component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ assets/packaged
 .vscode/settings.json
 .idea
 
+.phpunit.result.cache
 tests/cypress/screenshots
 docs/.vitepress/dist
 /vendor-prefixed

--- a/templates/booking-single.php
+++ b/templates/booking-single.php
@@ -69,7 +69,7 @@ echo commonsbooking_sanitizeHTML( $booking->bookingNotice() ); ?>
 }
 </style>
 
-<div class="cb-pending-banner" id="cb-pending-banner">
+<div class="cb-pending-banner" id="cb-pending-banner" data-expiry="<?php echo (int) $expiry_ts; ?>">
 	<span class="cb-pulse-dot"></span>
 	<span>
 		<?php echo esc_html__( 'Please confirm your booking — reserved for', 'commonsbooking' ); ?>

--- a/templates/booking-single.php
+++ b/templates/booking-single.php
@@ -29,6 +29,83 @@ do_action( 'commonsbooking_before_booking-single', $booking->ID, $booking );
 
 echo commonsbooking_sanitizeHTML( $booking->bookingNotice() ); ?>
 
+<?php if ( $current_status === 'unconfirmed' ) :
+	$expiry_ts = strtotime( $booking->post_date ) + 10 * 60;
+?>
+<style>
+@keyframes cb-pulse {
+	0%, 100% { opacity: 1; transform: scale(1); }
+	50%       { opacity: .4; transform: scale(1.35); }
+}
+.cb-pending-banner {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: var(--commonsbooking-spacer-big, 15px);
+	margin-bottom: var(--commonsbooking-spacer-big, 15px);
+	background: var(--commonsbooking-color-noticebg, #fff9c5);
+	border-radius: var(--commonsbooking-radius, 8px);
+	font-size: var(--commonsbooking-font-size-normal, 14px);
+	flex-wrap: wrap;
+}
+.cb-pulse-dot {
+	width: 12px; height: 12px;
+	border-radius: 50%;
+	background: var(--commonsbooking-color-warning, #ff9218);
+	flex-shrink: 0;
+	animation: cb-pulse 1.4s ease-in-out infinite;
+}
+.cb-pending-banner.cb-expired {
+	background: var(--commonsbooking-color-error, #d5425c);
+	color: #fff;
+}
+.cb-pending-banner.cb-expired .cb-pulse-dot {
+	background: #fff;
+	animation: none;
+}
+#cb-countdown-timer {
+	font-weight: bold;
+	font-variant-numeric: tabular-nums;
+}
+</style>
+
+<div class="cb-pending-banner" id="cb-pending-banner">
+	<span class="cb-pulse-dot"></span>
+	<span>
+		<?php echo esc_html__( 'Please confirm your booking — reserved for', 'commonsbooking' ); ?>
+		<span id="cb-countdown-timer">10:00</span>
+	</span>
+</div>
+
+<script>
+(function () {
+	var expiry  = <?php echo (int) $expiry_ts; ?> * 1000;
+	var banner  = document.getElementById('cb-pending-banner');
+	var display = document.getElementById('cb-countdown-timer');
+	if (!banner || !display) return;
+
+	function pad(n) { return n < 10 ? '0' + n : n; }
+
+	function tick() {
+		var remaining = Math.max(0, Math.floor((expiry - Date.now()) / 1000));
+		var m = Math.floor(remaining / 60);
+		var s = remaining % 60;
+		display.textContent = pad(m) + ':' + pad(s);
+
+		if (remaining <= 0) {
+			banner.classList.add('cb-expired');
+			display.parentElement.textContent =
+				'<?php echo esc_js( __( 'This reservation has expired. Please start a new booking.', 'commonsbooking' ) ); ?>';
+			clearInterval(timer);
+		}
+	}
+
+	tick();
+	var timer = setInterval(tick, 1000);
+})();
+</script>
+<?php endif; ?>
+
 	<div class="cb-wrapper cb-booking-item">
 		<div class="cb-list-header">
 			<?php echo commonsbooking_sanitizeHTML( $item->thumbnail( 'cb_listing_small' ) ); ?>

--- a/tests/cypress/e2e/08-booking-confirmation-banner.cy.js
+++ b/tests/cypress/e2e/08-booking-confirmation-banner.cy.js
@@ -1,0 +1,116 @@
+/**
+ * E2E tests for the booking confirmation pending banner.
+ *
+ * Covers the pulsing dot indicator, countdown timer, expired state,
+ * and absence of the banner on confirmed/cancelled bookings.
+ * See templates/booking-single.php for the implementation.
+ */
+describe('Booking confirmation pending banner', () => {
+
+    // Mirrors the helper in 06-booking-process.cy.js: returns a date that is
+    // never the last day of the month, so the calendar always has a next-day
+    // cell adjacent to .is-start-date.
+    function getTestDate() {
+        const dt = new Date();
+        const test = new Date(dt.getTime());
+        const month = test.getMonth();
+        test.setDate(test.getDate() + 1);
+        if (test.getMonth() !== month) {
+            dt.setDate(dt.getDate() + 1);
+        }
+        return dt.getTime();
+    }
+
+    beforeEach(() => {
+        cy.clock(getTestDate());
+        cy.loginAs('subscriber');
+        cy.visit('/?cb_item=basictest-noadmin&cb-location=32');
+    });
+
+    function createUnconfirmedBooking() {
+        cy.get('.is-today').click();
+        cy.get('.is-start-date').next('.day-item').click();
+        cy.get('#booking-form > [type="submit"]').click();
+        cy.get('.cb-notice').should('contain', 'Please check your booking and click confirm booking');
+    }
+
+    afterEach(() => {
+        // Cancel any leftover unconfirmed booking so subsequent tests start clean.
+        cy.get('body').then(($body) => {
+            if ($body.find('.cb-action-delete_unconfirmed').length) {
+                cy.get('.cb-action-delete_unconfirmed').click();
+            }
+        });
+    });
+
+    it('shows the pending banner for an unconfirmed booking', () => {
+        createUnconfirmedBooking();
+        cy.get('#cb-pending-banner').should('be.visible');
+        cy.screenshot('pending-banner_visible');
+    });
+
+    it('shows the pulsing dot inside the banner', () => {
+        createUnconfirmedBooking();
+        cy.get('#cb-pending-banner .cb-pulse-dot').should('be.visible');
+    });
+
+    it('shows a countdown timer in MM:SS format', () => {
+        createUnconfirmedBooking();
+        // On month-boundary days getTestDate() is 24 h ahead of the PHP server
+        // time, so the banner is already in expired state when the page loads.
+        cy.get('#cb-pending-banner').then(($banner) => {
+            if ($banner.hasClass('cb-expired')) {
+                // Acceptable edge case: verify the expired message is present.
+                cy.wrap($banner).should('contain', 'expired');
+            } else {
+                cy.get('#cb-countdown-timer')
+                    .should('be.visible')
+                    .invoke('text')
+                    .should('match', /^\d{2}:\d{2}$/);
+            }
+        });
+    });
+
+    it('countdown timer decrements when the clock ticks', () => {
+        createUnconfirmedBooking();
+        cy.get('#cb-pending-banner').then(($banner) => {
+            // Skip decrement check when already expired (month-boundary edge case).
+            if ($banner.hasClass('cb-expired')) return;
+
+            cy.get('#cb-countdown-timer').invoke('text').as('timeBefore');
+            cy.tick(1000);
+            cy.get('#cb-countdown-timer').invoke('text').then((timeAfter) => {
+                cy.get('@timeBefore').should('not.equal', timeAfter);
+            });
+        });
+    });
+
+    it('switches to expired state after the 10-minute window elapses', () => {
+        createUnconfirmedBooking();
+        // Advance the fake browser clock past the 10-minute expiry (601 s).
+        // Works on month-boundary days too: the banner is already expired so
+        // ticking past it simply keeps the expired state.
+        cy.tick(601 * 1000);
+        cy.get('#cb-pending-banner')
+            .should('have.class', 'cb-expired')
+            .should('contain', 'expired');
+        cy.screenshot('pending-banner_expired');
+    });
+
+    it('does not show the banner after the booking is confirmed', () => {
+        createUnconfirmedBooking();
+        cy.get('.cb-action-confirmed').click();
+        cy.get('.cb-notice').should('contain', 'Your booking is confirmed');
+        cy.get('#cb-pending-banner').should('not.exist');
+        cy.screenshot('pending-banner_after-confirm');
+        // Clean up the confirmed booking so the slot is free for other tests.
+        cy.get('.cb-action-canceled').click();
+    });
+
+    it('does not show the banner after the booking process is cancelled', () => {
+        createUnconfirmedBooking();
+        cy.get('.cb-action-delete_unconfirmed').click();
+        cy.get('#cb-pending-banner').should('not.exist');
+        cy.screenshot('pending-banner_after-cancel');
+    });
+});


### PR DESCRIPTION
This adds a visual "unconfirmed" booking state to the "to confirm"-booking process step.

I open it because I want to use the CI. I will review it myself first, before I will request review from someone else.