### PR TITLE
Removes duplicate hasBookingCodes()

### DIFF
--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -1024,15 +1024,6 @@ class Timeframe extends CustomPost {
 	}
 
 	/**
-	 * Returns true if booking codes were enabled for this timeframe
-	 *
-	 * @return bool
-	 */
-	public function hasBookingCodes(): bool {
-		return $this->getMeta( 'create-booking-codes' ) == 'on';
-	}
-
-	/**
 	 * Returns repetition-start \DateTime.
 	 * This function contains a weird hotfix for full day timeframes.
 	 * This is because it is mainly used by the iCalendar export where if we don't convert the timestamp to a UTC Datetime we will get the wrong starting time.

--- a/src/View/BookingCodes.php
+++ b/src/View/BookingCodes.php
@@ -181,7 +181,7 @@ class BookingCodes {
 				__( 'Unable to send Emails. No location email(s) configured, check location', 'commonsbooking' ) .
 													sprintf( ' <a href="%s" class="cb-title cb-title-link">%s</a>', esc_url( get_edit_post_link( $location->ID ) ), commonsbooking_sanitizeHTML( $location->post_title ) )
 			);
-		} elseif ( ! $timeframe->hasBookingCodes() ) {
+		} elseif ( ! $timeframe->usesBookingCodes() ) {
 			$errMsg = commonsbooking_sanitizeHTML( __( 'This timeframe has no booking codes. To generate booking codes you need to save the timeframe.', 'commonsbooking' ) );
 		}
 
@@ -290,7 +290,7 @@ HTML;
 				__( 'Unable to send Emails. No location email(s) configured, check location', 'commonsbooking' ) .
 				sprintf( ' <a href="%s" class="cb-title cb-title-link">%s</a>', esc_url( get_edit_post_link( $location->ID ) ), commonsbooking_sanitizeHTML( $location->post_title ) )
 			);
-		} elseif ( ! $timeframe->hasBookingCodes() ) {
+		} elseif ( ! $timeframe->usesBookingCodes() ) {
 			echo commonsbooking_sanitizeHTML( __( 'This timeframe has no booking codes. To generate booking codes you need to save the timeframe.', 'commonsbooking' ) );
 		} else {
 			echo '
@@ -386,7 +386,7 @@ HTML;
                 <div class="cmb-th">
                     <label for="booking-codes-download-link">' . commonsbooking_sanitizeHTML( __( 'Download booking codes', 'commonsbooking' ) ) . '</label>
                 </div>
-                <div id="booking-codes-download" class="cmb-td">' . ( $timeframe->hasBookingCodes() ? '
+                <div id="booking-codes-download" class="cmb-td">' . ( $timeframe->usesBookingCodes() ? '
                     <a id="booking-codes-download-link" href="' . esc_url( add_query_arg( [ 'action' => 'cb_download-bookingscodes-csv' ] ) ) . '" target="_blank"><strong>Download booking codes</strong></a>
                     <p  class="cmb2-metabox-description">
                     ' .
@@ -410,7 +410,7 @@ HTML;
                     <label id="booking-codes-list">' . commonsbooking_sanitizeHTML( __( 'Booking codes list', 'commonsbooking' ) ) . '</label>
                 </div>
                 <div class="cmb-td">';
-			if ( $timeframe->hasBookingCodes() ) {
+			if ( $timeframe->usesBookingCodes() ) {
 				echo self::renderTableFor( 'timeframe_form', $bookingCodes );
 
 				echo '<br>';


### PR DESCRIPTION
`Model\Timeframe::hasBookingCodes()` was identical to `Model\Timeframe::usesBookingCodes()`, both checking the `create-booking-codes` meta value. The duplicate has been removed, and all calls are updated to use `usesBookingCodes()`, which correctly references the `META_CREATE_BOOKING_CODES` constant.

Closes #2038