### PR TITLE
unflaky tests (02.06. problem)

### DIFF
--- a/src/Model/CustomPost.php
+++ b/src/Model/CustomPost.php
@@ -56,6 +56,9 @@ class CustomPost {
 		} else {
 			throw new Exception( 'Invalid post param. Needed WP_Post or ID (int)' );
 		}
+		if ( ! $this->post instanceof WP_Post ) {
+			throw new Exception( 'Invalid post param. No post found for ID ' . $post );
+		}
 		$this->ID = $this->post->ID;
 	}
 

--- a/src/View/Calendar.php
+++ b/src/View/Calendar.php
@@ -147,7 +147,11 @@ class Calendar {
 				$locations = [];
 				foreach ( $timeframes as $timeframe ) {
 					// TODO #507
-					$locations[ $timeframe->getLocationID() ] = $timeframe->getLocation()->post_title;
+					$location = $timeframe->getLocation();
+					if ( ! $location ) {
+						continue;
+					}
+					$locations[ $location->ID ] = $location->post_title;
 				}
 
 				// loop through location

--- a/tests/php/View/CalendarTest.php
+++ b/tests/php/View/CalendarTest.php
@@ -7,6 +7,7 @@ use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 use CommonsBooking\Wordpress\CustomPostType\Item;
 use CommonsBooking\View\Calendar;
 use DateTime;
+use Override;
 use SlopeIt\ClockMock\ClockMock;
 
 /**
@@ -476,6 +477,8 @@ class CalendarTest extends CustomPostTypeTest {
 	protected function setUp(): void {
 		parent::setUp();
 
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
 		$this->now         = time();
 		$this->timeframeId = $this->createTimeframe(
 			$this->locationId,
@@ -499,5 +502,11 @@ class CalendarTest extends CustomPostTypeTest {
 			strtotime( '+14 days midnight' ),
 			strtotime( '+300 days midnight' )
 		);
+	}
+
+	protected function tearDown(): void
+	{
+		ClockMock::reset();
+		parent::tearDown();
 	}
 }

--- a/tests/php/View/CalendarTest.php
+++ b/tests/php/View/CalendarTest.php
@@ -230,6 +230,7 @@ class CalendarTest extends CustomPostTypeTest {
 	}
 
 	public function testRenderTable() {
+		\CommonsBooking\Wordpress\CustomPostType\Item::registerPostTypeTaxonomy();
 		$calendar = Calendar::renderTable( [] );
 		$item     = new \CommonsBooking\Model\Item( $this->itemId );
 		$location = new \CommonsBooking\Model\Location( $this->locationId );
@@ -242,15 +243,11 @@ class CalendarTest extends CustomPostTypeTest {
 		$taxonomyItem = new \CommonsBooking\Model\Item( $taxonomyItem );
 		$term         = wp_create_term( 'Test Category', Item::getTaxonomyName() );
 		wp_set_post_terms( $taxonomyItem->ID, [ $term['term_id'] ], Item::getTaxonomyName() );
-		$termObj   = get_term_by( 'id', $term['term_id'], Item::getTaxonomyName() );
-		$slug      = $termObj->slug;
-		$timeframe = $this->createTimeframe(
-			$this->locationId,
-			$taxonomyItem->ID,
-			strtotime( '+' . self::timeframeStart . ' days midnight', $this->now ),
-			strtotime( '+' . self::timeframeEnd . ' days midnight', $this->now )
-		);
-		$calendar  = Calendar::renderTable( [ 'itemcat' => $slug ] );
+		$termObj = get_term_by( 'id', $term['term_id'], Item::getTaxonomyName() );
+		$slug    = $termObj->slug;
+		$this->createBookableTimeFrameIncludingCurrentDay( $location->ID, $taxonomyItem->ID );
+		wp_cache_flush(); // for some reason, the tests were failing without this
+		$calendar = Calendar::renderTable( [ 'itemcat' => $slug ] );
 		$this->assertStringContainsString( $taxonomyItem->post_title, $calendar );
 		$this->assertStringNotContainsString( $item->post_title, $calendar );
 
@@ -475,10 +472,9 @@ class CalendarTest extends CustomPostTypeTest {
 	}
 
 	protected function setUp(): void {
-		parent::setUp();
-
 		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
 
+		parent::setUp();
 		$this->now         = time();
 		$this->timeframeId = $this->createTimeframe(
 			$this->locationId,
@@ -504,8 +500,7 @@ class CalendarTest extends CustomPostTypeTest {
 		);
 	}
 
-	protected function tearDown(): void
-	{
+	protected function tearDown(): void {
 		ClockMock::reset();
 		parent::tearDown();
 	}

--- a/tests/php/View/ViewTest.php
+++ b/tests/php/View/ViewTest.php
@@ -91,13 +91,13 @@ class ViewTest extends CustomPostTypeTest {
 
 		$this->item     = new Item( $this->itemId );
 		$this->location = new Location( $this->locationId );
-		$timeframeId = $this->createTimeframe(
+		$timeframeId    = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
 			strtotime( '+5 days midnight', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+6 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-// set booking days in advance
+		// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
@@ -105,7 +105,7 @@ class ViewTest extends CustomPostTypeTest {
 			strtotime( '+2 days midnight', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+3 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-// set booking days in advance
+		// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
@@ -113,7 +113,7 @@ class ViewTest extends CustomPostTypeTest {
 			strtotime( '+8 days midnight', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+9 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-// set booking days in advance
+		// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
@@ -121,7 +121,7 @@ class ViewTest extends CustomPostTypeTest {
 			strtotime( '+12 days midnight', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+13 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-// set booking days in advance
+		// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
@@ -129,9 +129,9 @@ class ViewTest extends CustomPostTypeTest {
 			strtotime( '+14 days midnight', strtotime( self::CURRENT_DATE ) ),
 			strtotime( '+15 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-// set booking days in advance
+		// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
-// this timeframe should not be in shortcode data, because it's out of 30 days advanced booking range
+		// this timeframe should not be in shortcode data, because it's out of 30 days advanced booking range
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,

--- a/tests/php/View/ViewTest.php
+++ b/tests/php/View/ViewTest.php
@@ -89,62 +89,54 @@ class ViewTest extends CustomPostTypeTest {
 		parent::setUp();
 		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
 
-		$now       = time();
-		$this->now = $now;
-
 		$this->item     = new Item( $this->itemId );
 		$this->location = new Location( $this->locationId );
-
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+5 days midnight', $now ),
-			strtotime( '+6 days midnight', $now ),
+			strtotime( '+5 days midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+6 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-		// set booking days in advance
+// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
-
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+2 days midnight', $now ),
-			strtotime( '+3 days midnight', $now ),
-		);// set booking days in advance
-		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
-
-		$timeframeId = $this->createTimeframe(
-			$this->locationId,
-			$this->itemId,
-			strtotime( '+8 days midnight', $now ),
-			strtotime( '+9 days midnight', $now ),
+			strtotime( '+2 days midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+3 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-		// set booking days in advance
+// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
-
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+12 days midnight', $now ),
-			strtotime( '+13 days midnight', $now ),
+			strtotime( '+8 days midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+9 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-		// set booking days in advance
+// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
-
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+14 days midnight', $now ),
-			strtotime( '+15 days midnight', $now ),
+			strtotime( '+12 days midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+13 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
-		// set booking days in advance
+// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
-
-		// this timeframe should not be in shortcode data, because it's out of 30 days advanced booking range
 		$timeframeId = $this->createTimeframe(
 			$this->locationId,
 			$this->itemId,
-			strtotime( '+32 days midnight', $now ),
-			strtotime( '+33 days midnight', $now ),
+			strtotime( '+14 days midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+15 days midnight', strtotime( self::CURRENT_DATE ) ),
+		);
+// set booking days in advance
+		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
+// this timeframe should not be in shortcode data, because it's out of 30 days advanced booking range
+		$timeframeId = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '+32 days midnight', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+33 days midnight', strtotime( self::CURRENT_DATE ) ),
 		);
 		// set booking days in advance
 		update_post_meta( $timeframeId, \CommonsBooking\Model\Timeframe::META_TIMEFRAME_ADVANCE_BOOKING_DAYS, self::bookingDaysInAdvance );
@@ -152,5 +144,6 @@ class ViewTest extends CustomPostTypeTest {
 
 	protected function tearDown(): void {
 		parent::tearDown();
+		ClockMock::reset();
 	}
 }

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -110,6 +110,9 @@ abstract class CustomPostTypeTest extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		Plugin::clearCache();
+		wp_cache_flush();
+
 		$this->dateFormatted = date( 'Y-m-d', strtotime( self::CURRENT_DATE ) );
 
 		$this->setUpBookingCodesTable();
@@ -142,6 +145,8 @@ abstract class CustomPostTypeTest extends BaseTestCase {
 
 		ClockMock::reset();
 		$this->tearDownAllPosts();
+		Plugin::clearCache();
+		wp_cache_flush();
 		$this->tearDownBookingCodesTable();
 
 		wp_logout();


### PR DESCRIPTION
fixes that tests would fail on the 2nd of June every year
- **freeze time in View\CalendarTest.php to fix flakiness**
- **flush cache and simplify renderTable test**
