### PR TITLE
prevent setting of unconfirmed status on confirmed bookings

### DIFF
--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -291,6 +291,13 @@ class Booking extends Timeframe {
 			throw new BookingDeniedException( __( 'There is already a booking in this time-range. This notice may also appear if there is an unconfirmed booking in the requested period. Unconfirmed bookings are deleted after about 10 minutes. Please try again in a few minutes.', 'commonsbooking' ) );
 		}
 
+		// The initial calendar flow always submits post_status=unconfirmed without a post_ID.
+		// If an exact-slot booking already exists for the current user, redirect to that booking
+		// instead of downgrading it back to unconfirmed via the update path below.
+		if ( $booking && $post_status === 'unconfirmed' && $post_ID === null ) {
+			return $booking->ID;
+		}
+
 		$existingBookings =
 			\CommonsBooking\Repository\Booking::getExistingBookings(
 				$itemId,

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -298,6 +298,12 @@ class Booking extends Timeframe {
 			return $booking->ID;
 		}
 
+		// Frontend requests should never reopen an existing booking as unconfirmed by ID.
+		// Treat this as an invalid request instead of mutating the current booking state.
+		if ( $post_status === 'unconfirmed' && $post_ID !== null ) {
+			throw new BookingDeniedException( __( 'Invalid booking request. Please try again from the calendar.', 'commonsbooking' ) );
+		}
+
 		$existingBookings =
 			\CommonsBooking\Repository\Booking::getExistingBookings(
 				$itemId,

--- a/tests/php/Wordpress/CustomPostType/BookingTest.php
+++ b/tests/php/Wordpress/CustomPostType/BookingTest.php
@@ -50,7 +50,7 @@ class BookingTest extends CustomPostTypeTest {
 		$this->assertFalse( $bookingModel->isConfirmed() );
 
 		// Case 2: We now confirm the booking. The booking should be confirmed
-		$newBookingId       = Booking::handleBookingRequest(
+		$confirmedBookingId = Booking::handleBookingRequest(
 			$this->itemId,
 			$this->locationId,
 			'confirmed',
@@ -61,10 +61,10 @@ class BookingTest extends CustomPostTypeTest {
 			$postName,
 			null
 		);
-		$this->bookingIds[] = $newBookingId;
+		$this->bookingIds[] = $confirmedBookingId;
 
 		// the id should be the same
-		$this->assertEquals( $bookingId, $newBookingId );
+		$this->assertEquals( $bookingId, $confirmedBookingId );
 		// we create a new model, just to be sure
 		$bookingModel = new \CommonsBooking\Model\Booking( $bookingId );
 		$this->assertTrue( $bookingModel->isConfirmed() );
@@ -163,7 +163,7 @@ class BookingTest extends CustomPostTypeTest {
 		$this->assertFalse( $bookingModel->isConfirmed() );
 
 		// The overbooked days are not present anymore when confirming the booking cause they are only calculated on the Litepicker screen
-		$newBookingId       = Booking::handleBookingRequest(
+		$confirmedBookingId = Booking::handleBookingRequest(
 			$this->itemId,
 			$this->locationId,
 			'confirmed',
@@ -174,10 +174,10 @@ class BookingTest extends CustomPostTypeTest {
 			$postName,
 			null
 		);
-		$this->bookingIds[] = $newBookingId;
+		$this->bookingIds[] = $confirmedBookingId;
 
 		// the id should be the same
-		$this->assertEquals( $bookingId, $newBookingId );
+		$this->assertEquals( $bookingId, $confirmedBookingId );
 		// we create a new model, just to be sure
 		$bookingModel = new \CommonsBooking\Model\Booking( $bookingId );
 		$this->assertTrue( $bookingModel->isConfirmed() );
@@ -345,6 +345,65 @@ class BookingTest extends CustomPostTypeTest {
 			$postName,
 			'6'
 		);
+	}
+
+	/**
+	 * Regression test for #2217
+	 * When a booking is confirmed and another booking is created in the exact same timeframe afterwards,
+	 * the previously confirmed booking was set to unconfirmed again. This test is in place to ensure that
+	 * this does not happen again.
+	 *
+	 * @return void
+	 */
+	public function testHandleBookingRequest_noRecreation() {
+		$date = new \DateTime( self::CURRENT_DATE );
+		$date->modify( '-1 day' );
+		ClockMock::freeze( $date );
+		// create regular booking through unconfirmed -> confirmed route
+		$bookingId          = Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'unconfirmed',
+			null,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			null,
+			null
+		);
+		$this->bookingIds[] = $bookingId;
+
+		$bookingModel       = new \CommonsBooking\Model\Booking( $bookingId );
+		$postName           = $bookingModel->post_name;
+		$confirmedBookingId = Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'confirmed',
+			$bookingId,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			$postName,
+			null
+		);
+		$this->bookingIds[] = $confirmedBookingId;
+
+		// attempt to recreate the booking, should keep status as "confirmed" because it was not explicitly cancelled
+		$bookingId          = Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'unconfirmed',
+			null,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			null,
+			null
+		);
+		$this->bookingIds[] = $bookingId;
+
+		$bookingModel = new \CommonsBooking\Model\Booking( $bookingId );
+		$this->assertTrue( $bookingModel->isConfirmed() );
 	}
 
 	/**


### PR DESCRIPTION
Add logic to handle unconfirmed booking requests and redirect to existing booking.
It solves the bug filed in #2217 