### PR TITLE
Fix/2245 API-Titel mit HTML-Entities korrekt dekodieren

### DIFF
--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -179,6 +179,21 @@ class BaseRoute extends WP_REST_Controller {
 	}
 
 	/**
+	 * Decodes HTML entities in a post title for API output.
+	 *
+	 * WordPress stores post titles with encoded entities (e.g. "A&amp;B").
+	 * Since the API returns plain text values that consumers render as text,
+	 * we decode them so they receive "A&B" instead of "A&amp;B".
+	 *
+	 * @param string $title
+	 *
+	 * @return string
+	 */
+	public function decodeTitle( string $title ): string {
+		return html_entity_decode( $title, ENT_QUOTES, 'UTF-8' );
+	}
+
+	/**
 	 * Returns true if current request is allowed.
 	 *
 	 * @return bool

--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -189,8 +189,8 @@ class BaseRoute extends WP_REST_Controller {
 	 *
 	 * @return string
 	 */
-	public function decodeTitle( string $title ): string {
-		return html_entity_decode( $title, ENT_QUOTES, 'UTF-8' );
+	protected function decodeApiTitle( string $title ): string {
+		return html_entity_decode( $title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8' );
 	}
 
 	/**

--- a/src/API/GBFS/StationInformation.php
+++ b/src/API/GBFS/StationInformation.php
@@ -38,7 +38,7 @@ class StationInformation extends BaseRoute {
 		$preparedItem->station_id       = strval( $item->ID );
 		$preparedItem->name             = [
 			(object) [
-				'text' => $this->decodeTitle( $item->post_title ),
+				'text' => $this->decodeApiTitle( $item->post_title ),
 				'language' => get_bloginfo( 'language' ),
 			],
 		];

--- a/src/API/GBFS/StationInformation.php
+++ b/src/API/GBFS/StationInformation.php
@@ -38,7 +38,7 @@ class StationInformation extends BaseRoute {
 		$preparedItem->station_id       = strval( $item->ID );
 		$preparedItem->name             = [
 			(object) [
-				'text' => $item->post_title,
+				'text' => $this->decodeTitle( $item->post_title ),
 				'language' => get_bloginfo( 'language' ),
 			],
 		];

--- a/src/API/ItemsRoute.php
+++ b/src/API/ItemsRoute.php
@@ -126,7 +126,7 @@ class ItemsRoute extends BaseRoute {
 	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem              = new stdClass();
 		$preparedItem->id          = $item->ID . '';
-		$preparedItem->name        = $this->decodeTitle( $item->post_title );
+		$preparedItem->name        = $this->decodeApiTitle( $item->post_title );
 		$preparedItem->url         = get_permalink( $item->ID );
 		$preparedItem->description = $this->escapeJsonString( $item->post_content );
 		$preparedItem->ownerId     = '';  // not implemented, but currently required by schema

--- a/src/API/ItemsRoute.php
+++ b/src/API/ItemsRoute.php
@@ -126,7 +126,7 @@ class ItemsRoute extends BaseRoute {
 	public function prepare_item_for_response( $item, $request ): WP_REST_Response {
 		$preparedItem              = new stdClass();
 		$preparedItem->id          = $item->ID . '';
-		$preparedItem->name        = $item->post_title;
+		$preparedItem->name        = $this->decodeTitle( $item->post_title );
 		$preparedItem->url         = get_permalink( $item->ID );
 		$preparedItem->description = $this->escapeJsonString( $item->post_content );
 		$preparedItem->ownerId     = '';  // not implemented, but currently required by schema

--- a/src/API/LocationsRoute.php
+++ b/src/API/LocationsRoute.php
@@ -103,7 +103,7 @@ class LocationsRoute extends BaseRoute {
 		$preparedItem->properties = new stdClass();
 
 		$preparedItem->properties->id                 = $item->ID . '';
-		$preparedItem->properties->name               = $item->post_title;
+		$preparedItem->properties->name               = $this->decodeTitle( $item->post_title );
 		$preparedItem->properties->description        = $this->escapeJsonString( $item->post_content );
 		$preparedItem->properties->url                = get_permalink( $item->ID );
 		$preparedItem->properties->address            = $item->formattedAddressOneLine();

--- a/src/API/LocationsRoute.php
+++ b/src/API/LocationsRoute.php
@@ -103,7 +103,7 @@ class LocationsRoute extends BaseRoute {
 		$preparedItem->properties = new stdClass();
 
 		$preparedItem->properties->id                 = $item->ID . '';
-		$preparedItem->properties->name               = $this->decodeTitle( $item->post_title );
+		$preparedItem->properties->name               = $this->decodeApiTitle( $item->post_title );
 		$preparedItem->properties->description        = $this->escapeJsonString( $item->post_content );
 		$preparedItem->properties->url                = get_permalink( $item->ID );
 		$preparedItem->properties->address            = $item->formattedAddressOneLine();

--- a/tests/php/API/GBFS/StationInformationRouteTest.php
+++ b/tests/php/API/GBFS/StationInformationRouteTest.php
@@ -33,6 +33,29 @@ class StationInformationRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->assertEquals( 8.123, $station->lon );
 	}
 
+	public function testTitleHtmlEntitiesAreDecoded() {
+		update_post_meta( $this->locationId, 'geo_latitude', '50.123' );
+		update_post_meta( $this->locationId, 'geo_longitude', '8.123' );
+
+		wp_update_post(
+			[
+				'ID'         => $this->locationId,
+				'post_title' => 'Station &amp; Hof',
+			]
+		);
+
+		// Sanity check: WordPress stores the title with the encoded entity.
+		$this->assertStringContainsString( '&amp;', get_post( $this->locationId )->post_title );
+
+		$request  = new WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$station = $response->get_data()->data->stations[0];
+		$this->assertEquals( 'Station & Hof', $station->name[0]->text );
+	}
+
 	// no gps data and no address defined, skip location
 	public function testStationInformation_geocodingNonExistent() {
 		delete_post_meta( $this->locationId, 'geo_latitude' );

--- a/tests/php/API/ItemsRouteTest.php
+++ b/tests/php/API/ItemsRouteTest.php
@@ -82,6 +82,21 @@ class ItemsRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->assertEquals( (string) $this->itemId, $data->items[0]->id );
 	}
 
+	public function testTitleHtmlEntitiesAreDecoded() {
+		$entityItemId = $this->createItem( 'Bohrmaschine &amp; Akkuschrauber', 'publish' );
+
+		// Sanity check: WordPress stores the title with the encoded entity.
+		$this->assertStringContainsString( '&amp;', get_post( $entityItemId )->post_title );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT . '/' . $entityItemId );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$item = $response->get_data()->items[0];
+		$this->assertEquals( 'Bohrmaschine & Akkuschrauber', $item->name );
+	}
+
 	public function testExcludedIfBoxChecked() {
 		update_post_meta( $this->itemId, COMMONSBOOKING_METABOX_PREFIX . 'api_exclude', 'on' );
 		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT . '/' . $this->itemId );

--- a/tests/php/API/ItemsRouteTest.php
+++ b/tests/php/API/ItemsRouteTest.php
@@ -83,7 +83,7 @@ class ItemsRouteTest extends CB_REST_Route_UnitTestCase {
 	}
 
 	public function testTitleHtmlEntitiesAreDecoded() {
-		$entityItemId = $this->createItem( 'Bohrmaschine &amp; Akkuschrauber', 'publish' );
+		$entityItemId = $this->createItem( 'Bohrmaschine &amp; Akkuschrauber &apos;Pro&apos;', 'publish' );
 
 		// Sanity check: WordPress stores the title with the encoded entity.
 		$this->assertStringContainsString( '&amp;', get_post( $entityItemId )->post_title );
@@ -94,7 +94,7 @@ class ItemsRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 
 		$item = $response->get_data()->items[0];
-		$this->assertEquals( 'Bohrmaschine & Akkuschrauber', $item->name );
+		$this->assertEquals( 'Bohrmaschine & Akkuschrauber \'Pro\'', $item->name );
 	}
 
 	public function testExcludedIfBoxChecked() {

--- a/tests/php/API/LocationsRouteTest.php
+++ b/tests/php/API/LocationsRouteTest.php
@@ -58,6 +58,21 @@ class LocationsRouteTest extends CB_REST_Route_UnitTestCase {
 		$this->assertContains( (string) $secondId, $ids );
 	}
 
+	public function testTitleHtmlEntitiesAreDecoded() {
+		$entityLocationId = $this->createLocation( 'Markt &amp; Mehr', 'publish', [] );
+
+		// Sanity check: WordPress stores the title with the encoded entity.
+		$this->assertStringContainsString( '&amp;', get_post( $entityLocationId )->post_title );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT . '/' . $entityLocationId );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$feature = $response->get_data()->locations->features[0];
+		$this->assertEquals( 'Markt & Mehr', $feature->properties->name );
+	}
+
 	public function testEmptyLocations() {
 		// Remove the location created in setUp
 		wp_delete_post( array_pop( $this->locationIds ), true );


### PR DESCRIPTION
Closes #2245

Dieser PR behebt, dass Titel mit HTML-Entities wie `&amp;` in den API-Antworten unverändert ausgegeben wurden. Die betroffenen Endpunkte decodieren Post-Titel nun vor der Ausgabe, sodass z. B. `Hammer &amp; Nagel` als `Hammer & Nagel` zurückgegeben wird.