### PR TITLE
fix #2251 pass apikey by header

### DIFF
--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -189,8 +189,12 @@ class BaseRoute extends WP_REST_Controller {
 		$apiKey                 = array_key_exists( self::API_KEY_PARAM, $_REQUEST ) ? sanitize_text_field( $_REQUEST[ self::API_KEY_PARAM ] ) : false;
 		if ( ! $apiKey ) {
 			// get apikey from headers (#2251)
-			$allHeaders = array_change_key_case( getallheaders(), CASE_LOWER );
-			$apiKey     = array_key_exists( self::API_KEY_PARAM, $allHeaders ) ? sanitize_text_field( $allHeaders[ self::API_KEY_PARAM ] ) : false;
+			if ( function_exists( 'getallheaders' ) ) {
+				$allHeaders = array_change_key_case( getallheaders(), CASE_LOWER );
+				$apiKey     = array_key_exists( self::API_KEY_PARAM, $allHeaders ) ? sanitize_text_field( $allHeaders[ self::API_KEY_PARAM ] ) : false;
+			} else {
+				$apiKey = array_key_exists( 'HTTP_' . strtoupper( self::API_KEY_PARAM ), $_SERVER ) ? sanitize_text_field( $_SERVER[ 'HTTP_' . strtoupper( self::API_KEY_PARAM ) ] ) : false;
+			}
 		}
 		$apiShare = ApiShares::getByKey( $apiKey );
 

--- a/src/API/BaseRoute.php
+++ b/src/API/BaseRoute.php
@@ -187,7 +187,12 @@ class BaseRoute extends WP_REST_Controller {
 		$isApiActive            = Settings::getOption( 'commonsbooking_options_api', 'api-activated' );
 		$anonymousAccessAllowed = Settings::getOption( 'commonsbooking_options_api', 'apikey_not_required' );
 		$apiKey                 = array_key_exists( self::API_KEY_PARAM, $_REQUEST ) ? sanitize_text_field( $_REQUEST[ self::API_KEY_PARAM ] ) : false;
-		$apiShare               = ApiShares::getByKey( $apiKey );
+		if ( ! $apiKey ) {
+			// get apikey from headers (#2251)
+			$allHeaders = array_change_key_case( getallheaders(), CASE_LOWER );
+			$apiKey     = array_key_exists( self::API_KEY_PARAM, $allHeaders ) ? sanitize_text_field( $allHeaders[ self::API_KEY_PARAM ] ) : false;
+		}
+		$apiShare = ApiShares::getByKey( $apiKey );
 
 		// Only if api is active we return something
 		if ( $isApiActive ) {

--- a/src/API/GBFS/Discovery.php
+++ b/src/API/GBFS/Discovery.php
@@ -70,10 +70,6 @@ class Discovery extends \CommonsBooking\API\BaseRoute {
 		$feed       = new stdClass();
 		$feed->name = $name;
 		$feed->url  = get_rest_url() . 'commonsbooking/v1/' . $name . '.json';
-		$apiKey     = array_key_exists( self::API_KEY_PARAM, $_REQUEST ) ? sanitize_text_field( $_REQUEST[ self::API_KEY_PARAM ] ) : false;
-		if ( $apiKey ) {
-			$feed->url .= '?apikey=' . $apiKey;
-		}
 		return $feed;
 	}
 }


### PR DESCRIPTION
- **Revert "fix #2204: api routes could not be validated when api key was present"**
- **#2251 support passing apikey by header**

closes #2251
