### PR TITLE
Rendering der Einschränkungsliste optimieren

### DIFF
--- a/src/Wordpress/CustomPostType/Restriction.php
+++ b/src/Wordpress/CustomPostType/Restriction.php
@@ -159,31 +159,13 @@ class Restriction extends CustomPostType {
 					echo '-';
 					break;
 				case \CommonsBooking\Model\Restriction::META_TYPE:
-					$output = '-';
-
-					foreach ( $this->getCustomFields() as $customField ) {
-						if ( $customField['id'] == \CommonsBooking\Model\Restriction::META_TYPE ) {
-							foreach ( $customField['options'] as $key => $label ) {
-								if ( $value == $key ) {
-									$output = $label;
-								}
-							}
-						}
-					}
+					$types  = self::getTypes();
+					$output = $types[ $value ] ?? '-';
 					echo commonsbooking_sanitizeHTML( $output );
 					break;
 				case \CommonsBooking\Model\Restriction::META_STATE:
-					$output = '-';
-
-					foreach ( $this->getCustomFields() as $customField ) {
-						if ( $customField['id'] == \CommonsBooking\Model\Restriction::META_STATE ) {
-							foreach ( $customField['options'] as $key => $label ) {
-								if ( $value == $key ) {
-									$output = $label;
-								}
-							}
-						}
-					}
+					$states = self::getStates();
+					$output = $states[ $value ] ?? '-';
 					echo commonsbooking_sanitizeHTML( $output );
 					break;
 				case \CommonsBooking\Model\Restriction::META_START:

--- a/tests/php/Wordpress/CustomPostType/RestrictionListColumnsTest.php
+++ b/tests/php/Wordpress/CustomPostType/RestrictionListColumnsTest.php
@@ -18,6 +18,8 @@ class RestrictionListColumnsTest extends CustomPostTypeTest {
 		);
 		$postType      = new class() extends RestrictionPostType {
 			protected function getCustomFields(): array {
+				// Regression guard: getCustomFields() loads dynamic location and item options,
+				// so calling it for static type/state columns degrades list rendering performance.
 				throw new \RuntimeException( 'List columns must not build assignment options.' );
 			}
 		};

--- a/tests/php/Wordpress/CustomPostType/RestrictionListColumnsTest.php
+++ b/tests/php/Wordpress/CustomPostType/RestrictionListColumnsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CommonsBooking\Tests\Wordpress\CustomPostType;
+
+use CommonsBooking\Model\Restriction;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use CommonsBooking\Wordpress\CustomPostType\Restriction as RestrictionPostType;
+
+class RestrictionListColumnsTest extends CustomPostTypeTest {
+
+	public function testListColumnsDoNotBuildAssignmentOptions(): void {
+		$restrictionId = $this->createRestriction(
+			Restriction::TYPE_HINT,
+			$this->locationId,
+			$this->itemId,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) )
+		);
+		$postType      = new class() extends RestrictionPostType {
+			protected function getCustomFields(): array {
+				throw new \RuntimeException( 'List columns must not build assignment options.' );
+			}
+		};
+
+		ob_start();
+		$postType->setCustomColumnsData( Restriction::META_TYPE, $restrictionId );
+		$typeOutput = ob_get_clean();
+
+		ob_start();
+		$postType->setCustomColumnsData( Restriction::META_STATE, $restrictionId );
+		$stateOutput = ob_get_clean();
+
+		$this->assertSame( RestrictionPostType::getTypes()[ Restriction::TYPE_HINT ], $typeOutput );
+		$this->assertSame( RestrictionPostType::getStates()[ Restriction::STATE_ACTIVE ], $stateOutput );
+	}
+}


### PR DESCRIPTION
## Problem

Beim Rendern der Typ- und Statusspalten in der Einschränkungsliste wird derzeit für jede Tabellenzelle `getCustomFields()` aufgerufen.

Diese Methode erstellt nicht nur die benötigten Beschriftungen, sondern baut auch die vollständigen Auswahloptionen für alle administrierten Artikel und Standorte auf. Bei vielen Einschränkungen und Zuordnungen führt das zu unnötig wiederholten Repository- und Cache-Abfragen.

## Änderung

- Typbezeichnungen werden direkt über `Restriction::getTypes()` gelesen.
- Statusbezeichnungen werden direkt über `Restriction::getStates()` gelesen.
- Die Ausgabe der Listenspalten bleibt unverändert.
- Ein Regressionstest stellt sicher, dass für diese Spalten keine Zuordnungsoptionen mehr aufgebaut werden.

## Tests

Der neue Regressionstest und die vollständige PHPUnit-Suite laufen erfolgreich durch.
