### PR TITLE
Autocomplete für den Benutzerfilter in der Buchungsliste

### DIFF
--- a/assets/admin/js/src/booking-user-filter.js
+++ b/assets/admin/js/src/booking-user-filter.js
@@ -1,0 +1,105 @@
+(function ($) {
+    'use strict';
+
+    $(function () {
+        const config = window.cbBookingUserFilter;
+        if (!config) {
+            return;
+        }
+
+        const input = $('#' + config.inputId);
+        const userIdInput = $('#' + config.userIdInputId);
+        if (
+            input.length !== 1 ||
+            userIdInput.length !== 1 ||
+            typeof input.autocomplete !== 'function'
+        ) {
+            return;
+        }
+
+        input.on('input', function () {
+            userIdInput.val('');
+        });
+
+        input.autocomplete({
+            delay: 250,
+            minLength: config.minimumLength,
+            source(request, respond) {
+                $.ajax({
+                    url: config.ajaxUrl,
+                    method: 'POST',
+                    dataType: 'json',
+                    data: {
+                        action: config.action,
+                        nonce: config.nonce,
+                        term: request.term,
+                    },
+                })
+                    .done(function (response) {
+                        const results =
+                            response && response.success && Array.isArray(response.data)
+                                ? response.data
+                                : [];
+                        respond(results);
+                    })
+                    .fail(function () {
+                        respond([]);
+                    });
+            },
+            focus(event, ui) {
+                input.attr('aria-activedescendant', 'cb-booking-user-' + ui.item.id);
+                event.preventDefault();
+            },
+            select(event, ui) {
+                input.val(ui.item.value);
+                userIdInput.val(ui.item.id);
+                return false;
+            },
+            open() {
+                input.attr('aria-expanded', 'true');
+            },
+            close() {
+                input.attr('aria-expanded', 'false');
+            },
+            messages: {
+                noResults: config.noResults,
+                results(count) {
+                    return count === 1
+                        ? config.oneResult
+                        : config.multipleResults.replace('%d', count);
+                },
+            },
+        });
+
+        const autocomplete = input.autocomplete('instance');
+        if (!autocomplete) {
+            return;
+        }
+
+        const widget = input.autocomplete('widget');
+        input
+            .attr({
+                role: 'combobox',
+                'aria-autocomplete': 'list',
+                'aria-expanded': 'false',
+                'aria-controls': widget.attr('id'),
+            })
+            .on('keydown', function () {
+                input.removeAttr('aria-activedescendant');
+            });
+
+        widget
+            .addClass('cb-booking-user-autocomplete')
+            .attr('role', 'listbox')
+            .removeAttr('tabindex');
+
+        autocomplete._renderItem = function (list, item) {
+            return $('<li>', {
+                id: 'cb-booking-user-' + item.id,
+                role: 'option',
+            })
+                .append($('<div>').text(item.label))
+                .appendTo(list);
+        };
+    });
+})(jQuery);

--- a/assets/admin/sass/admin.scss
+++ b/assets/admin/sass/admin.scss
@@ -22,6 +22,9 @@
 /* Booking form  */
 @use './partials/form-booking';
 
+/* Booking list user filter */
+@use './partials/booking-user-filter';
+
 /* Map creation */
 @use './partials/form-map';
 

--- a/assets/admin/sass/partials/_booking-user-filter.scss
+++ b/assets/admin/sass/partials/_booking-user-filter.scss
@@ -1,0 +1,11 @@
+.cb-booking-user-filter {
+    min-width: 240px;
+}
+
+.ui-autocomplete.cb-booking-user-autocomplete {
+    max-width: 520px;
+    max-height: 320px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    z-index: 100000;
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -19,6 +19,145 @@ class UserRepository {
 	}
 
 	/**
+	 * Searches users by ID, login, email, display name, first name and last name.
+	 *
+	 * @param string $term  Search term.
+	 * @param int    $limit Maximum number of users to return.
+	 * @return WP_User[]
+	 */
+	public static function search( string $term, int $limit = 20 ): array {
+		$term = trim( $term );
+		if ( $term === '' || $limit < 1 ) {
+			return [];
+		}
+
+		$usersById   = [];
+		$exactUserId = 0;
+
+		if ( ctype_digit( $term ) ) {
+			$user = get_user_by( 'ID', (int) $term );
+			if ( $user instanceof WP_User ) {
+				$exactUserId            = (int) $user->ID;
+				$usersById[ $user->ID ] = $user;
+			}
+		}
+
+		$coreUsers = get_users(
+			[
+				'number'         => $limit,
+				'orderby'        => 'user_login',
+				'order'          => 'ASC',
+				'search'         => '*' . $term . '*',
+				'search_columns' => [ 'user_login', 'user_email', 'display_name' ],
+			]
+		);
+		foreach ( $coreUsers as $user ) {
+			if ( $user instanceof WP_User ) {
+				$usersById[ $user->ID ] = $user;
+			}
+		}
+
+		$metaQuery = new \WP_User_Query(
+			[
+				'number'     => $limit,
+				'orderby'    => 'user_login',
+				'order'      => 'ASC',
+				'meta_query' => [
+					'relation' => 'OR',
+					[
+						'key'     => 'first_name',
+						'value'   => $term,
+						'compare' => 'LIKE',
+					],
+					[
+						'key'     => 'last_name',
+						'value'   => $term,
+						'compare' => 'LIKE',
+					],
+				],
+			]
+		);
+		foreach ( $metaQuery->get_results() as $user ) {
+			if ( $user instanceof WP_User ) {
+				$usersById[ $user->ID ] = $user;
+			}
+		}
+
+		$users = array_values( $usersById );
+		usort(
+			$users,
+			static function ( WP_User $left, WP_User $right ) use ( $exactUserId ): int {
+				if ( $exactUserId > 0 ) {
+					if ( (int) $left->ID === $exactUserId ) {
+						return -1;
+					}
+					if ( (int) $right->ID === $exactUserId ) {
+						return 1;
+					}
+				}
+
+				return strcasecmp( $left->user_login, $right->user_login );
+			}
+		);
+
+		return array_slice( $users, 0, $limit );
+	}
+
+	/**
+	 * Returns all user IDs matching the supplied search term.
+	 *
+	 * @param string $term Search term.
+	 * @return int[]
+	 */
+	public static function searchIds( string $term ): array {
+		$term = trim( $term );
+		if ( $term === '' ) {
+			return [];
+		}
+
+		$userIds = [];
+		if ( ctype_digit( $term ) ) {
+			$user = get_user_by( 'ID', (int) $term );
+			if ( $user instanceof WP_User ) {
+				$userIds[] = (int) $user->ID;
+			}
+		}
+
+		$userIds = array_merge(
+			$userIds,
+			get_users(
+				[
+					'fields'         => 'ID',
+					'search'         => '*' . $term . '*',
+					'search_columns' => [ 'user_login', 'user_email', 'display_name' ],
+				]
+			)
+		);
+
+		$metaQuery = new \WP_User_Query(
+			[
+				'fields'     => 'ID',
+				'meta_query' => [
+					'relation' => 'OR',
+					[
+						'key'     => 'first_name',
+						'value'   => $term,
+						'compare' => 'LIKE',
+					],
+					[
+						'key'     => 'last_name',
+						'value'   => $term,
+						'compare' => 'LIKE',
+					],
+				],
+			]
+		);
+		$userIds   = array_merge( $userIds, $metaQuery->get_results() );
+
+		return array_values( array_unique( array_map( 'intval', $userIds ) ) );
+	}
+
+	/**
 	 * Returns all valid roles that are considered by CommonsBooking as "Manager" roles.
 	 *
 	 * @return string[]

--- a/src/View/Admin/BookingUserFilter.php
+++ b/src/View/Admin/BookingUserFilter.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace CommonsBooking\View\Admin;
+
+use CommonsBooking\Repository\UserRepository;
+use CommonsBooking\Wordpress\CustomPostType\Booking;
+use WP_Query;
+use WP_User;
+
+/**
+ * User filter for the booking list in the WordPress backend.
+ */
+class BookingUserFilter {
+
+	public const AJAX_ACTION = 'cb_booking_user_search';
+
+	private const FILTER_PARAM         = 'admin_filter_user';
+	private const FILTER_USER_ID_PARAM = 'admin_filter_user_id';
+	private const AUTOCOMPLETE_LIMIT   = 20;
+
+	/**
+	 * Registers the hooks required by the booking user filter.
+	 */
+	public static function initHooks(): void {
+		add_action( 'restrict_manage_posts', array( self::class, 'renderFilter' ) );
+		add_action( 'pre_get_posts', array( self::class, 'applyFilter' ) );
+		add_action( 'admin_enqueue_scripts', array( self::class, 'enqueueAssets' ) );
+		add_action( 'wp_ajax_' . self::AJAX_ACTION, array( self::class, 'ajaxSearchUsers' ) );
+	}
+
+	/**
+	 * Renders the autocomplete input above the booking list.
+	 */
+	public static function renderFilter(): void {
+		if ( ! self::isBookingListScreen() ) {
+			return;
+		}
+
+		$value  = self::getRequestValue( self::FILTER_PARAM );
+		$userId = self::getRequestUserId();
+		$label  = esc_html__( 'Filter bookings by user or email', 'commonsbooking' );
+		?>
+		<label class="screen-reader-text" for="<?php echo esc_attr( self::FILTER_PARAM ); ?>">
+			<?php echo esc_html( $label ); ?>
+		</label>
+		<input
+			type="hidden"
+			name="<?php echo esc_attr( self::FILTER_USER_ID_PARAM ); ?>"
+			id="<?php echo esc_attr( self::FILTER_USER_ID_PARAM ); ?>"
+			value="<?php echo esc_attr( (string) $userId ); ?>"
+		/>
+		<input
+			type="search"
+			name="<?php echo esc_attr( self::FILTER_PARAM ); ?>"
+			id="<?php echo esc_attr( self::FILTER_PARAM ); ?>"
+			value="<?php echo esc_attr( $value ); ?>"
+			placeholder="<?php echo esc_attr__( 'User or email', 'commonsbooking' ); ?>"
+			class="cb-booking-user-filter"
+			autocomplete="off"
+			aria-label="<?php echo esc_attr( $label ); ?>"
+		/>
+		<?php
+	}
+
+	/**
+	 * Adds autocomplete configuration on the booking list screen.
+	 *
+	 * @param string $hookSuffix Current admin page hook.
+	 */
+	public static function enqueueAssets( string $hookSuffix ): void {
+		if ( $hookSuffix !== 'edit.php' || ! self::isBookingListScreen() ) {
+			return;
+		}
+
+		wp_enqueue_script( 'jquery-ui-autocomplete' );
+		wp_localize_script(
+			'cb-scripts-admin',
+			'cbBookingUserFilter',
+			[
+				'action'            => self::AJAX_ACTION,
+				'ajaxUrl'           => admin_url( 'admin-ajax.php' ),
+				'nonce'             => wp_create_nonce( self::AJAX_ACTION ),
+				'inputId'           => self::FILTER_PARAM,
+				'userIdInputId'     => self::FILTER_USER_ID_PARAM,
+				'minimumLength'     => 2,
+				'noResults'         => esc_html__( 'No matching users found.', 'commonsbooking' ),
+				'oneResult'         => esc_html__( 'One user found. Use the arrow keys to navigate.', 'commonsbooking' ),
+				/* translators: %d: Number of matching users. */
+				'multipleResults'   => esc_html__( '%d users found. Use the arrow keys to navigate.', 'commonsbooking' ),
+			]
+		);
+	}
+
+	/**
+	 * Returns matching users for the autocomplete field.
+	 */
+	public static function ajaxSearchUsers(): void {
+		check_ajax_referer( self::AJAX_ACTION, 'nonce' );
+
+		if ( ! self::currentUserCanAccessBookingList() ) {
+			wp_send_json_error(
+				[ 'message' => esc_html__( 'You are not allowed to filter bookings.', 'commonsbooking' ) ],
+				403
+			);
+		}
+
+		$term = isset( $_POST['term'] )
+			? trim( sanitize_text_field( wp_unslash( $_POST['term'] ) ) )
+			: '';
+		if ( strlen( $term ) < 2 ) {
+			wp_send_json_success( [] );
+		}
+
+		$results = array_map(
+			array( self::class, 'formatUserResult' ),
+			UserRepository::search( $term, self::AUTOCOMPLETE_LIMIT )
+		);
+		wp_send_json_success( $results );
+	}
+
+	/**
+	 * Applies the selected user or a free-text user search to the booking list.
+	 *
+	 * @param WP_Query $query Current admin list query.
+	 */
+	public static function applyFilter( WP_Query $query ): void {
+		if ( ! self::isBookingListQuery( $query ) ) {
+			return;
+		}
+
+		$filterValue = self::getRequestValue( self::FILTER_PARAM );
+		$searchValue = self::getRequestValue( 's' );
+		$term        = $filterValue !== '' ? $filterValue : $searchValue;
+		if ( $term === '' ) {
+			return;
+		}
+
+		$selectedUserId = $filterValue !== '' ? self::getRequestUserId() : 0;
+		$userIds        = $selectedUserId > 0 && get_user_by( 'ID', $selectedUserId )
+			? [ $selectedUserId ]
+			: UserRepository::searchIds( $term );
+
+		if ( $userIds === [] ) {
+			if ( $filterValue !== '' ) {
+				$query->set( 'author__in', [ 0 ] );
+				$query->set( 's', '' );
+			}
+			return;
+		}
+
+		$query->set( 'author__in', $userIds );
+		$query->set( 's', '' );
+	}
+
+	/**
+	 * Formats a user for jQuery UI autocomplete.
+	 *
+	 * @param WP_User $user User object.
+	 * @return array{id: int, label: string, value: string}
+	 */
+	public static function formatUserResult( WP_User $user ): array {
+		$details = array_values(
+			array_filter(
+				[
+					$user->display_name !== $user->user_login ? $user->display_name : '',
+					$user->user_email,
+				]
+			)
+		);
+		$label   = $user->user_login;
+		if ( $details !== [] ) {
+			$label .= ' — ' . implode( ' · ', $details );
+		}
+
+		return [
+			'id'    => (int) $user->ID,
+			'label' => $label,
+			'value' => $user->user_login,
+		];
+	}
+
+	private static function isBookingListScreen(): bool {
+		if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return $screen && $screen->id === 'edit-' . Booking::getPostType();
+	}
+
+	private static function isBookingListQuery( WP_Query $query ): bool {
+		global $pagenow;
+
+		if ( ! is_admin() || ! $query->is_main_query() || $pagenow !== 'edit.php' ) {
+			return false;
+		}
+
+		$postType = $query->get( 'post_type' );
+		if ( is_array( $postType ) ) {
+			$postType = reset( $postType );
+		}
+		if ( ! $postType ) {
+			$postType = self::getRequestValue( 'post_type' );
+		}
+
+		return $postType === Booking::getPostType();
+	}
+
+	private static function getRequestValue( string $key ): string {
+		if ( ! isset( $_GET[ $key ] ) ) {
+			return '';
+		}
+
+		return trim( sanitize_text_field( wp_unslash( $_GET[ $key ] ) ) );
+	}
+
+	private static function getRequestUserId(): int {
+		if ( ! isset( $_GET[ self::FILTER_USER_ID_PARAM ] ) ) {
+			return 0;
+		}
+
+		return absint( wp_unslash( $_GET[ self::FILTER_USER_ID_PARAM ] ) );
+	}
+
+	private static function currentUserCanAccessBookingList(): bool {
+		$postType = get_post_type_object( Booking::getPostType() );
+		return $postType && current_user_can( $postType->cap->edit_posts );
+	}
+}

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -8,6 +8,7 @@ use CommonsBooking\Helper\Helper;
 use CommonsBooking\Messages\BookingMessage;
 use CommonsBooking\Service\BookingRuleApplied;
 use CommonsBooking\Service\iCalendar;
+use CommonsBooking\View\Admin\BookingUserFilter;
 use Exception;
 use function wp_verify_nonce;
 
@@ -63,6 +64,7 @@ class Booking extends Timeframe {
 		add_action( 'restrict_manage_posts', array( static::class, 'addAdminDateFilter' ) );
 		add_action( 'restrict_manage_posts', array( static::class, 'addAdminStatusFilter' ) );
 		add_action( 'pre_get_posts', array( static::class, 'filterAdminList' ) );
+		BookingUserFilter::initHooks();
 
 		// show admin notice
 		add_action( 'admin_notices', array( $this, 'displayBookingsAdminListNotice' ) );

--- a/tests/php/Repository/UserRepositoryTest.php
+++ b/tests/php/Repository/UserRepositoryTest.php
@@ -8,6 +8,7 @@ use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 
 class UserRepositoryTest extends CustomPostTypeTest {
 
+	private array $searchUserIds = [];
 
 	public function testGetSelectableCBManagers() {
 		$cbAdmins = UserRepository::getSelectableCBManagers();
@@ -69,6 +70,60 @@ class UserRepositoryTest extends CustomPostTypeTest {
 		$user->remove_role( Plugin::$CB_MANAGER_ID );
 	}
 
+	public function testSearchUsersByCoreFieldsAndNameMetadata() {
+		$this->createSearchUser( 'anna', 'anna@example.test', 'Anna Meyer', 'Anna', 'Meyer' );
+		$this->createSearchUser( 'annabelle', 'user8@example.test', 'Annabelle König', 'Annabelle', 'König' );
+		$this->createSearchUser( 'bert', 'ann-team@example.test', 'Bert Beispiel', 'Bert', 'Beispiel' );
+		$this->createSearchUser( 'zeta', 'zeta@example.test', 'Zeta User', 'Annika', 'Schmidt' );
+
+		$users = UserRepository::search( 'ann', 20 );
+		$this->assertSame(
+			[ 'anna', 'annabelle', 'bert', 'zeta' ],
+			array_map(
+				static function ( \WP_User $user ): string {
+					return $user->user_login;
+				},
+				$users
+			)
+		);
+
+		$this->assertSame(
+			[ 'anna', 'annabelle' ],
+			array_map(
+				static function ( \WP_User $user ): string {
+					return $user->user_login;
+				},
+				UserRepository::search( 'ann', 2 )
+			)
+		);
+
+		$this->assertSame(
+			[ $this->searchUserIds[3] ],
+			UserRepository::searchIds( 'Schmidt' )
+		);
+	}
+
+	private function createSearchUser(
+		string $login,
+		string $email,
+		string $displayName,
+		string $firstName,
+		string $lastName
+	): void {
+		$userId = wp_insert_user(
+			[
+				'user_login'   => $login,
+				'user_pass'    => 'test-password',
+				'user_email'   => $email,
+				'display_name' => $displayName,
+				'first_name'   => $firstName,
+				'last_name'    => $lastName,
+			]
+		);
+		$this->assertIsInt( $userId );
+		$this->searchUserIds[] = $userId;
+	}
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->createCBManager();
@@ -77,6 +132,9 @@ class UserRepositoryTest extends CustomPostTypeTest {
 	}
 
 	protected function tearDown(): void {
+		foreach ( $this->searchUserIds as $userId ) {
+			wp_delete_user( $userId );
+		}
 		parent::tearDown();
 	}
 }

--- a/tests/php/View/BookingUserFilterTest.php
+++ b/tests/php/View/BookingUserFilterTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace CommonsBooking\Tests\View;
+
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use CommonsBooking\View\Admin\BookingUserFilter;
+use CommonsBooking\Wordpress\CustomPostType\Booking;
+
+class BookingUserFilterTest extends CustomPostTypeTest {
+
+	private int $filterUserId;
+
+	public function testSelectedAutocompleteUserFiltersByExactId() {
+		$this->prepareBookingListRequest(
+			[
+				'admin_filter_user'    => 'filter-user',
+				'admin_filter_user_id' => (string) $this->filterUserId,
+			]
+		);
+
+		$query = $this->createMainBookingQuery();
+		BookingUserFilter::applyFilter( $query );
+
+		$this->assertSame( [ $this->filterUserId ], $query->get( 'author__in' ) );
+	}
+
+	public function testFreeTextFilterSearchesLastName() {
+		$this->prepareBookingListRequest( [ 'admin_filter_user' => 'Example-Surname' ] );
+
+		$query = $this->createMainBookingQuery();
+		BookingUserFilter::applyFilter( $query );
+
+		$this->assertSame( [ $this->filterUserId ], $query->get( 'author__in' ) );
+	}
+
+	public function testDefaultSearchFallsBackToBookingSearchWithoutUserMatch() {
+		$this->prepareBookingListRequest( [ 's' => 'does-not-match-a-user' ] );
+
+		$query = $this->createMainBookingQuery();
+		$query->set( 's', 'does-not-match-a-user' );
+		BookingUserFilter::applyFilter( $query );
+
+		$this->assertEmpty( $query->get( 'author__in' ) );
+		$this->assertSame( 'does-not-match-a-user', $query->get( 's' ) );
+	}
+
+	public function testAutocompleteResultContainsLoginNameAndEmail() {
+		$user = get_user_by( 'ID', $this->filterUserId );
+
+		$this->assertSame(
+			[
+				'id'    => $this->filterUserId,
+				'label' => 'filter-user — Filter User · filter-user@example.test',
+				'value' => 'filter-user',
+			],
+			BookingUserFilter::formatUserResult( $user )
+		);
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->filterUserId = wp_insert_user(
+			[
+				'user_login'   => 'filter-user',
+				'user_pass'    => 'test-password',
+				'user_email'   => 'filter-user@example.test',
+				'display_name' => 'Filter User',
+				'first_name'   => 'Filter',
+				'last_name'    => 'Example-Surname',
+			]
+		);
+		set_current_screen( 'edit-' . Booking::getPostType() );
+	}
+
+	protected function tearDown(): void {
+		wp_delete_user( $this->filterUserId );
+		set_current_screen( 'front' );
+		parent::tearDown();
+	}
+
+	private function prepareBookingListRequest( array $parameters ): void {
+		global $pagenow;
+
+		$pagenow = 'edit.php';
+		$_GET    = array_merge(
+			[
+				'post_type' => Booking::getPostType(),
+			],
+			$parameters
+		);
+	}
+
+	private function createMainBookingQuery(): \WP_Query {
+		global $wp_the_query;
+
+		$query = new \WP_Query();
+		$query->set( 'post_type', Booking::getPostType() );
+		$wp_the_query = $query;
+
+		return $query;
+	}
+}

--- a/tests/php/View/BookingUserFilter_AJAX_Test.php
+++ b/tests/php/View/BookingUserFilter_AJAX_Test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CommonsBooking\Tests\View;
+
+use CommonsBooking\Plugin;
+use CommonsBooking\Tests\Wordpress\CustomPostType_AJAX_Test;
+use CommonsBooking\View\Admin\BookingUserFilter;
+
+/**
+ * @group ajax
+ */
+class BookingUserFilter_AJAX_Test extends CustomPostType_AJAX_Test {
+
+	protected $hooks = [
+		BookingUserFilter::AJAX_ACTION => [ BookingUserFilter::class, 'ajaxSearchUsers' ],
+	];
+
+	private int $adminUserId;
+	private int $searchUserId;
+
+	public function testSearchUsersReturnsAutocompleteResults() {
+		$_POST['term']  = 'autocomplete';
+		$_POST['nonce'] = wp_create_nonce( BookingUserFilter::AJAX_ACTION );
+
+		$response = $this->runHook();
+
+		$this->assertTrue( $response->success );
+		$this->assertCount( 1, $response->data );
+		$this->assertSame( $this->searchUserId, $response->data[0]->id );
+		$this->assertSame( 'autocomplete-user', $response->data[0]->value );
+	}
+
+	public function testSearchUsersRequiresPermission() {
+		wp_set_current_user( 0 );
+		$_POST['term']  = 'autocomplete';
+		$_POST['nonce'] = wp_create_nonce( BookingUserFilter::AJAX_ACTION );
+
+		$response = $this->runHook();
+
+		$this->assertFalse( $response->success );
+	}
+
+	public function testSearchUsersRequiresTwoCharacters() {
+		$_POST['term']  = 'a';
+		$_POST['nonce'] = wp_create_nonce( BookingUserFilter::AJAX_ACTION );
+
+		$response = $this->runHook();
+
+		$this->assertTrue( $response->success );
+		$this->assertSame( [], $response->data );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		Plugin::addCPTRoleCaps();
+		$this->adminUserId  = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->searchUserId = self::factory()->user->create(
+			[
+				'user_login'   => 'autocomplete-user',
+				'user_email'   => 'autocomplete@example.test',
+				'display_name' => 'Autocomplete User',
+			]
+		);
+		wp_set_current_user( $this->adminUserId );
+	}
+}


### PR DESCRIPTION
## Worum geht es?

In der Buchungsliste kann jetzt direkt nach Nutzer:innen gesucht werden, ohne Benutzername oder E-Mail vollständig kennen zu müssen.

## Änderung

- Vorschläge ab zwei Zeichen
- Suche nach Benutzername, E-Mail, Anzeigename, Vor- und Nachname sowie Benutzer-ID
- Auswahl filtert eindeutig über die Benutzer-ID
- Freie Texteingabe bleibt möglich
- Maximal 20 Treffer pro Anfrage

Der AJAX-Endpunkt prüft Nonce und Berechtigung. Die Benutzerliste wird nicht vollständig in die Seite geladen.

## Tests

Die Nutzersuche, Filterung und der AJAX-Endpunkt sind mit PHPUnit-Tests abgedeckt.
