### PR TITLE
Settings: deprovision custom image sizes for next release

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -211,6 +211,38 @@ function commonsbooking_sanitizeHTML( $string ): string {
 }
 
 /**
+ * Renders a deprecation notice for CMB2 fields.
+ *
+ * @param string $issue_url GitHub issue URL.
+ * @param string $version   Version in which the field will be removed.
+ */
+function commonsbooking_deprecated_field_notice( $issue_url = '', $version = '' ) {
+
+	$message = __( 'Deprecated.', 'commonsbooking' );
+
+	if ( $version ) {
+		$message .= ' ' . sprintf(
+			/* translators: %s: version number */
+			__( 'Will be removed in version %s.', 'commonsbooking' ),
+			esc_html( $version )
+		);
+	}
+
+	$message = '<div class="notice notice-warning inline" style="margin:10px 0;padding:8px 12px;">'
+		. '<strong>' . esc_html( $message ) . '</strong>';
+
+	if ( $issue_url ) {
+		$message .= ' <a href="' . esc_url( $issue_url ) . '" target="_blank" rel="noopener noreferrer">'
+			. esc_html__( 'See GitHub issue', 'commonsbooking' )
+			. '</a>';
+	}
+
+	$message .= '</div>';
+
+	return $message;
+}
+
+/**
  * Create filter hooks for cmb2 fields
  *
  * @param array $field_args  Array of field args.

--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -491,6 +491,7 @@ your booking of {{item:post_title}} at {{location:post_title}} {{booking:formatt
 				'title'  => commonsbooking_sanitizeHTML( __( 'Image formatting', 'commonsbooking' ) ),
 				'id'     => 'imageoptions',
 				'desc'   => '',
+				'before_row' => commonsbooking_deprecated_field_notice( 'https://github.com/wielebenwir/commonsbooking/issues/1066', '2.12.0' ),
 				'fields' => array(
 					array(
 						'name'    => commonsbooking_sanitizeHTML( __( 'Listing image small width (in px)', 'commonsbooking' ) ),

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,10 @@ CommonsBooking was developed for the ["Commons Cargobike" movement](http://commo
 
 ## Changelog
 
+### 2.11.1
+
+DEPRECATION: Custom listing image sizes cb_listing_small and cb_listing_medium and Settings image_listing_* will be removed in next 2.12.0 release.
+
 ### 2.11 (13.07.2026)
 ADDED: GBFS routes vehicle_availability.json, vehicle_types.json, vehicle_status.json
 ADDED: Multi-select now also available for timeframes of type repair

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1011,7 +1011,13 @@ class Plugin {
 	}
 
 
+	/**
+	 * @deprecated 2.11.1 Custom listing image sizes will be removed probably in 2.12.0
+	 *             @see https://github.com/commonsbooking/commonsbooking/issues/1066
+	 */
 	function AddImageSizes() {
+
+		_deprecated_function( __METHOD__, '2.11.1' );
 
 		$crop = Settings::getOption( 'commonsbooking_options_templates', 'image_listing_crop' ) == 'on' ? true : false;
 

--- a/src/Wordpress/Options/OptionsTab.php
+++ b/src/Wordpress/Options/OptionsTab.php
@@ -100,11 +100,13 @@ class OptionsTab {
 	public static function prependTitle( array $metabox_group ): array {
 
 		if ( isset( $metabox_group['title'] ) or isset( $metabox_group['desc'] ) ) {
-			$title = $metabox_group['title'] ?? '';
-			$desc  = $metabox_group['desc'] ?? '';
+			$title      = $metabox_group['title'] ?? '';
+			$desc       = $metabox_group['desc'] ?? '';
+			$before_row = $metabox_group['before_row'] ?? '';
 
 			$header_html = sprintf(
-				'<h4>%s</h4>%s',
+				'%s<h4>%s</h4>%s',
+				$before_row,
 				$title,
 				$desc
 			);


### PR DESCRIPTION
supersedes https://github.com/wielebenwir/commonsbooking/pull/1988

Deprecates image settings from next release 2.11.1.
Target release for removing the settings is 2.12.0.

Adds deprecation warning inside of `AddImageSizes`, so warning gets rendered in logging and in admin backend.

Adds deprecation warning as `before_row` in cmb2 settings of `imageoptions`.

I did not add a deprecation warning inside of `Settings::getOption`, this could be a improvement for future deprecations, since somebody could dependent on the settings in their code.