### PR TITLE
bump strauss from 0.27.3 to 0.28.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
       "@prefix-namespaces"
     ],
     "prefix-namespaces": [
-      "sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.27.3/strauss.phar'",
+      "sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.28.1/strauss.phar'",
       "@php bin/strauss.phar --info",
       "@composer dump-autoload"
     ]


### PR DESCRIPTION
will remove deprecation warnings
