### PR TITLE
apis: show cpt meta field for api_exclude only when api is enabled

### DIFF
--- a/docs/de/documentation/api/commonsbooking-api.md
+++ b/docs/de/documentation/api/commonsbooking-api.md
@@ -10,7 +10,7 @@ Die API basiert auf der in [WordPress implementierten REST-API](https://develope
 
 ::: tip Aktivierung der API
 Die API ist standardmäßig deaktiviert und es gibt keine Verbindungen zu externen Services oder Plattformen.
-Die API aktivierst du über die Einstellungen (s.u.) und die Checkbox "API aktivieren".
+Die API aktivierst du über die Einstellungen (s.u.).
 :::
 
 
@@ -18,7 +18,7 @@ Die API aktivierst du über die Einstellungen (s.u.) und die Checkbox "API aktiv
 
 Die API erreichst du über _Einstellungen_ -> _CommonsBooking_ -> Tab: _API / Export_.
 
-  * API aktivieren: Aktiviert generell den API-Zugriff
+  * API aktivieren: Aktiviert generell den API-Zugriff (auch für die [GBFS API](gbfs)).
   * API Zugang ohne API-Schlüssel: Wenn diese Option aktiviert ist, kann auf die API auch ohne einen individuellen API-Key zugegriffen werden. Diese Einstellung ist sinnvoll, wenn ihre eure Daten mit mehreren Plattformen teilen möchtet.
   * API-Freigaben: Die Schnittstelle kann für verschiedene Endpunkte bzw. anfragende Seiten freigegeben werden. Um die Zugriffsrechte entsprechend zu steuern könnt ihr auch mehrere unterschiedliche Freigaben anlegen.
 
@@ -31,7 +31,9 @@ Die API erreichst du über _Einstellungen_ -> _CommonsBooking_ -> Tab: _API / Ex
 
 ## Artikel von der API ausschliessen
 
-Wenn Artikel nicht in der API erscheinen sollen, müssen diese explizit ausgeschlossen werden. Diese Einstellungen kann auf Artikelebene vorgenommen werden, wenn dort der entsprechende Haken gesetzt ist, tauchen diese Artikel nicht in den API Routen auf.
+Wenn Artikel nicht in der API erscheinen sollen, müssen diese explizit ausgeschlossen werden.
+Diese Einstellungen kann auf Artikelebene vorgenommen werden, wenn die API aktiviert ist.
+Wenn in der Artikel-Ansicht der Haken im entsprechenden Meta-Feld gesetzt ist, tauchen diese Artikel nicht in den API Routen auf.
 
 ##  Spezifikation der API-Routen
 

--- a/docs/de/documentation/api/gbfs.md
+++ b/docs/de/documentation/api/gbfs.md
@@ -1,5 +1,11 @@
 # GBFS
 
+::: tip Aktivierung der API
+Die API ist standardmäßig deaktiviert und es gibt keine Verbindungen zu externen Services oder Plattformen.
+Die API aktivierst du über die Einstellungen (s.u.).
+:::
+
+
 Diese Schnittstelle stellt Daten der [Standorte](../first-steps/create-location),
 [Artikel](../first-steps/create-item) und deren Verfügbarkeit über die
 [Zeitrahmen](../first-steps/booking-timeframes-manage) in einem stadardisierten Schema bereit.
@@ -12,6 +18,18 @@ Aktuell wird die Version 3.1-RC3 der _General Bikeshare Feed Specification_ ([GB
 * vehicle_availability.json
 * vehicle_types.json
 * gbfs.json (Discovery)
+
+##  Einstellungen
+
+Die API erreichst du über _Einstellungen_ -> _CommonsBooking_ -> Tab: _API / Export_.
+
+* API aktivieren: Aktiviert generell den API-Zugriff (auch für die [Commons API](commonsbooking-api)).
+
+### Artikel von der API ausschliessen
+
+Wenn Artikel nicht in der API erscheinen sollen, müssen diese explizit ausgeschlossen werden.
+Diese Einstellungen kann auf Artikelebene vorgenommen werden, wenn die API aktiviert ist.
+Wenn in der Artikel-Ansicht der Haken im entsprechenden Meta-Feld gesetzt ist, tauchen diese Artikel nicht in den API Routen auf.
 
 ## Zu vehicle_types.json
 

--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1426,13 +1426,19 @@ This item has been booked by {{user:first_name}} {{user:last_name}} ( {{user:use
 			'api' => array(
 				'title'  => esc_html__( 'Configure API Access', 'commonsbooking' ),
 				'id'     => 'api_access',
+				'desc'   => sprintf(
+					__( 'If not stated otherwise, this refers to the Commons API. See %1$sCommons API documentation here%2$s.', 'commonsbooking' ),
+					'<a target="_blank" href="' . esc_url( 'https://commonsbooking.org/documentation/api/commonsbooking-api' ) . '">',
+					'</a>'
+				),
 				'fields' => [
 					array(
 						'name' => esc_html__( 'Activate API', 'commonsbooking' ),
 						'desc' => commonsbooking_sanitizeHTML(
 							sprintf(
-								__( 'If selected, the API is enabled. See more information in the documentation: %1$sAPI documentation%2$s', 'commonsbooking' ),
-								'<a target="_blank" href="' . esc_url( 'https://commonsbooking.org/documentation/api/commonsbooking-api/' ) . '">',
+								// translators: %1$s, %2$s = doc link
+								__( 'If selected, the API is enabled. This option also enables the GBFS API of the plugin, see %1$sGBFS documentation here%2$s.', 'commonsbooking' ),
+								'<a target="_blank" href="' . esc_url( 'https://commonsbooking.org/documentation/api/gbfs' ) . '">',
 								'</a>'
 							)
 						),

--- a/src/Wordpress/CustomPostType/Item.php
+++ b/src/Wordpress/CustomPostType/Item.php
@@ -285,9 +285,10 @@ class Item extends CustomPostType {
 			$cmb->add_field(
 				array(
 					'name' => esc_html__( 'Exclude from API', 'commonsbooking' ),
-					'desc' => esc_html__( 'When this box is checked, the item will not appear in any of the API shares.', 'commonsbooking' ),
+					'desc' => esc_html__( 'When this box is checked, the item will not appear in any of the Commons API shares or the GBFS API.', 'commonsbooking' ),
 					'id' => COMMONSBOOKING_METABOX_PREFIX . 'api_exclude',
 					'type' => 'checkbox',
+					'show_on_cb' => fn() => Settings::getOption( 'commonsbooking_options_api', 'api-activated' ) === 'on',
 				)
 			);
 		}


### PR DESCRIPTION
This shows the "Exclude in API" meta field of the custom post type "Item" only then when "commonsbooking_options_api", "api-activated" is enabled.

Also updated the docs to reflect that change.

The Text in the item meta field says "[...], the item will not appear in any of the API shares.", but a quick search for "api_exclude" (which is the meta field id", shows that it is also used to exclude in the GBFS BaseRoute.php, so in `BaseRoute::getItemData` this meta field value is respected too! I've added the documentation paragraph for that in the GBFS chapter and also the respective translation comments for that in admin settings too.

TODO: Update english docs after review.

EDIT1: Add todo for english docs.

EDIT2: add note about gbfs api

EDIT3: adds note about new commit.
