### PR TITLE
fix #2295 creating duplicate canceled bookings

### DIFF
--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -346,6 +346,10 @@ class Booking extends Timeframe {
 
 		// New booking
 		if ( empty( $booking ) ) {
+			if ( $post_status !== 'unconfirmed' ) {
+				// New bookings always have to be unconfirmed
+				throw new BookingDeniedException( __( 'Invalid booking request. Please try again.', 'commonsbooking' ) );
+			}
 			$postarr['post_name']  = Helper::generateRandomString();
 			$postarr['meta_input'] = array(
 				\CommonsBooking\Model\Timeframe::META_LOCATION_ID   => $locationId,

--- a/tests/php/Model/BookingTest.php
+++ b/tests/php/Model/BookingTest.php
@@ -534,7 +534,7 @@ class BookingTest extends CustomPostTypeTest {
 			$this->assertStringContainsString( 'There are one ore more overlapping bookings within the chosen timerange', $e->getMessage() );
 			// also test, that correct notice for Bookings is shown
 			$this->assertStringContainsString( 'Booking is saved as draft.', $e->getMessage() );
-			$this->assertStringContainsString( $validBooking->getFormattedEditLink(), $e->getMessage() );
+			$this->assertStringContainsString( get_edit_post_link( $validBooking->ID ), $e->getMessage() );
 		}
 
 		$startDateBeforeEnd = new Booking(
@@ -745,10 +745,10 @@ class BookingTest extends CustomPostTypeTest {
 		$endingTime->setTime( 17, 59, 59 );
 		// we need to create this booking in the "frontend" way in order to save the correct grid sizes for the generation
 		// pickup and returntimes
-		$testBookingSpanningOverTwoSlotsID     = \CommonsBooking\Wordpress\CustomPostType\Booking::handleBookingRequest(
+		$testBookingSpanningOverTwoSlotsID = \CommonsBooking\Wordpress\CustomPostType\Booking::handleBookingRequest(
 			$separateItem,
 			$separateLocation,
-			'confirmed',
+			'unconfirmed',
 			null,
 			null,
 			$beginningTime->getTimestamp(),
@@ -756,6 +756,19 @@ class BookingTest extends CustomPostTypeTest {
 			null,
 			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
 		);
+
+		\CommonsBooking\Wordpress\CustomPostType\Booking::handleBookingRequest(
+			$separateItem,
+			$separateLocation,
+			'confirmed',
+			$testBookingSpanningOverTwoSlotsID,
+			null,
+			$beginningTime->getTimestamp(),
+			$endingTime->getTimestamp(),
+			get_post( $testBookingSpanningOverTwoSlotsID )->post_name,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
+		);
+
 		$this->testBookingSpanningOverTwoSlots = new Booking(
 			$testBookingSpanningOverTwoSlotsID
 		);

--- a/tests/php/Repository/BookingTest.php
+++ b/tests/php/Repository/BookingTest.php
@@ -349,6 +349,7 @@ class BookingTest extends CustomPostTypeTest {
 	 */
 	public function testGetForCurrentUser() {
 		// Without current user we shouldn't get bookings.
+		wp_logout();
 		$bookings = Booking::getForCurrentUser();
 		$this->assertCount( 0, $bookings );
 

--- a/tests/php/Wordpress/CustomPostType/BookingTest.php
+++ b/tests/php/Wordpress/CustomPostType/BookingTest.php
@@ -186,6 +186,66 @@ class BookingTest extends CustomPostTypeTest {
 		$this->assertEquals( 2, $bookingModel->getOverbookedDays() );
 	}
 
+	/**
+	 * Makes sure, that bookings that are created always have to be unconfirmed first and then confirmed.
+	 * It should not be possible to create a confirmed or canceled booking immediately.
+	 * Fixes #2295, where impatient users who would click cancel multiple times would create new bookings.
+	 * @return void
+	 */
+	public function testHandleBookingRequest_noDirectCreation() {
+		$this->expectException( \CommonsBooking\Exception\BookingDeniedException::class );
+		$bookingId          = Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'unconfirmed',
+			null,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			null,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
+		);
+		$this->bookingIds[] = $bookingId;
+		Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'confirmed',
+			$bookingId,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			get_post( $bookingId )->post_name,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
+		);
+
+		// cancel once
+		Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'canceled',
+			$bookingId,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			get_post( $bookingId )->post_name,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
+		);
+
+		$this->expectException( \CommonsBooking\Exception\BookingDeniedException::class );
+		// cancel twice, should throw exception
+		Booking::handleBookingRequest(
+			$this->itemId,
+			$this->locationId,
+			'canceled',
+			$bookingId,
+			null,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+			get_post( $bookingId )->post_name,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID
+		);
+	}
+
 	public function testBookingWithoutLoc() {
 		// Case 1: We try to create a booking without a defined location
 		$this->expectException( \CommonsBooking\Exception\BookingDeniedException::class );

--- a/tests/php/Wordpress/CustomPostTypeTest.php
+++ b/tests/php/Wordpress/CustomPostTypeTest.php
@@ -122,6 +122,9 @@ abstract class CustomPostTypeTest extends BaseTestCase {
 
 		// Create Item
 		$this->itemId = self::createItem( 'TestItem' );
+
+		// login as test user
+		wp_set_current_user( self::USER_ID );
 	}
 
 	protected function setUpBookingCodesTable() {


### PR DESCRIPTION
Manually tested, that regression tests work.
closes #2295
