### PR TITLE
bump strauss from 0.28.1 to 0.29.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
       "@prefix-namespaces"
     ],
     "prefix-namespaces": [
-      "sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.28.1/strauss.phar'",
+      "sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.29.1/strauss.phar'",
       "@php bin/strauss.phar --info",
       "@composer dump-autoload"
     ]


### PR DESCRIPTION
@BrianHenryIE maybe you wanna take a look at this, building the plugin still works in CI with 0.28.1 but fails in 0.29.1