### PR TITLE
fix #2320 metadata export not working

### DIFF
--- a/assets/admin/js/src/export.js
+++ b/assets/admin/js/src/export.js
@@ -2,9 +2,9 @@
     'use strict';
     $(function () {
         let typeInput = $('#export-type');
-        let locationFields = $('#location-fields');
-        let itemFields = $('#item-fields');
-        let userFields = $('#user-fields');
+        let locationFields = $('#locationFields');
+        let itemFields = $('#itemFields');
+        let userFields = $('#userFields');
         let exportTimerangeStart = $('#export-timerange-start');
         let exportTimerangeEnd = $('#export-timerange-end');
         let inProgress = $('#timeframe-export-in-progress');

--- a/src/Service/TimeframeExport.php
+++ b/src/Service/TimeframeExport.php
@@ -30,21 +30,21 @@ class TimeframeExport {
 	/**
 	 * The extra meta fields to export for locations.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	private ?array $locationFields = null;
+	private array $locationFields = [];
 	/**
 	 * The extra meta fields to export for items.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	private ?array $itemFields = null;
+	private array $itemFields = [];
 	/**
 	 * The extra meta fields to export for users.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	private ?array $userFields = null;
+	private array $userFields = [];
 	/**
 	 * Export start date in whatever string format the WP field provides
 	 *
@@ -112,9 +112,9 @@ class TimeframeExport {
 	 * @param string      $exportStartDate Start date string of export
 	 * @param string      $exportEndDate End date string of export
 	 *
-	 * @param array|null  $locationFields Metafields of location objects that should be included in the export
-	 * @param array|null  $itemFields Metafields of item objects that should be included in the export
-	 * @param array|null  $userFields Metafields of user objects that should be included in the export
+	 * @param array       $locationFields Metafields of location objects that should be included in the export
+	 * @param array       $itemFields Metafields of item objects that should be included in the export
+	 * @param array       $userFields Metafields of user objects that should be included in the export
 	 * @param int|null    $lastProcessedPage 0 when starting, otherwise the last processed page from previous run
 	 * @param int|null    $totalPosts Set on previous run, total amount of posts in export
 	 * @param string|null $transientName Set on previous run, name of transient where intermediate results are stored
@@ -125,9 +125,9 @@ class TimeframeExport {
 		string $exportType,
 		string $exportStartDate,
 		string $exportEndDate,
-		?array $locationFields = null,
-		?array $itemFields = null,
-		?array $userFields = null,
+		array $locationFields = [],
+		array $itemFields = [],
+		array $userFields = [],
 		?int $lastProcessedPage = null,
 		?int $totalPosts = null,
 		?string $transientName = null
@@ -186,9 +186,9 @@ class TimeframeExport {
 				$postSettings['exportType'],
 				$postSettings['exportStartDate'],
 				$postSettings['exportEndDate'],
-				$postSettings['locationFields'] ? self::convertInputFields( $postSettings['locationFields'] ) : null,
-				$postSettings['itemFields'] ? self::convertInputFields( $postSettings['itemFields'] ) : null,
-				$postSettings['userFields'] ? self::convertInputFields( $postSettings['userFields'] ) : null,
+				$postSettings['locationFields'] ? self::convertInputFields( $postSettings['locationFields'] ) : [],
+				$postSettings['itemFields'] ? self::convertInputFields( $postSettings['itemFields'] ) : [],
+				$postSettings['userFields'] ? self::convertInputFields( $postSettings['userFields'] ) : [],
 				$postSettings['lastProcessedPage'] ?? null,
 				$postSettings['totalPages'] ?? null,
 				$postSettings['transientName'] ?? null
@@ -284,9 +284,9 @@ class TimeframeExport {
 				$type,
 				$start,
 				$end,
-				$configuredLocationFields ? self::convertInputFields( $configuredLocationFields ) : null,
-				$configuredItemFields ? self::convertInputFields( $configuredItemFields ) : null,
-				$configuredUserFields ? self::convertInputFields( $configuredUserFields ) : null,
+				$configuredLocationFields ? self::convertInputFields( $configuredLocationFields ) : [],
+				$configuredItemFields ? self::convertInputFields( $configuredItemFields ) : [],
+				$configuredUserFields ? self::convertInputFields( $configuredUserFields ) : [],
 			);
 			$exportObject->setCron();
 			$exportObject->getExportData();
@@ -309,9 +309,9 @@ class TimeframeExport {
 	 */
 	public function getCSV( ?string $exportPath = null ): string {
 		$inputFields = [
-			'location' => self::getInputFields( 'location-fields' ),
-			'item'     => self::getInputFields( 'item-fields' ),
-			'user'     => self::getInputFields( 'user-fields' ),
+			'location' => $this->locationFields,
+			'item'     => $this->itemFields,
+			'user'     => $this->userFields,
 		];
 
 		if ( ! $this->exportDataComplete ) {
@@ -406,13 +406,17 @@ class TimeframeExport {
 
 	/**
 	 * Gets export fields array from the comma separated string in the settings.
+	 * After first run, this might already be an array. Therefore it has already been sanitized.
 	 *
-	 * @param string|null $inputString
+	 * @param string|array $inputFields
 	 *
 	 * @return string[] returns an empty array when non-string or empty-string input
 	 */
-	private static function convertInputFields( $inputString ): array {
-		return array_filter( explode( ',', sanitize_text_field( $inputString ) ) );
+	private static function convertInputFields( $inputFields ): array {
+		if ( is_array( $inputFields ) ) {
+			return $inputFields;
+		}
+		return array_filter( explode( ',', sanitize_text_field( $inputFields ) ) );
 	}
 
 
@@ -430,21 +434,6 @@ class TimeframeExport {
 
 		// translators: %1$d actual item number, %2$d total item number
 		return sprintf( __( 'Processed %1$d of %2$d bookings', 'commonsbooking' ), $progressBookings, $totalBookings );
-	}
-
-	/**
-	 * Return user defined export fields.
-	 *
-	 * @param $inputName
-	 *
-	 * @return false|string[]
-	 */
-	protected static function getInputFields( $inputName ) {
-		$inputFieldsString =
-			array_key_exists( $inputName, $_REQUEST ) ? sanitize_text_field( $_REQUEST[ $inputName ] ) :
-				Settings::getOption( 'commonsbooking_options_export', '$inputName' );
-
-		return array_filter( explode( ',', $inputFieldsString ) );
 	}
 
 	/**

--- a/src/Service/Upgrade.php
+++ b/src/Service/Upgrade.php
@@ -59,6 +59,9 @@ class Upgrade {
 		'2.10.5' => [
 			[ self::class, 'migrateCacheSettings' ],
 		],
+		'2.11.1' => [
+			[ self::class, 'migrateExportSettings' ],
+		],
 	];
 
 	/**
@@ -586,6 +589,27 @@ class Upgrade {
 				Settings::getOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_path' )
 			);
 			Settings::updateOption( COMMONSBOOKING_PLUGIN_SLUG . '_options_advanced-options', 'cache_adapter', 'filesystem' );
+		}
+	}
+
+	/**
+	 * In order to fix #2320 and unify the input names, the custom metadata
+	 * fields were renamed from hyphenated to camelCase. This moves them.
+	 *
+	 * @return void
+	 */
+	public static function migrateExportSettings(): void {
+		$itemFields     = Settings::getOption( 'commonsbooking_options_export', 'item-fields' );
+		$locationFields = Settings::getOption( 'commonsbooking_options_export', 'location-fields' );
+		$userFields     = Settings::getOption( 'commonsbooking_options_export', 'user-fields' );
+		if ( ! empty( $itemFields ) ) {
+			Settings::updateOption( 'commonsbooking_options_export', 'itemFields', $itemFields );
+		}
+		if ( ! empty( $locationFields ) ) {
+			Settings::updateOption( 'commonsbooking_options_export', 'locationFields', $locationFields );
+		}
+		if ( ! empty( $userFields ) ) {
+			Settings::updateOption( 'commonsbooking_options_export', 'userFields', $userFields );
 		}
 	}
 }

--- a/src/View/TimeframeExport.php
+++ b/src/View/TimeframeExport.php
@@ -11,9 +11,9 @@ namespace CommonsBooking\View;
  */
 class TimeframeExport {
 
-	const LOCATION_FIELD = 'location-fields';
-	const ITEM_FIELD     = 'item-fields';
-	const USER_FIELD     = 'user-fields';
+	const LOCATION_FIELD = 'locationFields';
+	const ITEM_FIELD     = 'itemFields';
+	const USER_FIELD     = 'userFields';
 
 	/**
 	 * @param $field_args

--- a/tests/php/Service/TimeframeExport_AJAX_Test.php
+++ b/tests/php/Service/TimeframeExport_AJAX_Test.php
@@ -8,12 +8,18 @@ use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
 
 class TimeframeExport_AJAX_Test extends CustomPostType_AJAX_Test {
 
-	protected $hooks = [
+	protected $hooks              = [
 		'cb_export_timeframes' => array(
 			\CommonsBooking\Service\TimeframeExport::class,
 			'ajaxExportCsv',
 		),
 	];
+	protected $itemFieldKey       = 'item_meta_test';
+	protected $itemFieldValue     = 'item_meta_test_value';
+	protected $locationFieldKey   = 'location_meta_test';
+	protected $locationFieldValue = 'location_meta_test_value';
+	protected $userFieldKey       = 'user_meta_test';
+	protected $userFieldValue     = 'user_meta_test_value';
 	public function testAjaxExport_empty() {
 		// first case: empty bookings
 		$response = $this->runHook();
@@ -83,10 +89,41 @@ class TimeframeExport_AJAX_Test extends CustomPostType_AJAX_Test {
 				$stdObjects
 			)
 		);
+		// assert, that custom fields are still present
+		foreach ( $stdObjects as $booking ) {
+			$this->assertEquals( $this->itemFieldValue, $booking->{'item: ' . $this->itemFieldKey}, 'item metadata not present for booking with ID ' . $booking->ID );
+			$this->assertEquals( $this->locationFieldValue, $booking->{'location: ' . $this->locationFieldKey}, 'location metadata not present for booking with ID ' . $booking->ID );
+			$this->assertEquals( $this->userFieldValue, $booking->{'user: ' . $this->userFieldKey}, 'user metadata not present for booking with ID ' . $booking->ID );
+		}
+	}
+
+	/**
+	 * regression test for #2320
+	 * @return void
+	 */
+	public function testAjaxExport_withCustomFields() {
+		// create a booking
+		$booking  = $this->createBooking(
+			strtotime( CustomPostTypeTest::CURRENT_DATE ),
+			strtotime( '+1 day', strtotime( CustomPostTypeTest::CURRENT_DATE ) )
+		);
+		$response = $this->runHook();
+		$this->assertTrue( $response->success );
+		$this->assertFalse( $response->error );
+		$this->assertEquals( 'Export finished', $response->message );
+		$stdObjects = TimeframeExportTest::csvStringToStdObjects( $response->csv );
+		$this->assertEquals( 1, count( $stdObjects ) );
+		$exportedBooking = reset( $stdObjects );
+		$this->assertEquals( $this->itemFieldValue, $exportedBooking->{'item: ' . $this->itemFieldKey} );
+		$this->assertEquals( $this->locationFieldValue, $exportedBooking->{'location: ' . $this->locationFieldKey} );
+		$this->assertEquals( $this->userFieldValue, $exportedBooking->{'user: ' . $this->userFieldKey} );
 	}
 
 	public function set_up() {
 		parent::set_up();
+		update_post_meta( $this->itemID, $this->itemFieldKey, $this->itemFieldValue );
+		update_post_meta( $this->locationID, $this->locationFieldKey, $this->locationFieldValue );
+		update_user_meta( $this->userID, $this->userFieldKey, $this->userFieldValue );
 		$currentDateNextMonth = new \DateTime( CustomPostTypeTest::CURRENT_DATE );
 		$currentDateNextMonth->modify( '+2 years' );
 		$currentDateNextMonth = $currentDateNextMonth->format( 'd.m.Y' );
@@ -94,9 +131,9 @@ class TimeframeExport_AJAX_Test extends CustomPostType_AJAX_Test {
 			'exportType'      => 'all',
 			'exportStartDate' => CustomPostTypeTest::CURRENT_DATE,
 			'exportEndDate'   => $currentDateNextMonth,
-			'locationFields'  => '',
-			'itemFields'      => '',
-			'userFields'      => '',
+			'locationFields'  => $this->locationFieldKey,
+			'itemFields'      => $this->itemFieldKey,
+			'userFields'      => $this->userFieldKey,
 		);
 		$progressText         = '0/0 bookings exported';
 		$_POST['data']        = [

--- a/tests/php/Wordpress/CustomPostType_AJAX_Test.php
+++ b/tests/php/Wordpress/CustomPostType_AJAX_Test.php
@@ -36,7 +36,11 @@ abstract class CustomPostType_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	/**
 	 * @int array The IDs of all created timeframes. Append here, if you should create one.
 	 */
-	protected $timeframeIDs   = [];
+	protected $timeframeIDs = [];
+	/**
+	 * @int The ID of the user that the bookings belong to.
+	 */
+	protected $userID;
 	private $previousResponse = '';
 	public function set_up() {
 		parent::set_up();
@@ -58,6 +62,13 @@ abstract class CustomPostType_AJAX_Test extends \WP_Ajax_UnitTestCase {
 				'post_status' => 'publish',
 			]
 		);
+
+		$wp_user = get_user_by( 'email', 'subscriber@ajax.de' );
+		if ( ! $wp_user ) {
+			$this->userID = wp_create_user( 'subscriber', 'subscriber', 'subscriber@ajax.de' );
+		} else {
+			$this->userID = $wp_user->ID;
+		}
 	}
 	public function tear_down() {
 		parent::tear_down();
@@ -117,7 +128,7 @@ abstract class CustomPostType_AJAX_Test extends \WP_Ajax_UnitTestCase {
 				'post_title'  => 'Booking',
 				'post_type'   => \CommonsBooking\Wordpress\CustomPostType\Booking::$postType,
 				'post_status' => 'confirmed',
-				'post_author' => '0',
+				'post_author' => $this->userID,
 				'meta_input'  => [
 					'type' => \CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKING_ID,
 					'location-id' => $this->locationID,


### PR DESCRIPTION
The method TimeframeExport::getInputFields was fundamentally broken. When retrieving the export settings from the $_REQUEST superglobal, it did not check for the array key in the right spot (did not descend down ["data"]["settings"] and retrieving it from the options as a fallback also didn't work because ' instead of " quotations were used with a variable. I reworked the whole thing and just take the data when the TimeframeExport object is constructed. Because after first sanitization the comma seperated string becomes an array, we have to check if it is already an array because after the first pass of handing the object back (when pagination is set) sanitize_text_field would delete the array with the post metadata. 

closes #2320
