### PR TITLE
Improve simultaneous booking rule performance

### DIFF
--- a/src/Service/BookingRule.php
+++ b/src/Service/BookingRule.php
@@ -352,7 +352,17 @@ class BookingRule {
 	 * @throws Exception
 	 */
 	public static function checkSimultaneousBookings( Booking $booking, array $args = [], $appliedTerms = false ): ?array {
-		$userBookings = \CommonsBooking\Repository\Booking::getForUser( $booking->getUserData(), true, time(), [ 'confirmed' ] );
+		$user         = $booking->getUserData();
+		$userBookings = \CommonsBooking\Repository\Booking::getByTimerange(
+			$booking->getStartDate(),
+			$booking->getEndDate(),
+			null,
+			null,
+			[
+				'author' => $user->ID,
+			],
+			[ 'confirmed' ]
+		);
 		$userBookings = Booking::filterTermsApply( $userBookings, $appliedTerms );
 		if ( empty( $userBookings ) ) {
 			return null;


### PR DESCRIPTION
## Summary
- limit simultaneous-booking checks to confirmed bookings overlapping the requested date range
- filter the query by booking author before applying term and overlap checks

## Validation
- `./vendor/bin/phpunit --configuration phpunit.xml.dist tests/php/Service/BookingRuleTest.php`
- `./vendor/bin/phpcbf --parallel=1 src/Service/BookingRule.php`