### PR TITLE
Add fractional booking grids

### DIFF
--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -474,7 +474,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 			// If we have the grid size, we use it to calculate right time end
 			$timeframeGridSize = $this->getMeta( self::START_TIMEFRAME_GRIDSIZE );
 			if ( is_numeric( $timeframeGridSize ) ) {
-				$grid = intval( $timeframeGridSize );
+				$grid = floatval( $timeframeGridSize );
 			}
 		}
 
@@ -510,7 +510,7 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 			// If we have the grid size, we use it to calculate right time start
 			$timeframeGridSize = $this->getMeta( self::END_TIMEFRAME_GRIDSIZE );
 			if ( is_numeric( $timeframeGridSize ) ) {
-				$grid = intval( $timeframeGridSize );
+				$grid = floatval( $timeframeGridSize );
 			}
 		}
 

--- a/src/Model/Day.php
+++ b/src/Model/Day.php
@@ -17,6 +17,10 @@ use WP_Post;
  */
 class Day {
 
+	private const MINUTES_PER_DAY = 1440;
+
+	private const MINUTES_PER_CELL = 15;
+
 	/**
 	 * @var string
 	 */
@@ -190,28 +194,27 @@ class Day {
 	/**
 	 * Returns the slot number for specific timeframe and time.
 	 *
-	 * @param DateTime $date
-	 * @param int      $grid
+	 * @param DateTime $date        Date to map.
+	 * @param int      $grid Minutes per availability cell.
 	 *
-	 * @return float|int
+	 * @return int
 	 */
-	protected function getSlotByTime( DateTime $date, int $grid ) {
-		$hourSlots   = $date->format( 'H' ) / $grid;
-		$minuteSlots = $date->format( 'i' ) / 60 / $grid;
+	protected function getSlotByTime( DateTime $date, int $grid ): int {
+		$minutesSinceMidnight = (int) $date->format( 'G' ) * 60 + (int) $date->format( 'i' );
 
-		return $hourSlots + $minuteSlots;
+		return intdiv( $minutesSinceMidnight, $grid );
 	}
 
 	/**
 	 * Returns start-slot id.
 	 *
-	 * @param int                             $grid
-	 * @param \CommonsBooking\Model\Timeframe $timeframe
+	 * @param int                             $grid      Minutes per availability cell.
+	 * @param \CommonsBooking\Model\Timeframe $timeframe Timeframe to map.
 	 *
-	 * @return float|int
+	 * @return int
 	 * @throws Exception
 	 */
-	protected function getStartSlot( int $grid, \CommonsBooking\Model\Timeframe $timeframe ) {
+	protected function getStartSlot( int $grid, \CommonsBooking\Model\Timeframe $timeframe ): int {
 		// Timeframe
 		$fullDay   = $timeframe->isFullDay();
 		$startTime = $timeframe->getStartTimeDateTime();
@@ -240,12 +243,12 @@ class Day {
 	/**
 	 * Returns start slot for restriction.
 	 *
-	 * @param int         $grid
-	 * @param Restriction $restriction
-
-	 * @return float|int
+	 * @param int         $grid        Minutes per availability cell.
+	 * @param Restriction $restriction Timeframe restriction to map.
+	 *
+	 * @return int
 	 */
-	protected function getRestrictionStartSlot( int $grid, Restriction $restriction ) {
+	protected function getRestrictionStartSlot( int $grid, Restriction $restriction ): int {
 
 		$startTime = $restriction->getStartTimeDateTime();
 		$startSlot = $this->getSlotByTime( $startTime, $grid );
@@ -264,14 +267,14 @@ class Day {
 	/**
 	 * Returns end-slot id.
 	 *
-	 * @param array                           $slots
-	 * @param int                             $grid
-	 * @param \CommonsBooking\Model\Timeframe $timeframe
+	 * @param array                           $slots     Availability cells to map.
+	 * @param int                             $grid      Minutes per availability cell.
+	 * @param \CommonsBooking\Model\Timeframe $timeframe Timeframe to map.
 	 *
-	 * @return float|int
+	 * @return int
 	 * @throws Exception
 	 */
-	protected function getEndSlot( array $slots, int $grid, \CommonsBooking\Model\Timeframe $timeframe ) {
+	protected function getEndSlot( array $slots, int $grid, \CommonsBooking\Model\Timeframe $timeframe ): int {
 		// Timeframe
 		$endTime = $timeframe->getEndTimeDateTime( $this->getDateObject()->getTimestamp() );
 		$endDate = $timeframe->getEndDateDateTime();
@@ -282,6 +285,10 @@ class Day {
 		// If timeframe isn't configured as full day
 		if ( ! $timeframe->isFullDay() ) {
 			$endSlot = $this->getSlotByTime( $endTime, $grid );
+		}
+
+		if ( $endDate && $endDate->getTimestamp() === $this->getEndTimestamp() ) {
+			$endSlot = count( $slots );
 		}
 
 		// If we have a overbooked day, we need to mark all slots as booked
@@ -298,19 +305,23 @@ class Day {
 	/**
 	 * Returns end slot for restriction.
 	 *
-	 * @param array       $slots
-	 * @param int         $grid
-	 * @param Restriction $restriction
+	 * @param array       $slots       Availability cells to map.
+	 * @param int         $grid        Minutes per availability cell.
+	 * @param Restriction $restriction Timeframe restriction to map.
 	 *
-	 * @return float|int
+	 * @return int
 	 * @throws Exception
 	 */
-	protected function getRestrictionEndSlot( array $slots, int $grid, Restriction $restriction ) {
+	protected function getRestrictionEndSlot( array $slots, int $grid, Restriction $restriction ): int {
 		$endTime = $restriction->getEndTimeDateTime( $this->getDateObject()->getTimestamp() );
 		$endDate = $restriction->getEndDateDateTime();
 
 		// Slots
 		$endSlot = $this->getSlotByTime( $endTime, $grid );
+
+		if ( $endDate->getTimestamp() === $this->getEndTimestamp() ) {
+			$endSlot = count( $slots );
+		}
 
 		// Check if timeframe ends after the current day
 		if ( strtotime( $this->getFormattedDate( 'd.m.Y 23:59' ) ) < $endDate->getTimestamp() ) {
@@ -423,7 +434,7 @@ class Day {
 	 * @throws Exception
 	 */
 	protected function mapTimeFrames( array &$slots ) {
-		$grid = 24 / count( $slots );
+		$grid = intdiv( self::MINUTES_PER_DAY, count( $slots ) );
 
 		// Iterate through timeframes and fill slots
 		foreach ( $this->getTimeframes() as $timeframe ) {
@@ -438,9 +449,14 @@ class Day {
 				$timeframePost->locked = $timeframe->isLocked();
 
 				if ( ! array_key_exists( 'timeframe', $slots[ $startSlot ] ) || ! $slots[ $startSlot ]['timeframe'] ) {
-					$slots[ $startSlot ]['timeframe'] = $timeframePost;
+					$slots[ $startSlot ]['timeframe']   = $timeframePost;
+					$slots[ $startSlot ]['gridMinutes'] = $timeframe->getGridMinutes();
 				} else {
-					$slots[ $startSlot ]['timeframe'] = Timeframe::getHigherPrioFrame( $timeframePost, $slots[ $startSlot ]['timeframe'] );
+					$winningTimeframe = Timeframe::getHigherPrioFrame( $timeframePost, $slots[ $startSlot ]['timeframe'] );
+					if ( $winningTimeframe === $timeframePost ) {
+						$slots[ $startSlot ]['timeframe']   = $timeframePost;
+						$slots[ $startSlot ]['gridMinutes'] = $timeframe->getGridMinutes();
+					}
 				}
 
 				++$startSlot;
@@ -456,7 +472,7 @@ class Day {
 	 * @throws Exception
 	 */
 	protected function mapRestrictions( array &$slots ) {
-		$grid = 24 / count( $slots );
+		$grid = intdiv( self::MINUTES_PER_DAY, count( $slots ) );
 
 		// Iterate through timeframes and fill slots
 		/** @var Restriction $restriction */
@@ -471,9 +487,10 @@ class Day {
 				// Add timeframe to relevant slots
 				while ( $startSlot < $endSlot ) {
 					// Set locked property
-					$restrictionPost                  = $restriction->getPost();
-					$restrictionPost->locked          = true;
-					$slots[ $startSlot ]['timeframe'] = $restrictionPost;
+					$restrictionPost                    = $restriction->getPost();
+					$restrictionPost->locked            = true;
+					$slots[ $startSlot ]['timeframe']   = $restrictionPost;
+					$slots[ $startSlot ]['gridMinutes'] = 0;
 					++$startSlot;
 				}
 			}
@@ -496,39 +513,58 @@ class Day {
 
 
 	/**
-	 * Remove empty and merge connected slots.
+	 * Removes empty cells and groups contiguous cells according to their timeframe's grid.
 	 *
-	 * @param array $slots Given an array of assocs in hourly slot resolution.
+	 * @param array $slots Given an array of assocs in fifteen-minute cell resolution.
 	 */
 	protected function sanitizeSlots( array &$slots ) {
 		$this->removeEmptySlots( $slots );
 
-		// merge multiple slots if they are of same type
+		$sanitizedSlots = [];
+		$run            = [];
+		$previousSlotNr = null;
+		$timeframeId    = null;
+
 		foreach ( $slots as $slotNr => $slot ) {
-			if ( ! array_key_exists( $slotNr - 1, $slots ) ) {
-				continue;
+			$slot['slotNr']     = $slotNr;
+			$currentTimeframeId = $slot['timeframe']->ID;
+			if ( $run && ( $slotNr !== $previousSlotNr + 1 || $currentTimeframeId !== $timeframeId ) ) {
+				$this->appendSanitizedRun( $run, $sanitizedSlots );
+				$run = [];
 			}
-			$slotBefore = $slots[ $slotNr - 1 ];
 
-			// If Slot before is of same timeframe and we have no hourly grid, we merge them.
-			if (
-				$slotBefore &&
-				$slotBefore['timeframe']->ID == $slot['timeframe']->ID &&
-				(
-					get_post_meta( $slot['timeframe']->ID, 'full-day', true ) == 'on' ||
-					get_post_meta( $slot['timeframe']->ID, 'grid', true ) == 0
-				)
-			) {
-				// Take over start time from slot before
-				$slots[ $slotNr ]['timestart']      = $slotBefore['timestart'];
-				$slots[ $slotNr ]['timestampstart'] = $slotBefore['timestampstart'];
-
-				// unset timeframe from slot before
-				unset( $slots[ $slotNr - 1 ]['timeframe'] );
-			}
+			$run[]          = $slot;
+			$previousSlotNr = $slotNr;
+			$timeframeId    = $currentTimeframeId;
+		}
+		if ( $run ) {
+			$this->appendSanitizedRun( $run, $sanitizedSlots );
 		}
 
-		$this->removeEmptySlots( $slots );
+		$slots = $sanitizedSlots;
+	}
+
+	/**
+	 * Merges a contiguous timeframe run into its configured grid size.
+	 *
+	 * @param non-empty-array $run
+	 * @param array           $sanitizedSlots
+	 */
+	protected function appendSanitizedRun( array $run, array &$sanitizedSlots ): void {
+		$timeframe    = $run[0]['timeframe'];
+		$gridMinutes  = $run[0]['gridMinutes'];
+		$slotsPerGrid = get_post_meta( $timeframe->ID, 'full-day', true ) === 'on' || 0 === $gridMinutes ?
+			count( $run ) :
+			intdiv( $gridMinutes, self::MINUTES_PER_CELL );
+
+		foreach ( array_chunk( $run, $slotsPerGrid ) as $group ) {
+			$slot                 = $group[0];
+			$lastSlot             = $group[ count( $group ) - 1 ];
+			$slot['timeend']      = $lastSlot['timeend'];
+			$slot['timestampend'] = $lastSlot['timestampend'];
+			unset( $slot['slotNr'], $slot['gridMinutes'] );
+			$sanitizedSlots[ $lastSlot['slotNr'] ] = $slot;
+		}
 	}
 
 	/**
@@ -546,33 +582,33 @@ class Day {
 	}
 
 	/**
-	 * Returns an array of timeslots, which is build according the relevant timeframes and their configuration.
+	 * Returns an array of timeslots, which is built according to the relevant timeframes and their configuration.
 	 * So this takes the hourly-, daily or custom-sized-slot configuration of timeframes into account.
 	 *
-	 * Implementation note: An hourly resolution is used, but as a last step, the hourly slots are merged into
+	 * Implementation note: A fifteen-minute resolution is used, but as a last step, the cells are merged into
 	 * the representation that is configured in the timeframes.
 	 *
 	 * @return array
 	 * @throws Exception
 	 */
 	protected function getTimeframeSlots(): array {
-		$customCacheKey = $this->getDate() . serialize( $this->items ) . serialize( $this->locations ) . serialize( $this->ignoreRestrictions );
+		$slotsPerDay    = intdiv( self::MINUTES_PER_DAY, self::MINUTES_PER_CELL );
+		$customCacheKey = $this->getDate() . serialize( $this->items ) . serialize( $this->locations ) . serialize( $this->ignoreRestrictions ) . $slotsPerDay;
 		$customCacheKey = md5( $customCacheKey );
 		$cacheItem      = Plugin::getCacheItem( $customCacheKey );
 		if ( $cacheItem ) {
 			return $cacheItem;
 		} else {
-			$slots       = [];
-			$slotsPerDay = 24;
-			$timeFormat  = esc_html( get_option( 'time_format' ) );
+			$slots      = [];
+			$timeFormat = esc_html( get_option( 'time_format' ) );
 
-			// Init Slots
+			// Init slots.
 			for ( $i = 0; $i < $slotsPerDay; $i++ ) {
 				$slots[ $i ] = [
-					'timestart'      => date( $timeFormat, $i * ( ( 24 / $slotsPerDay ) * 3600 ) ),
-					'timeend'        => date( $timeFormat, ( $i + 1 ) * ( ( 24 / $slotsPerDay ) * 3600 ) ),
-					'timestampstart' => $this->getSlotTimestampStart( $slotsPerDay, $i ),
-					'timestampend'   => $this->getSlotTimestampEnd( $slotsPerDay, $i ),
+					'timestart'      => date( $timeFormat, $i * self::MINUTES_PER_CELL * 60 ),
+					'timeend'        => date( $timeFormat, ( $i + 1 ) * self::MINUTES_PER_CELL * 60 ),
+					'timestampstart' => $this->getSlotTimestampStart( $i ),
+					'timestampend'   => $this->getSlotTimestampEnd( $i ),
 				];
 			}
 
@@ -595,25 +631,19 @@ class Day {
 	/**
 	 * Returns timestamp when $slotNr starts.
 	 *
-	 * @param $slotsPerDay
-	 * @param $slotNr
-	 *
-	 * @return false|float|int
+	 * @return int
 	 */
-	protected function getSlotTimestampStart( $slotsPerDay, $slotNr ) {
-		return strtotime( $this->getDate() ) + ( $slotNr * ( ( 24 / $slotsPerDay ) * 3600 ) );
+	protected function getSlotTimestampStart( int $slotNr ): int {
+		return $this->getStartTimestamp() + $slotNr * self::MINUTES_PER_CELL * 60;
 	}
 
 	/**
 	 * Returns timestamp when $slotNr ends.
 	 *
-	 * @param $slotsPerDay
-	 * @param $slotNr
-	 *
-	 * @return false|float|int
+	 * @return int
 	 */
-	protected function getSlotTimestampEnd( $slotsPerDay, $slotNr ) {
-		return strtotime( $this->getDate() ) + ( ( $slotNr + 1 ) * ( ( 24 / $slotsPerDay ) * 3600 ) ) - 1;
+	protected function getSlotTimestampEnd( int $slotNr ): int {
+		return $this->getStartTimestamp() + ( $slotNr + 1 ) * self::MINUTES_PER_CELL * 60 - 1;
 	}
 
 	public function setIgnoreRestrictions( bool $ignoreRestrictions ): void {

--- a/src/Model/Timeframe.php
+++ b/src/Model/Timeframe.php
@@ -711,6 +711,23 @@ class Timeframe extends CustomPost {
 					);
 				}
 
+				if ( ! $this->isFullDay() && $this->getGrid() !== 0 ) {
+					$gridMinutes = $this->getGridMinutes();
+					foreach ( [ $this->getStartTime(), $this->getEndTime() ] as $time ) {
+						if ( ! $time ) {
+							continue;
+						}
+
+						$timestamp = strtotime( $time );
+						$minutes   = (int) date( 'G', $timestamp ) * 60 + (int) date( 'i', $timestamp );
+						if ( $minutes % $gridMinutes !== 0 ) {
+							throw new TimeframeInvalidException(
+								__( 'Start and end times must align with the selected grid.', 'commonsbooking' )
+							);
+						}
+					}
+				}
+
 				// First we check if the item is already connected to another location to avoid overlapping bookable dates
 				$sameItemTimeframes = \CommonsBooking\Repository\Timeframe::getBookable(
 					[],
@@ -974,14 +991,26 @@ class Timeframe extends CustomPost {
 
 	/**
 	 * Returns grid type id.
-	 * The timeframe grid describes if either the full slot is bookable or if the timeframe is bookable hourly.
+	 * The timeframe grid describes if either the full slot is bookable or if the timeframe is bookable in a configured interval.
 	 * 0 = slot
-	 * 1 = hourly
+	 *
+	 * @return int|float
+	 */
+	public function getGrid(): int|float {
+		$grid = floatval( $this->getMeta( 'grid' ) );
+
+		return $grid === 0.0 ? 0 : $grid;
+	}
+
+	/**
+	 * Returns the configured interval grid in minutes.
 	 *
 	 * @return int
 	 */
-	public function getGrid(): int {
-		return intval( $this->getMeta( 'grid' ) );
+	public function getGridMinutes(): int {
+		$grid = $this->getGrid();
+
+		return 0 === $grid ? 0 : (int) round( $grid * 60 );
 	}
 
 	/**
@@ -1048,20 +1077,20 @@ class Timeframe extends CustomPost {
 	 * This means the length of the individual bookable slots.
 	 * For example if the grid is 2, the bookable slots are 2 hours long.
 	 *
-	 * @return int|null
+	 * @return float|null
 	 */
-	public function getGridSize(): ?int {
+	public function getGridSize(): ?float {
 		if ( $this->isFullDay() ) {
-			return 24;
+			return 24.0;
 		} elseif ( $this->getGrid() === 0 ) {
 			// this is for slot timeframes
 			$startTime = strtotime( $this->getMeta( 'start-time' ) );
 			$endTime   = strtotime( $this->getMeta( 'end-time' ) );
 
-			return intval( round( abs( $endTime - $startTime ) / 3600, 2 ) );
+			return round( abs( $endTime - $startTime ) / 3600, 2 );
 		} else {
-			// this is for hourly timeframes, the grid will be 1, because each hour is bookable
-			return intval( $this->getGrid() );
+			// this is for interval timeframes, the grid is the bookable slot length.
+			return $this->getGrid();
 		}
 	}
 

--- a/src/Service/TimeframeExport.php
+++ b/src/Service/TimeframeExport.php
@@ -591,7 +591,7 @@ class TimeframeExport {
 
 			// Grid option
 			$gridOptions           = \CommonsBooking\Wordpress\CustomPostType\Timeframe::getGridOptions();
-			$gridOptionId          = $timeframePost->getGrid();
+			$gridOptionId          = $timeframePost->getMeta( 'grid' );
 			$timeframeData['grid'] = array_key_exists( $gridOptionId, $gridOptions ) ?
 				$gridOptions[ $gridOptionId ] : __( 'Unknown', 'commonsbooking' );
 

--- a/src/Wordpress/CustomPostType/Timeframe.php
+++ b/src/Wordpress/CustomPostType/Timeframe.php
@@ -614,7 +614,7 @@ class Timeframe extends CustomPostType {
 				'attributes'  => array(
 					'data-timepicker' => wp_json_encode(
 						array(
-							'stepMinute' => 60,
+							'stepMinute' => 15,
 							'timeFormat' => 'HH:mm',
 						)
 					),
@@ -631,7 +631,7 @@ class Timeframe extends CustomPostType {
 				'attributes'  => array(
 					'data-timepicker' => wp_json_encode(
 						array(
-							'stepMinute' => 60,
+							'stepMinute' => 15,
 							'timeFormat' => 'HH:mm',
 						)
 					),
@@ -824,8 +824,10 @@ class Timeframe extends CustomPostType {
 	 */
 	public static function getGridOptions() {
 		return [
-			0 => esc_html__( 'Full slot', 'commonsbooking' ),
-			1 => esc_html__( 'Hourly', 'commonsbooking' ),
+			0      => esc_html__( 'Full slot', 'commonsbooking' ),
+			1      => esc_html__( 'Hourly', 'commonsbooking' ),
+			'0.5'  => esc_html__( '30 minutes', 'commonsbooking' ),
+			'0.25' => esc_html__( '15 minutes', 'commonsbooking' ),
 		];
 	}
 

--- a/tests/php/Model/BookingTest.php
+++ b/tests/php/Model/BookingTest.php
@@ -253,6 +253,33 @@ class BookingTest extends CustomPostTypeTest {
 		$this->assertEquals( self::CURRENT_DATE_FORMATTED . ' 3:00 pm - 6:00 pm', $this->testBookingSpanningOverTwoSlots->returnDatetime() );
 	}
 
+	public function testFractionalSlotDatetimes() {
+		$start   = strtotime( self::CURRENT_DATE . ' 09:15' );
+		$end     = strtotime( self::CURRENT_DATE . ' 09:30' ) - 1;
+		$booking = new Booking(
+			$this->createBooking(
+				$this->locationId,
+				$this->itemId,
+				$start,
+				$end,
+				'09:15 AM',
+				'09:30 AM',
+				'confirmed',
+				self::USER_ID,
+				'w',
+				3,
+				'Quarter-hour booking',
+				0,
+				[ '1', '2', '3', '4', '5', '6', '7' ],
+				'0.25',
+				'0.25'
+			)
+		);
+
+		$this->assertSame( self::CURRENT_DATE_FORMATTED . ' 9:15 am - 9:30 am', $booking->pickupDatetime() );
+		$this->assertSame( self::CURRENT_DATE_FORMATTED . ' 9:15 am - 9:30 am', $booking->returnDatetime() );
+	}
+
 	public function testShowBookingCodes() {
 		$this->assertFalse( $this->testBookingTomorrow->showBookingCodes() );
 

--- a/tests/php/Model/DayTest.php
+++ b/tests/php/Model/DayTest.php
@@ -414,4 +414,11 @@ class DayTest extends CustomPostTypeTest {
 			$this->assertTrue( $slot['timeframe']->locked );
 		}
 	}
+	public function testGetGridIncludesBookingEndingAtEndOfDay() {
+		$booking = $this->createConfirmedBookingEndingToday();
+		$grid    = $this->instance->getGrid();
+
+		$this->assertSame( $booking, $grid[95]['timeframe']->ID );
+		$this->assertTrue( $grid[95]['timeframe']->locked );
+	}
 }

--- a/tests/php/Model/DayTest.php
+++ b/tests/php/Model/DayTest.php
@@ -221,8 +221,8 @@ class DayTest extends CustomPostTypeTest {
 		// one grid entry spanning whole day
 		$grid = $this->instance->getGrid();
 		$this->assertCount( 1, $grid );
-		$this->assertArrayHasKey( 23, $grid );
-		$this->assertEquals( $grid[23]['timeframe']->ID, $this->bookableTimeframeForCurrentDayId );
+		$this->assertArrayHasKey( 95, $grid );
+		$this->assertEquals( $grid[95]['timeframe']->ID, $this->bookableTimeframeForCurrentDayId );
 
 		// hourly grid
 		// we explicitly define a new location and item here to avoid interference with other tests
@@ -271,18 +271,18 @@ class DayTest extends CustomPostTypeTest {
 
 		$assertGridLocked = function ( $grid ) {
 			$this->assertCount( 8, $grid );
-			$this->assertArrayHasKey( 8, $grid );
-			$this->assertArrayHasKey( 15, $grid );
+			$this->assertArrayHasKey( 35, $grid );
+			$this->assertArrayHasKey( 63, $grid );
 
-			// make sure, that only 8:00-10:00 is correctly blocked
-			$this->assertTrue( $grid[8]['timeframe']->locked );
-			$this->assertTrue( $grid[9]['timeframe']->locked );
-			$this->assertFalse( $grid[10]['timeframe']->locked );
-			$this->assertFalse( $grid[11]['timeframe']->locked );
-			$this->assertFalse( $grid[12]['timeframe']->locked );
-			$this->assertFalse( $grid[13]['timeframe']->locked );
-			$this->assertFalse( $grid[14]['timeframe']->locked );
-			$this->assertFalse( $grid[15]['timeframe']->locked );
+			// make sure that only 8:00-10:00 is correctly blocked
+			$this->assertTrue( $grid[35]['timeframe']->locked );
+			$this->assertTrue( $grid[39]['timeframe']->locked );
+			$this->assertFalse( $grid[43]['timeframe']->locked );
+			$this->assertFalse( $grid[47]['timeframe']->locked );
+			$this->assertFalse( $grid[51]['timeframe']->locked );
+			$this->assertFalse( $grid[55]['timeframe']->locked );
+			$this->assertFalse( $grid[59]['timeframe']->locked );
+			$this->assertFalse( $grid[63]['timeframe']->locked );
 		};
 
 		$assertGridLocked( $grid );
@@ -298,9 +298,9 @@ class DayTest extends CustomPostTypeTest {
 		// blocking grid should extend till end of the day
 		$assertOverbookLocked = function ( $grid ) {
 			$this->assertCount( 16, $grid );
-			$this->assertArrayHasKey( 8, $grid );
-			$this->assertArrayHasKey( 23, $grid );
-			for ( $i = 8; $i <= 23; $i++ ) {
+			$this->assertArrayHasKey( 35, $grid );
+			$this->assertArrayHasKey( 95, $grid );
+			for ( $i = 35; $i <= 95; $i += 4 ) {
 				$this->assertTrue( $grid[ $i ]['timeframe']->locked );
 			}
 		};
@@ -327,9 +327,91 @@ class DayTest extends CustomPostTypeTest {
 		$grid     = $instance->getGrid();
 		// first hour (8:00-9:00) still free, rest blocked
 		$this->assertCount( 2, $grid );
-		$this->assertArrayHasKey( 8, $grid );
-		$this->assertArrayHasKey( 23, $grid );
-		$this->assertFalse( $grid[8]['timeframe']->locked );
-		$this->assertTrue( $grid[23]['timeframe']->locked );
+		$this->assertArrayHasKey( 35, $grid );
+		$this->assertArrayHasKey( 95, $grid );
+		$this->assertFalse( $grid[35]['timeframe']->locked );
+		$this->assertTrue( $grid[95]['timeframe']->locked );
+	}
+	public function testGetGridSupportsFractionalIntervals() {
+		$quarterLocation  = $this->createLocation( 'Quarter-hour Location' );
+		$quarterItem      = $this->createItem( 'Quarter-hour Item', $quarterLocation );
+		$quarterTimeframe = $this->createTimeframe(
+			$quarterLocation,
+			$quarterItem,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( 'tomorrow', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'off',
+			'd',
+			'0.25',
+			'9:00 AM',
+			'10:00 AM'
+		);
+		$quarterGrid      = ( new Day( $this->dateFormatted, [ $quarterLocation ], [ $quarterItem ] ) )->getGrid();
+
+		$this->assertSame( [ 36, 37, 38, 39 ], array_keys( $quarterGrid ) );
+		foreach ( $quarterGrid as $slot ) {
+			$this->assertEquals( 899, $slot['timestampend'] - $slot['timestampstart'] );
+			$this->assertSame( $quarterTimeframe, $slot['timeframe']->ID );
+		}
+
+		$halfLocation  = $this->createLocation( 'Half-hour Location' );
+		$halfItem      = $this->createItem( 'Half-hour Item', $halfLocation );
+		$halfTimeframe = $this->createTimeframe(
+			$halfLocation,
+			$halfItem,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( 'tomorrow', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'off',
+			'd',
+			'0.5',
+			'9:00 AM',
+			'10:00 AM'
+		);
+		$halfGrid      = ( new Day( $this->dateFormatted, [ $halfLocation ], [ $halfItem ] ) )->getGrid();
+
+		$this->assertSame( [ 37, 39 ], array_keys( $halfGrid ) );
+		foreach ( $halfGrid as $slot ) {
+			$this->assertEquals( 1799, $slot['timestampend'] - $slot['timestampstart'] );
+			$this->assertSame( $halfTimeframe, $slot['timeframe']->ID );
+		}
+
+		$priorityLocation = $this->createLocation( 'Priority Location' );
+		$priorityItem     = $this->createItem( 'Priority Item', $priorityLocation );
+		$this->createTimeframe(
+			$priorityLocation,
+			$priorityItem,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( 'tomorrow', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'off',
+			'd',
+			'0.5',
+			'9:00 AM',
+			'10:00 AM'
+		);
+		$priorityBooking = $this->createBooking(
+			$priorityLocation,
+			$priorityItem,
+			strtotime( self::CURRENT_DATE ),
+			strtotime( 'tomorrow', strtotime( self::CURRENT_DATE ) ),
+			'9:00 AM',
+			'10:00 AM',
+			'confirmed',
+			self::USER_ID,
+			'w',
+			3,
+			'Quarter-hour priority booking',
+			'0.25'
+		);
+		$priorityGrid    = ( new Day( $this->dateFormatted, [ $priorityLocation ], [ $priorityItem ] ) )->getGrid();
+
+		$this->assertSame( [ 36, 37, 38, 39 ], array_keys( $priorityGrid ) );
+		foreach ( $priorityGrid as $slot ) {
+			$this->assertEquals( 899, $slot['timestampend'] - $slot['timestampstart'] );
+			$this->assertSame( $priorityBooking, $slot['timeframe']->ID );
+			$this->assertTrue( $slot['timeframe']->locked );
+		}
 	}
 }

--- a/tests/php/Model/TimeframeTest.php
+++ b/tests/php/Model/TimeframeTest.php
@@ -539,6 +539,26 @@ class TimeframeTest extends CustomPostTypeTest {
 		$timeframe->isValid();
 	}
 
+	public function testIsValidSkipsUnsetFractionalGridBoundary() {
+		$location  = $this->createLocation( 'Fractional grid location without start time', 'publish' );
+		$item      = $this->createItem( 'Fractional grid item without start time', 'publish' );
+		$timeframe = new Timeframe(
+			$this->createTimeframe(
+				$location,
+				$item,
+				strtotime( self::CURRENT_DATE ),
+				strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+				\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+				'off',
+				'd',
+				'0.5',
+				null,
+				'10:00 AM'
+			)
+		);
+
+		$this->assertTrue( $timeframe->isValid() );
+	}
 	public function testIsUserPrivileged() {
 		$this->createSubscriber();
 		$this->createCBManager();

--- a/tests/php/Model/TimeframeTest.php
+++ b/tests/php/Model/TimeframeTest.php
@@ -516,6 +516,29 @@ class TimeframeTest extends CustomPostTypeTest {
 		$this->assertTrue( $isOverlapping->isValid() );
 	}
 
+	public function testIsValidRejectsUnalignedFractionalGrid() {
+		$location  = $this->createLocation( 'Fractional grid location', 'publish' );
+		$item      = $this->createItem( 'Fractional grid item', 'publish' );
+		$timeframe = new Timeframe(
+			$this->createTimeframe(
+				$location,
+				$item,
+				strtotime( self::CURRENT_DATE ),
+				strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+				\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+				'off',
+				'd',
+				'0.5',
+				'09:15 AM',
+				'10:15 AM'
+			)
+		);
+
+		$this->expectException( TimeframeInvalidException::class );
+		$this->expectExceptionMessage( 'Start and end times must align with the selected grid.' );
+		$timeframe->isValid();
+	}
+
 	public function testIsUserPrivileged() {
 		$this->createSubscriber();
 		$this->createCBManager();
@@ -1042,6 +1065,51 @@ class TimeframeTest extends CustomPostTypeTest {
 			)
 		);
 		$this->assertEquals( 1, $hourlyBookable->getGridSize() );
+
+		$quarterHourlyBookable = new Timeframe(
+			$this->createTimeframe(
+				$this->locationId,
+				$this->itemId,
+				strtotime( self::CURRENT_DATE ),
+				strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+				\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+				'',
+				'd',
+				'0.25',
+				'08:00 AM',
+				'10:00 AM',
+			)
+		);
+		$this->assertSame( 0.25, $quarterHourlyBookable->getGrid() );
+		$this->assertSame( 0.25, $quarterHourlyBookable->getGridSize() );
+	}
+
+	public function testGetGridMinutes() {
+		foreach (
+			[
+				0      => 0,
+				'0.25' => 15,
+				'0.5'  => 30,
+				1      => 60,
+			] as $grid => $expectedMinutes
+		) {
+			$timeframe = new Timeframe(
+				$this->createTimeframe(
+					$this->locationId,
+					$this->itemId,
+					strtotime( self::CURRENT_DATE ),
+					strtotime( '+1 day', strtotime( self::CURRENT_DATE ) ),
+					\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+					'off',
+					'd',
+					$grid,
+					'08:00 AM',
+					'10:00 AM',
+				)
+			);
+
+			$this->assertSame( $expectedMinutes, $timeframe->getGridMinutes() );
+		}
 	}
 
 	public function testGetAdmins() {

--- a/tests/php/Service/TimeframeExportTest.php
+++ b/tests/php/Service/TimeframeExportTest.php
@@ -21,6 +21,9 @@ class TimeframeExportTest extends CustomPostTypeTest {
 		$timeframeOneItemAndLocation = $this->createBookableTimeFrameIncludingCurrentDay();
 		$dataArray                   = \CommonsBooking\Service\TimeframeExport::getTimeframeData( [ $timeframeOneItemAndLocation ] );
 		$this->assertEquals( 1, count( $dataArray ) );
+		update_post_meta( $timeframeOneItemAndLocation, 'grid', '0.25' );
+		$dataArray = \CommonsBooking\Service\TimeframeExport::getTimeframeData( [ $timeframeOneItemAndLocation ] );
+		$this->assertSame( '15 minutes', $dataArray[0]['grid'] );
 
 		$secondItem                   = $this->createItem( 'second-item' );
 		$timeframeTwoItemsOneLocation =

--- a/tests/php/Wordpress/CustomPostType/TimeframeTest.php
+++ b/tests/php/Wordpress/CustomPostType/TimeframeTest.php
@@ -53,7 +53,15 @@ class TimeframeTest extends CustomPostTypeTest {
 	}
 
 	public function testGetGridOptions() {
-		$this->assertIsArray( Timeframe::getGridOptions() );
+		$this->assertSame(
+			[
+				0      => 'Full slot',
+				1      => 'Hourly',
+				'0.5'  => '30 minutes',
+				'0.25' => '15 minutes',
+			],
+			Timeframe::getGridOptions()
+		);
 	}
 
 	/**


### PR DESCRIPTION
Hi,

wir würden sehr gerne Halb- und Viertelstunden Slots für die buchbaren Gegenstände haben. Dieser PR ist komplett AI generiert, kann aber vielleicht als Diskussionsgrundlage dienen?

Hier wurde mal etwas ähnliches angefragt: https://github.com/wielebenwir/commonsbooking/issues/715

## Summary
- Add 15-minute and 30-minute timeframe grids with aligned-boundary validation.
- Use 15-minute integer cells for `Day` availability calculations while retaining the established hour-valued `grid` metadata, booking display, and export contracts.
- Preserve inclusive all-day `23:59:59` ends as an exclusive day-grid bound, and group slots using the priority-winning timeframe’s grid.

## Verification
- `WP_TESTS_DIR=/tmp/commonsbooking-minute-slot-tests vendor/bin/phpunit --filter 'testGetGridSupportsFractionalIntervals|testGetGridMinutes|testGetGridSize'` — passed: 3 tests, 36 assertions.
- Targeted PHPStan analysis of `src/Model/Timeframe.php` and `src/Model/Day.php` — no errors.
- Browser-checked the local half-hour booking demo: pickup and return expose four 30-minute slots; selecting 09:30 only disables the earlier return slot.